### PR TITLE
Small UI - Fix theme synchronization between sidepanel and newtab

### DIFF
--- a/src/newtab/NewTab.tsx
+++ b/src/newtab/NewTab.tsx
@@ -13,7 +13,7 @@ export function NewTab() {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const [currentView, setCurrentView] = useState<'main' | 'create-agent'>('main')
   const { loadAgents } = useAgentsStore()
-  
+
   // Load agents from storage on mount
   useEffect(() => {
     // Load agents from storage
@@ -23,7 +23,7 @@ export function NewTab() {
       }
     })
   }, [loadAgents])
-  
+
   // Apply theme and font size
   useEffect(() => {
     document.documentElement.style.setProperty('--app-font-size', `${fontSize}px`)
@@ -31,6 +31,40 @@ export function NewTab() {
     root.classList.remove('dark', 'gray')
     if (theme === 'dark') root.classList.add('dark')
     if (theme === 'gray') root.classList.add('gray')
+  }, [theme, fontSize])
+
+  // Listen for theme changes from other tabs/views
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === 'nxtscape-settings' && e.newValue) {
+        try {
+          const newSettings = JSON.parse(e.newValue)
+          const newTheme = newSettings?.state?.theme
+          const newFontSize = newSettings?.state?.fontSize
+
+          // Update theme if changed
+          if (newTheme && newTheme !== theme) {
+            const root = document.documentElement
+            root.classList.remove('dark', 'gray')
+            if (newTheme === 'dark') root.classList.add('dark')
+            if (newTheme === 'gray') root.classList.add('gray')
+            // Force store update
+            useSettingsStore.setState({ theme: newTheme })
+          }
+
+          // Update font size if changed
+          if (newFontSize && newFontSize !== fontSize) {
+            document.documentElement.style.setProperty('--app-font-size', `${newFontSize}px`)
+            useSettingsStore.setState({ fontSize: newFontSize })
+          }
+        } catch (err) {
+          console.error('Failed to parse settings from storage:', err)
+        }
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+    return () => window.removeEventListener('storage', handleStorageChange)
   }, [theme, fontSize])
   
   // Render create agent page if view is set
