### PR TITLE
fix: align assistant text with thinking brain icon

### DIFF
--- a/src/sidepanel/components/MessageItem.tsx
+++ b/src/sidepanel/components/MessageItem.tsx
@@ -668,7 +668,9 @@ export const MessageItem = memo<MessageItemProps>(function MessageItem({ message
       {/* Show content without bubble for other message types */}
       {!shouldShowBubble && (
         <div className={cn(
-          'relative px-4 py-2 transition-all duration-200',
+          'relative transition-all duration-200',
+          // Match thinking section alignment: assistant messages align with brain icon position
+          isAssistant ? 'pl-3 py-2' : 'px-4 py-2',
           // Indentation styling
           shouldIndent && applyIndentMargin && 'ml-4',
           shouldIndent && showLocalIndentLine && 'border-l border-border/30 pl-3 ml-1',


### PR DESCRIPTION
## Align assistant text with thinking brain icon

<img width="371" height="161" alt="image" src="https://github.com/user-attachments/assets/3e0d8738-6680-45d5-adca-0673d82c2c68" />
