### PR TITLE
fix bun compile with new agent

### DIFF
--- a/scripts/build_server.ts
+++ b/scripts/build_server.ts
@@ -158,6 +158,7 @@ async function buildTarget(
     `--target=${target.bunTarget}`,
     "--env",
     "inline",
+    "--external=*?binary",
   ];
 
   const buildEnv = mode === "prod" ? createCleanEnv(envVars) : { ...process.env, ...envVars };


### PR DESCRIPTION
  **Root cause:** The @google/gemini-cli-core package's shell-utils.js uses esbuild-specific imports for WASM files:
  import('web-tree-sitter/tree-sitter.wasm?binary')
  import('tree-sitter-bash/tree-sitter-bash.wasm?binary')

  The ?binary suffix is handled by esbuild-plugin-wasm, but Bun's bundler doesn't understand this syntax.

  **Fix:** Added --external=*?binary to the build args in scripts/build_server.ts:161. This tells Bun to skip bundling any imports with the
  ?binary suffix.

  **Why this is safe:** The shell parsing functionality (shell-utils.js) is only used when executing shell commands. Your GeminiAgent already
  excludes the shell tool via:
  excludeTools: ['run_shell_command', 'write_file', 'replace']

  So the code path that requires the WASM files is never executed.
