### PR TITLE
Fix multi-tab selection

### DIFF
--- a/src/sidepanel/components/ChatInput.tsx
+++ b/src/sidepanel/components/ChatInput.tsx
@@ -140,11 +140,10 @@ export function ChatInput({ isConnected, isProcessing }: ChatInputProps) {
       chatMode  // Include chat mode setting
     })
     
-    // Clear input and selected tabs
+    // Clear input but preserve selected tabs for follow-up queries
     setInput('')
     setHistoryIndex(-1)
     setDraftBeforeHistory('')
-    clearSelectedTabs()
     setShowTabSelector(false)
   }
   
@@ -335,6 +334,19 @@ export function ChatInput({ isConnected, isProcessing }: ChatInputProps) {
                   </button>
                 </div>
               ))}
+
+              {/* Clear all button */}
+              {selectedContextTabs.length > 1 && (
+                <button
+                  type="button"
+                  className="flex items-center gap-1 px-2 py-1 rounded-full bg-muted/60 text-muted-foreground hover:bg-muted hover:text-foreground text-xs border border-border/50 hover:border-border transition-all duration-200 shrink-0"
+                  onClick={clearSelectedTabs}
+                  aria-label="Clear all selected tabs"
+                  title="Clear all selected tabs"
+                >
+                  Clear all
+                </button>
+              )}
             </div>
           </div>
         )}

--- a/src/sidepanel/components/shared/TabSelector.tsx
+++ b/src/sidepanel/components/shared/TabSelector.tsx
@@ -114,7 +114,6 @@ export const TabSelector: React.FC<TabSelectorComponentProps> = ({
             if (activeTab) {
               toggleTabSelection(activeTab.id);
               onTabSelect?.(activeTab.id);
-              onClose();
             }
           }
           break;
@@ -219,7 +218,6 @@ export const TabSelector: React.FC<TabSelectorComponentProps> = ({
                   onClick={() => {
                     toggleTabSelection(tab.id);
                     onTabSelect?.(tab.id);
-                    onClose();
                   }}
                   role="option"
                   aria-selected={isSelected}
@@ -262,3 +260,4 @@ export const TabSelector: React.FC<TabSelectorComponentProps> = ({
 
 // Re-export BrowserTab type from store
 export type { BrowserTab };
+


### PR DESCRIPTION
# Fix multi-tab selection persistence across conversations

- Users can now select multiple tabs and ask follow-up questions while maintaining the same tab context, enabling proper multi-tab workflows.

<img width="1181" height="917" alt="Screenshot 2025-09-20 023045" src="https://github.com/user-attachments/assets/d735ea94-d8c7-4b08-880f-fea1b690fd76" />
