### PR TITLE
Fix: Welcome Screen Tagline Alignment

### DIFF
--- a/src/sidepanel/components/MessageList.tsx
+++ b/src/sidepanel/components/MessageList.tsx
@@ -237,17 +237,20 @@ export function MessageList({ messages, isProcessing = false, onScrollStateChang
         <div className="relative z-0 flex flex-col items-center justify-center min-h-0 max-w-lg w-full">
           
           {/* Tagline */}
-          <div className="flex items-center justify-center -mt-4">
-            <h2 className="text-3xl font-bold text-muted-foreground animate-fade-in-up flex items-baseline flex-wrap justify-center gap-2 text-center px-2">
-              <span>Your <span className="text-brand">Agentic</span></span>
-              <span>
-                web assistant{' '}
+          <div className="flex flex-col items-center justify-center -mt-4">
+            <h2 className="text-3xl font-bold text-muted-foreground animate-fade-in-up text-center px-2 leading-tight">
+              <div className="flex items-center justify-center gap-2">
+                <span>Your</span>
+                <span className="text-brand">Agentic</span>
+              </div>
+              <div className="flex items-center justify-center gap-2 mt-1">
+                <span>web assistant</span>
                 <img 
                   src="/assets/browseros.svg" 
                   alt="BrowserOS" 
-                  className="w-8 h-8 inline-block align-text-bottom animate-fade-in-up"
+                  className="w-8 h-8 inline-block align-middle animate-fade-in-up"
                 />
-              </span>
+              </div>
             </h2>
           </div>
 


### PR DESCRIPTION
## Fix: Welcome Screen Tagline Alignment

**Changes:**
- Fixed dog icon misalignment in "Your Agentic web assistant" text
- Changed icon alignment from `align-text-bottom` to `align-middle`
- Restructured tagline to always display as exactly 2 rows regardless of screen width


**Result:** Consistent, properly aligned welcome screen tagline across all screen sizes.

<img width="1267" height="913" alt="image" src="https://github.com/user-attachments/assets/4f3ce6bf-d798-4731-8097-24bbb9ad693f" />
