### PR TITLE
fix: openai comptabile endpoint

### DIFF
--- a/packages/agent/src/agent/gemini-vercel-sdk-adapter/index.ts
+++ b/packages/agent/src/agent/gemini-vercel-sdk-adapter/index.ts
@@ -279,6 +279,7 @@ export class VercelAIContentGenerator implements ContentGenerator {
         return createOpenAICompatible({
           name: 'lmstudio',
           baseURL: config.baseUrl,
+          ...(config.apiKey && {apiKey: config.apiKey}),
         });
 
       case AIProvider.OLLAMA:
@@ -288,6 +289,7 @@ export class VercelAIContentGenerator implements ContentGenerator {
         return createOpenAICompatible({
           name: 'ollama',
           baseURL: config.baseUrl,
+          ...(config.apiKey && {apiKey: config.apiKey}),
         });
 
       case AIProvider.BEDROCK:
@@ -311,6 +313,16 @@ export class VercelAIContentGenerator implements ContentGenerator {
           name: 'browseros',
           baseURL: config.baseUrl,
           apiKey: config.apiKey,
+        });
+
+      case AIProvider.OPENAI_COMPATIBLE:
+        if (!config.baseUrl) {
+          throw new Error('OpenAI-compatible provider requires baseUrl');
+        }
+        return createOpenAICompatible({
+          name: 'openai-compatible',
+          baseURL: config.baseUrl,
+          ...(config.apiKey && {apiKey: config.apiKey}),
         });
 
       default:

--- a/packages/agent/src/agent/gemini-vercel-sdk-adapter/types.ts
+++ b/packages/agent/src/agent/gemini-vercel-sdk-adapter/types.ts
@@ -213,6 +213,7 @@ export enum AIProvider {
   LMSTUDIO = 'lmstudio',
   BEDROCK = 'bedrock',
   BROWSEROS = 'browseros',
+  OPENAI_COMPATIBLE = 'openai-compatible',
 }
 
 /**


### PR DESCRIPTION
Adding `openai-compatible` endpoint
Lets not silently ignore the `apiKey` in `LM studio` or `Ollama`.