@@ -47,13 +81,13 @@ export function NewTab() {
         <button
           type="button"
           className="
-            p-2 rounded-full 
-            transition-colors duration-200 ease-in-out 
-            focus:outline-none focus:ring-2 focus:ring-offset-2 
-            focus:ring-offset-white dark:focus:ring-offset-gray-900 
-            focus:ring-gray-400 
-            text-gray-600 dark:text-gray-300
-            hover:bg-gray-100 dark:hover:bg-gray-800
+            p-2 rounded-full
+            transition-colors duration-200 ease-in-out
+            focus:outline-none focus:ring-2 focus:ring-offset-2
+            focus:ring-offset-white dark:focus:ring-offset-gray-900 gray:focus:ring-offset-gray-800
+            focus:ring-gray-400
+            text-gray-600 dark:text-gray-300 gray:text-gray-400
+            hover:bg-gray-100 dark:hover:bg-gray-800 gray:hover:bg-gray-700
           "
           aria-label="Settings"
           onClick={() => setIsSettingsOpen(true)}

--- a/src/newtab/components/ThemeToggle.tsx
+++ b/src/newtab/components/ThemeToggle.tsx
@@ -1,34 +1,48 @@
 import React from 'react'
-import { SunIcon, MoonIcon } from 'lucide-react'
+import { SunIcon, MoonIcon, MonitorIcon } from 'lucide-react'
 import { useSettingsStore } from '@/sidepanel/stores/settingsStore'
 
 export function ThemeToggle() {
   const { theme, setTheme } = useSettingsStore()
-  
+
   const toggleTheme = () => {
-    const newTheme = theme === 'light' ? 'dark' : theme === 'dark' ? 'light' : 'light'
+    // Cycle through: light -> dark -> gray -> light
+    const newTheme = theme === 'light' ? 'dark' : theme === 'dark' ? 'gray' : 'light'
     setTheme(newTheme)
   }
-  
+
+  const getNextTheme = () => {
+    return theme === 'light' ? 'dark' : theme === 'dark' ? 'gray' : 'light'
+  }
+
+  const getIcon = () => {
+    switch (theme) {
+      case 'light':
+        return <MoonIcon size={20} className="transition-transform duration-200" />
+      case 'dark':
+        return <MonitorIcon size={20} className="transition-transform duration-200" />
+      case 'gray':
+        return <SunIcon size={20} className="transition-transform duration-200" />
+      default:
+        return <SunIcon size={20} className="transition-transform duration-200" />
+    }
+  }
+
   return (
     <button
       onClick={toggleTheme}
       className="
-        p-2 rounded-full 
-        transition-colors duration-200 ease-in-out 
-        focus:outline-none focus:ring-2 focus:ring-offset-2 
-        focus:ring-offset-white dark:focus:ring-offset-gray-900 
-        focus:ring-gray-400 
-        text-gray-600 dark:text-gray-300
-        hover:bg-gray-100 dark:hover:bg-gray-800
+        p-2 rounded-full
+        transition-colors duration-200 ease-in-out
+        focus:outline-none focus:ring-2 focus:ring-offset-2
+        focus:ring-offset-white dark:focus:ring-offset-gray-900 gray:focus:ring-offset-gray-800
+        focus:ring-gray-400
+        text-gray-600 dark:text-gray-300 gray:text-gray-400
+        hover:bg-gray-100 dark:hover:bg-gray-800 gray:hover:bg-gray-700
       "
-      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+      aria-label={`Switch to ${getNextTheme()} mode`}
     >
-      {theme === 'light' ? (
-        <MoonIcon size={20} className="transition-transform duration-200" />
-      ) : (
-        <SunIcon size={20} className="transition-transform duration-200" />
-      )}
+      {getIcon()}
     </button>
   )
 }

--- a/src/newtab/styles.css
+++ b/src/newtab/styles.css
@@ -55,6 +55,7 @@
   .gray {
     --background: 220 10% 3%;
     --background-alt: 220 8% 6%;
+    --header: 220 7% 16%;
     --foreground: 0 0% 96%;
     --card: 220 8% 12%;
     --card-foreground: 0 0% 96%;

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -49,7 +49,7 @@ export function App() {
   useEffect(() => {
     // Apply font size
     document.documentElement.style.setProperty('--app-font-size', `${fontSize}px`)
-    
+
     // Apply theme classes
     const root = document.documentElement
     root.classList.remove('dark')
@@ -57,6 +57,40 @@ export function App() {
     if (theme === 'dark') root.classList.add('dark')
     if (theme === 'gray') root.classList.add('gray')
   }, [fontSize, theme])
+
+  // Listen for theme changes from other tabs/views
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === 'nxtscape-settings' && e.newValue) {
+        try {
+          const newSettings = JSON.parse(e.newValue)
+          const newTheme = newSettings?.state?.theme
+          const newFontSize = newSettings?.state?.fontSize
+
+          // Update theme if changed
+          if (newTheme && newTheme !== theme) {
+            const root = document.documentElement
+            root.classList.remove('dark', 'gray')
+            if (newTheme === 'dark') root.classList.add('dark')
+            if (newTheme === 'gray') root.classList.add('gray')
+            // Force store update
+            useSettingsStore.setState({ theme: newTheme })
+          }
+
+          // Update font size if changed
+          if (newFontSize && newFontSize !== fontSize) {
+            document.documentElement.style.setProperty('--app-font-size', `${newFontSize}px`)
+            useSettingsStore.setState({ fontSize: newFontSize })
+          }
+        } catch (err) {
+          console.error('Failed to parse settings from storage:', err)
+        }
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+    return () => window.removeEventListener('storage', handleStorageChange)
+  }, [theme, fontSize])
   
   // Announce connection status changes
   useEffect(() => {


### PR DESCRIPTION
 ## Summary
  - Fixed theme inconsistency where newtab showed different theme than sidepanel
  - Added cross-tab synchronization so theme changes in one view update the other
  - Both views now use exact same gray theme colors and shared Zustand store

  ## Changes
  - Updated newtab to use shared `useSettingsStore` from sidepanel
  - Added storage event listeners for real-time theme sync across tabs
  - Ensured pixel-perfect gray theme match between both views
  
  Demo : 
  https://www.loom.com/share/4dd393009c3646eab708428634097aff?sid=987f0523-bfa7-4cce-af2c-ec5d99f8caa1
  
<img width="1919" height="905" alt="Screenshot 2025-10-04 190407" src="https://github.com/user-attachments/assets/285323f5-af19-4e1e-a3a4-4873fe7b1cd0" />
