### PR TITLE
fix: resolve scroll misalignment on side panel home page

### DIFF
--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -70,7 +70,7 @@ export function Chat({ isConnected }: ChatProps) {
             </div>
           )}
         >
-          <main id="main-content" className="h-full">
+          <main id="main-content" className="h-full min-h-0">
             
             <MessageList 
               messages={messages} 

--- a/src/sidepanel/components/MessageList.tsx
+++ b/src/sidepanel/components/MessageList.tsx
@@ -307,8 +307,7 @@ export function MessageList({ messages, isProcessing = false, onScrollStateChang
   if (messages.length === 0) {
     return (
       <div 
-        className="flex-1 flex flex-col items-center justify-start p-8 text-center relative overflow-hidden pt-16"
-        style={{ paddingBottom: '180px' }}
+        className="h-full overflow-y-auto flex flex-col items-center justify-start p-8 pt-16 pb-6 text-center relative"
         role="region"
         aria-label="Welcome screen with example prompts"
       >


### PR DESCRIPTION
## This PR resolve scroll misalignment on side panel home page

- Fix scroll container inconsistency between home and chat states
- Replace overflow-hidden with overflow-y-auto on landing view
- Remove CSS paddingBottom hack in favor of proper Tailwind classes
- Add min-h-0 to main container for proper flexbox overflow
- Ensures input section stays fixed while content scrolls consistently

Fixes scroll behavior where entire panel would move on home page