### PR TITLE
Fix/tool use

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "browseros-server",
@@ -69,7 +68,7 @@
         "@ai-sdk/amazon-bedrock": "^3.0.59",
         "@ai-sdk/anthropic": "^2.0.47",
         "@ai-sdk/azure": "^2.0.74",
-        "@ai-sdk/google": "^2.0.43",
+        "@ai-sdk/google": "^2.0.49",
         "@ai-sdk/openai": "^2.0.72",
         "@ai-sdk/openai-compatible": "^1.0.27",
         "@ai-sdk/provider": "2.0.0",
@@ -203,7 +202,7 @@
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.15", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-i1YVKzC1dg9LGvt+GthhD7NlRhz9J4+ZRj3KELU14IZ/MHPsOBiFeEoCCIDLR+3tqT8/+5nIsK3eZ7DFRfMfdw=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@2.0.43", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-qO6giuoYCX/SdZScP/3VO5Xnbd392zm3HrTkhab/efocZU8J/VVEAcAUE1KJh0qOIAYllofRtpJIUGkRK8Q5rw=="],
+    "@ai-sdk/google": ["@ai-sdk/google@2.0.49", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-efwKk4mOV0SpumUaQskeYABk37FJPmEYwoDJQEjyLRmGSjtHRe9P5Cwof5ffLvaFav2IaJpBGEz98pyTs7oNWA=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@2.0.72", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9j8Gdt9gFiUGFdQIjjynbC7+w8YQxkXje6dwAq1v2Pj17wmB3U0Td3lnEe/a+EnEysY3mdkc8dHPYc5BNev9NQ=="],
 
@@ -2435,7 +2434,7 @@
 
     "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
-    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
+    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA=="],
 
     "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
@@ -2455,7 +2454,7 @@
 
     "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@browseros/agent/@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+    "@browseros/agent/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@browseros/agent/zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
 
@@ -2465,7 +2464,7 @@
 
     "@browseros/tools/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.19.1", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-3Y2h3MZKjec1eAqSTBclATlX+AbC6n1LgfVzRMJLt3v6w0RCYgwLrjbxPDbhsYHt6Wdqc/aCceNJYgj448ELQQ=="],
 
-    "@browseros/tools/@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+    "@browseros/tools/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@browseros/tools/zod": ["zod@3.24.3", "", {}, "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg=="],
 
@@ -2767,9 +2766,9 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@browseros/agent/@types/bun/bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+    "@browseros/agent/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
-    "@browseros/tools/@types/bun/bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+    "@browseros/tools/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "@google/gemini-cli-core/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -31,7 +31,7 @@
     "@ai-sdk/amazon-bedrock": "^3.0.59",
     "@ai-sdk/anthropic": "^2.0.47",
     "@ai-sdk/azure": "^2.0.74",
-    "@ai-sdk/google": "^2.0.43",
+    "@ai-sdk/google": "^2.0.49",
     "@ai-sdk/openai": "^2.0.72",
     "@ai-sdk/openai-compatible": "^1.0.27",
     "@ai-sdk/provider": "2.0.0",

--- a/packages/agent/src/agent/gemini-vercel-sdk-adapter/strategies/message.test.ts
+++ b/packages/agent/src/agent/gemini-vercel-sdk-adapter/strategies/message.test.ts
@@ -311,7 +311,19 @@ describe('MessageConversionStrategy', () => {
     );
 
     t('tests that function response without id generates one', () => {
+      // Must include matching tool_use for adjacency validation
       const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'test_tool',
+                args: {},
+              } as Partial<FunctionCall> as FunctionCall,
+            },
+          ],
+        },
         {
           role: 'user',
           parts: [
@@ -327,8 +339,10 @@ describe('MessageConversionStrategy', () => {
 
       const result = strategy.geminiToVercel(contents);
 
-      const content = result[0].content as VercelContentPart[];
-      const toolResult = content[0] as VercelToolResultPart;
+      // Both tool_call and tool_result generate IDs
+      expect(result).toHaveLength(2);
+      const toolContent = result[1].content as VercelContentPart[];
+      const toolResult = toolContent[0] as VercelToolResultPart;
       expect(toolResult.toolCallId).toBeDefined();
       expect(toolResult.toolCallId).toMatch(/^call_\d+_[a-z0-9]+$/);
     });
@@ -483,14 +497,13 @@ describe('MessageConversionStrategy', () => {
     );
 
     t(
-      'tests that tool_result is filtered when its tool_use was filtered earlier',
+      'tests that non-adjacent tool_use/tool_result pairs are filtered (adjacency validation)',
       () => {
-        // This tests the critical fix: when a tool_use is filtered out because
-        // its result doesn't exist, any tool_result with that ID that comes later
-        // should also be filtered out.
+        // This tests adjacency validation: tool_use must be IMMEDIATELY followed by tool_result
+        // After compression, tool_use and tool_result may exist but not be adjacent.
+        // Anthropic requires: "Each tool_result must have a corresponding tool_use in the previous message"
         //
-        // Scenario: compression removed the tool_result, tool_use gets filtered,
-        // but then a stale/duplicate tool_result appears later in history
+        // Scenario: tool_use and tool_result exist but have other messages between them
         const contents: Content[] = [
           {role: 'user', parts: [{text: 'Hello'}]},
           {
@@ -506,9 +519,9 @@ describe('MessageConversionStrategy', () => {
               },
             ],
           },
-          // Note: NO tool_result here - simulating compression removed it
+          // Another message in between - breaks adjacency!
           {role: 'model', parts: [{text: 'Search complete'}]},
-          // Later, a stale tool_result appears (shouldn't happen but might due to bugs)
+          // Tool_result is NOT adjacent to its tool_use
           {
             role: 'user',
             parts: [
@@ -525,15 +538,16 @@ describe('MessageConversionStrategy', () => {
 
         const result = strategy.geminiToVercel(contents);
 
-        // First pass collects: allToolCallIds = {filter_cascade}, allToolResultIds = {filter_cascade}
-        // Both IDs exist, so both pass initial filter.
-        // But the ordering is wrong - tool_use at index 1, tool_result at index 3
-        // with unrelated content in between.
-        //
-        // Actually, since both IDs match, both should be kept.
-        // The API will accept this because tool_use comes before tool_result.
-        // This is actually a valid (if unusual) conversation.
-        expect(result).toHaveLength(4); // user text, assistant with tool_use, assistant text, tool
+        // Adjacency validation filters out non-adjacent pairs:
+        // - tool_use is filtered because next message is not a tool message
+        // - tool_result is filtered because previous message is not an assistant with matching tool_use
+        // Result: user text, assistant (text only, tool_use removed), assistant text
+        expect(result).toHaveLength(3);
+        expect(result[0].role).toBe('user');
+        expect(result[1].role).toBe('assistant');
+        expect(result[1].content).toBe('Let me search'); // Only text, tool_use removed
+        expect(result[2].role).toBe('assistant');
+        expect(result[2].content).toBe('Search complete');
       },
     );
 
@@ -843,6 +857,7 @@ describe('MessageConversionStrategy', () => {
     );
 
     t('tests that function call without id generates one', () => {
+      // Must include matching tool_result for adjacency validation
       const contents: Content[] = [
         {
           role: 'model',
@@ -855,12 +870,25 @@ describe('MessageConversionStrategy', () => {
             },
           ],
         },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'test_tool',
+                response: {result: 'ok'},
+              } as Partial<FunctionResponse> as FunctionResponse,
+            },
+          ],
+        },
       ];
 
       const result = strategy.geminiToVercel(contents);
 
-      const content = result[0].content as VercelContentPart[];
-      const toolCall = content[0] as VercelToolCallPart;
+      // Both get generated IDs, and they match each other
+      expect(result).toHaveLength(2);
+      const assistantContent = result[0].content as VercelContentPart[];
+      const toolCall = assistantContent[0] as VercelToolCallPart;
       expect(toolCall.toolCallId).toBeDefined();
       expect(toolCall.toolCallId).toMatch(/^call_\d+_[a-z0-9]+$/);
     });

--- a/packages/agent/src/agent/gemini-vercel-sdk-adapter/strategies/message.test.ts
+++ b/packages/agent/src/agent/gemini-vercel-sdk-adapter/strategies/message.test.ts
@@ -541,11 +541,14 @@ describe('MessageConversionStrategy', () => {
         // Adjacency validation filters out non-adjacent pairs:
         // - tool_use is filtered because next message is not a tool message
         // - tool_result is filtered because previous message is not an assistant with matching tool_use
-        // Result: user text, assistant (text only, tool_use removed), assistant text
+        // Result: user text, assistant (text only as array, tool_use removed), assistant text
         expect(result).toHaveLength(3);
         expect(result[0].role).toBe('user');
         expect(result[1].role).toBe('assistant');
-        expect(result[1].content).toBe('Let me search'); // Only text, tool_use removed
+        // Content is an array with text part after tool_call removal
+        expect(result[1].content).toEqual([
+          {type: 'text', text: 'Let me search'},
+        ]);
         expect(result[2].role).toBe('assistant');
         expect(result[2].content).toBe('Search complete');
       },
@@ -1159,6 +1162,379 @@ describe('MessageConversionStrategy', () => {
         null as unknown as ContentUnion,
       );
       expect(result).toBeUndefined();
+    });
+  });
+
+  // PROVIDER COMPATIBILITY TESTS
+  // These tests verify that the message conversion works correctly for all supported providers
+  describe('Provider Compatibility', () => {
+    // Anthropic/OpenAI: Always have IDs
+    t('Anthropic-style: tool_use and tool_result with matching IDs', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'toolu_01abc123',
+                name: 'search',
+                args: {query: 'test'},
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'toolu_01abc123',
+                name: 'search',
+                response: {results: []},
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      expect(result).toHaveLength(2);
+      const toolCall = (
+        result[0].content as VercelContentPart[]
+      )[0] as VercelToolCallPart;
+      const toolResult = (
+        result[1].content as VercelContentPart[]
+      )[0] as VercelToolResultPart;
+      expect(toolCall.toolCallId).toBe('toolu_01abc123');
+      expect(toolResult.toolCallId).toBe('toolu_01abc123');
+    });
+
+    // Gemini: Empty IDs, match by name
+    t('Gemini-style: empty IDs matched by tool name', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'get_weather',
+                args: {location: 'NYC'},
+              } as Partial<FunctionCall> as FunctionCall,
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'get_weather',
+                response: {temp: 72},
+              } as Partial<FunctionResponse> as FunctionResponse,
+            },
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      expect(result).toHaveLength(2);
+      const toolCall = (
+        result[0].content as VercelContentPart[]
+      )[0] as VercelToolCallPart;
+      const toolResult = (
+        result[1].content as VercelContentPart[]
+      )[0] as VercelToolResultPart;
+      // Both should have the same generated ID
+      expect(toolCall.toolCallId).toBe(toolResult.toolCallId);
+      expect(toolCall.toolCallId).toMatch(/^call_\d+_[a-z0-9]+$/);
+    });
+
+    // Mixed: Call has ID, result doesn't
+    t('Mixed: call has ID, result matched by name uses call ID', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call_from_ollama',
+                name: 'calculate',
+                args: {x: 1},
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'calculate',
+                response: {result: 2},
+              } as Partial<FunctionResponse> as FunctionResponse,
+            },
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      expect(result).toHaveLength(2);
+      const toolCall = (
+        result[0].content as VercelContentPart[]
+      )[0] as VercelToolCallPart;
+      const toolResult = (
+        result[1].content as VercelContentPart[]
+      )[0] as VercelToolResultPart;
+      expect(toolCall.toolCallId).toBe('call_from_ollama');
+      expect(toolResult.toolCallId).toBe('call_from_ollama');
+    });
+
+    // Mixed: Result has ID, call doesn't
+    t('Mixed: result has ID, call matched by name uses result ID', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'fetch_data',
+                args: {},
+              } as Partial<FunctionCall> as FunctionCall,
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'result_id_123',
+                name: 'fetch_data',
+                response: {data: 'test'},
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      expect(result).toHaveLength(2);
+      const toolCall = (
+        result[0].content as VercelContentPart[]
+      )[0] as VercelToolCallPart;
+      const toolResult = (
+        result[1].content as VercelContentPart[]
+      )[0] as VercelToolResultPart;
+      expect(toolCall.toolCallId).toBe('result_id_123');
+      expect(toolResult.toolCallId).toBe('result_id_123');
+    });
+
+    // Multiple tools: Anthropic-style parallel tool calls
+    t('Multiple parallel tool calls with IDs (Anthropic-style)', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {functionCall: {id: 'toolu_1', name: 'search', args: {q: 'a'}}},
+            {functionCall: {id: 'toolu_2', name: 'fetch', args: {url: 'b'}}},
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'toolu_1',
+                name: 'search',
+                response: {r: 1},
+              },
+            },
+            {
+              functionResponse: {
+                id: 'toolu_2',
+                name: 'fetch',
+                response: {r: 2},
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      expect(result).toHaveLength(2);
+      const calls = result[0].content as VercelContentPart[];
+      const results = result[1].content as VercelContentPart[];
+      expect(calls).toHaveLength(2);
+      expect(results).toHaveLength(2);
+      expect((calls[0] as VercelToolCallPart).toolCallId).toBe('toolu_1');
+      expect((calls[1] as VercelToolCallPart).toolCallId).toBe('toolu_2');
+      expect((results[0] as VercelToolResultPart).toolCallId).toBe('toolu_1');
+      expect((results[1] as VercelToolResultPart).toolCallId).toBe('toolu_2');
+    });
+
+    // Multiple tools: Gemini-style (empty IDs)
+    t('Multiple parallel tool calls without IDs (Gemini-style)', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'tool_a',
+                args: {},
+              } as Partial<FunctionCall> as FunctionCall,
+            },
+            {
+              functionCall: {
+                name: 'tool_b',
+                args: {},
+              } as Partial<FunctionCall> as FunctionCall,
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'tool_a',
+                response: {},
+              } as Partial<FunctionResponse> as FunctionResponse,
+            },
+            {
+              functionResponse: {
+                name: 'tool_b',
+                response: {},
+              } as Partial<FunctionResponse> as FunctionResponse,
+            },
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      expect(result).toHaveLength(2);
+      const calls = result[0].content as VercelContentPart[];
+      const results = result[1].content as VercelContentPart[];
+      expect(calls).toHaveLength(2);
+      expect(results).toHaveLength(2);
+      // Each call should have matching result ID
+      expect((calls[0] as VercelToolCallPart).toolCallId).toBe(
+        (results[0] as VercelToolResultPart).toolCallId,
+      );
+      expect((calls[1] as VercelToolCallPart).toolCallId).toBe(
+        (results[1] as VercelToolResultPart).toolCallId,
+      );
+      // IDs should be different from each other
+      expect((calls[0] as VercelToolCallPart).toolCallId).not.toBe(
+        (calls[1] as VercelToolCallPart).toolCallId,
+      );
+    });
+
+    // Edge case: Different names, no matching
+    t('Different names with no IDs are filtered as orphans', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'tool_x',
+                args: {},
+              } as Partial<FunctionCall> as FunctionCall,
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'tool_y',
+                response: {},
+              } as Partial<FunctionResponse> as FunctionResponse,
+            },
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      // Both should be filtered out - no matching pairs
+      expect(result).toHaveLength(0);
+    });
+
+    // Edge case: Mismatched IDs are matched by name (fallback behavior)
+    t('Mismatched IDs fall back to name matching', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [{functionCall: {id: 'call_1', name: 'tool', args: {}}}],
+        },
+        {
+          role: 'user',
+          parts: [
+            {functionResponse: {id: 'call_2', name: 'tool', response: {}}},
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      // IDs don't match in PHASE 1, but PHASE 2 matches by name
+      // Uses call's ID as the synchronized ID
+      expect(result).toHaveLength(2);
+      const toolCall = (
+        result[0].content as VercelContentPart[]
+      )[0] as VercelToolCallPart;
+      const toolResult = (
+        result[1].content as VercelContentPart[]
+      )[0] as VercelToolResultPart;
+      expect(toolCall.toolCallId).toBe('call_1');
+      expect(toolResult.toolCallId).toBe('call_1');
+    });
+
+    // Bedrock: Uses toolu_bdrk_ prefix
+    t('Bedrock-style: tool_use with toolu_bdrk_ prefix', () => {
+      const contents: Content[] = [
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'toolu_bdrk_01XYZ',
+                name: 'invoke_lambda',
+                args: {fn: 'test'},
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'toolu_bdrk_01XYZ',
+                name: 'invoke_lambda',
+                response: {status: 'ok'},
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = strategy.geminiToVercel(contents);
+
+      expect(result).toHaveLength(2);
+      const toolCall = (
+        result[0].content as VercelContentPart[]
+      )[0] as VercelToolCallPart;
+      expect(toolCall.toolCallId).toBe('toolu_bdrk_01XYZ');
     });
   });
 });

--- a/packages/agent/src/agent/gemini-vercel-sdk-adapter/strategies/message.ts
+++ b/packages/agent/src/agent/gemini-vercel-sdk-adapter/strategies/message.ts
@@ -42,19 +42,10 @@ export class MessageConversionStrategy {
     const messages: CoreMessage[] = [];
     const seenToolResultIds = new Set<string>();
 
-    // First pass: collect all tool call IDs and tool result IDs
-    const allToolCallIds = new Set<string>();
-    const allToolResultIds = new Set<string>();
-    for (const content of contents) {
-      for (const part of content.parts || []) {
-        if (isFunctionCallPart(part) && part.functionCall?.id) {
-          allToolCallIds.add(part.functionCall.id);
-        }
-        if (isFunctionResponsePart(part) && part.functionResponse?.id) {
-          allToolResultIds.add(part.functionResponse.id);
-        }
-      }
-    }
+    // PHASE 1: Build tool call/result pairs with synchronized IDs
+    // This ensures that even when IDs are missing, we generate consistent IDs for pairs
+    const {pairedToolCallIds, pairedToolResultIds, idMapping} =
+      this.buildToolPairs(contents);
 
     for (const content of contents) {
       const role = content.role === 'model' ? 'assistant' : 'user';
@@ -132,20 +123,22 @@ export class MessageConversionStrategy {
       if (functionResponses.length > 0) {
         // Filter out duplicate tool results AND orphaned tool results (no matching tool_use)
         const uniqueResponses = functionResponses.filter(fr => {
-          const id = fr.id || '';
+          // Use synchronized ID from pairing, or original ID if not in mapping
+          const originalId = fr.id || '';
+          const synchronizedId = idMapping.get(originalId) || originalId;
+
           // Skip duplicates
-          if (seenToolResultIds.has(id)) {
+          if (synchronizedId && seenToolResultIds.has(synchronizedId)) {
             return false;
           }
-          // Skip orphaned tool results (no matching tool_use in history)
+          // Skip orphaned tool results (no matching tool_use in paired set)
           // This prevents: "unexpected tool_use_id found in tool_result blocks"
-          // Also remove from allToolResultIds so corresponding tool_uses in later
-          // Contents will also be filtered out (cascading deletion)
-          if (id && !allToolCallIds.has(id)) {
-            allToolResultIds.delete(id);
+          if (originalId && !pairedToolResultIds.has(originalId)) {
             return false;
           }
-          seenToolResultIds.add(id);
+          if (synchronizedId) {
+            seenToolResultIds.add(synchronizedId);
+          }
           return true;
         });
 
@@ -156,8 +149,10 @@ export class MessageConversionStrategy {
 
         // If there are NO images → standard tool message
         if (imageParts.length === 0) {
-          const toolResultParts =
-            this.convertFunctionResponsesToToolResults(uniqueResponses);
+          const toolResultParts = this.convertFunctionResponsesToToolResults(
+            uniqueResponses,
+            idMapping,
+          );
           messages.push({
             role: 'tool',
             content: toolResultParts,
@@ -170,8 +165,10 @@ export class MessageConversionStrategy {
         // 2. User message with images (tool messages don't support images)
 
         // Message 1: Tool message with tool results (no images)
-        const toolResultParts =
-          this.convertFunctionResponsesToToolResults(uniqueResponses);
+        const toolResultParts = this.convertFunctionResponsesToToolResults(
+          uniqueResponses,
+          idMapping,
+        );
         messages.push({
           role: 'tool',
           content: toolResultParts,
@@ -218,15 +215,18 @@ export class MessageConversionStrategy {
         // This prevents Anthropic error: "tool_use ids were found without tool_result blocks"
         let isFirst = true;
         for (const fc of functionCalls) {
-          const toolCallId = fc.id || this.generateToolCallId();
+          const originalId = fc.id || '';
 
-          // Skip orphaned tool calls (no matching tool result in history)
-          // Also remove from allToolCallIds so corresponding tool_results in later
-          // Contents will also be filtered out (cascading deletion)
-          if (fc.id && !allToolResultIds.has(fc.id)) {
-            allToolCallIds.delete(fc.id);
+          // Skip orphaned tool calls (no matching tool result in paired set)
+          if (originalId && !pairedToolCallIds.has(originalId)) {
             continue;
           }
+
+          // Use synchronized ID from pairing - this ensures tool_call and tool_result have SAME ID
+          const toolCallId =
+            idMapping.get(originalId) ||
+            originalId ||
+            this.generateToolCallId();
 
           const toolCallPart: Record<string, unknown> = {
             type: 'tool-call' as const,
@@ -264,7 +264,12 @@ export class MessageConversionStrategy {
     // The API requires ALL tool_results to be in a single message immediately following
     // the assistant message with tool_uses. If tool_results are split across multiple
     // messages, we get: "unexpected tool_use_id found in tool_result blocks"
-    return this.mergeConsecutiveToolMessages(messages);
+    const merged = this.mergeConsecutiveToolMessages(messages);
+
+    // CRITICAL: Validate adjacency - tool_use must be immediately followed by tool_result
+    // After compression, pairs may exist but not be adjacent, causing:
+    // "Each tool_result block must have a corresponding tool_use block in the previous message"
+    return this.validateToolAdjacency(merged);
   }
 
   /**
@@ -299,6 +304,7 @@ export class MessageConversionStrategy {
 
   /**
    * Convert function responses to tool result parts for AI SDK v5
+   * Uses idMapping to ensure tool_result IDs match corresponding tool_call IDs
    */
   private convertFunctionResponsesToToolResults(
     responses: Array<{
@@ -306,6 +312,7 @@ export class MessageConversionStrategy {
       name?: string;
       response?: Record<string, unknown>;
     }>,
+    idMapping: Map<string, string>,
   ): VercelContentPart[] {
     return responses.map(fr => {
       // Convert Gemini response to AI SDK v5 structured output format
@@ -338,9 +345,14 @@ export class MessageConversionStrategy {
             : {type: 'json', value: response as JSONValue};
       }
 
+      // Use synchronized ID from pairing - this ensures tool_result matches tool_call
+      const originalId = fr.id || '';
+      const synchronizedId =
+        idMapping.get(originalId) || originalId || this.generateToolCallId();
+
       return {
         type: 'tool-result' as const,
-        toolCallId: fr.id || this.generateToolCallId(),
+        toolCallId: synchronizedId,
         toolName: fr.name || 'unknown',
         output: output,
       };
@@ -352,6 +364,161 @@ export class MessageConversionStrategy {
    */
   private generateToolCallId(): string {
     return `call_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+  }
+
+  /**
+   * Build tool call/result pairs with synchronized IDs
+   *
+   * This method solves the root cause of "unexpected tool_use_id" errors:
+   * When IDs are missing or inconsistent, we need to:
+   * 1. Match tool calls with their corresponding results (by ID, name, or position)
+   * 2. Generate a single synchronized ID for pairs where IDs are missing
+   * 3. Track which IDs are valid (have both call and result)
+   *
+   * @returns pairedToolCallIds - Set of original tool call IDs that have matching results
+   * @returns pairedToolResultIds - Set of original tool result IDs that have matching calls
+   * @returns idMapping - Map from original ID to synchronized ID (for ID generation/consistency)
+   */
+  private buildToolPairs(contents: readonly Content[]): {
+    pairedToolCallIds: Set<string>;
+    pairedToolResultIds: Set<string>;
+    idMapping: Map<string, string>;
+  } {
+    // Collect all tool calls and results with their metadata
+    const toolCalls: Array<{
+      id: string;
+      name: string;
+      index: number;
+      contentIndex: number;
+    }> = [];
+    const toolResults: Array<{
+      id: string;
+      name: string;
+      index: number;
+      contentIndex: number;
+    }> = [];
+
+    let globalCallIndex = 0;
+    let globalResultIndex = 0;
+
+    for (let contentIndex = 0; contentIndex < contents.length; contentIndex++) {
+      const content = contents[contentIndex];
+      for (const part of content.parts || []) {
+        if (isFunctionCallPart(part)) {
+          toolCalls.push({
+            id: part.functionCall?.id || '',
+            name: part.functionCall?.name || '',
+            index: globalCallIndex++,
+            contentIndex,
+          });
+        }
+        if (isFunctionResponsePart(part)) {
+          toolResults.push({
+            id: part.functionResponse?.id || '',
+            name: part.functionResponse?.name || '',
+            index: globalResultIndex++,
+            contentIndex,
+          });
+        }
+      }
+    }
+
+    const pairedToolCallIds = new Set<string>();
+    const pairedToolResultIds = new Set<string>();
+    const idMapping = new Map<string, string>();
+    const usedResultIndices = new Set<number>();
+
+    // PHASE 1: Match by exact ID (when both have IDs that match)
+    for (const call of toolCalls) {
+      if (!call.id) continue;
+
+      const matchingResult = toolResults.find(
+        r => r.id === call.id && !usedResultIndices.has(r.index),
+      );
+
+      if (matchingResult) {
+        pairedToolCallIds.add(call.id);
+        pairedToolResultIds.add(matchingResult.id);
+        usedResultIndices.add(matchingResult.index);
+        // ID is already synchronized (same value)
+        idMapping.set(call.id, call.id);
+        idMapping.set(matchingResult.id, call.id);
+      }
+    }
+
+    // PHASE 2: Match by name for calls/results without IDs or unmatched IDs
+    for (const call of toolCalls) {
+      // Skip if already paired
+      if (call.id && pairedToolCallIds.has(call.id)) continue;
+
+      // Find a result with same name that hasn't been used
+      const matchingResult = toolResults.find(
+        r =>
+          r.name === call.name &&
+          !usedResultIndices.has(r.index) &&
+          r.contentIndex > call.contentIndex, // Result must come after call
+      );
+
+      if (matchingResult) {
+        // Generate a synchronized ID for this pair
+        const syncId =
+          call.id || matchingResult.id || this.generateToolCallId();
+
+        if (call.id) {
+          pairedToolCallIds.add(call.id);
+          idMapping.set(call.id, syncId);
+        }
+        if (matchingResult.id) {
+          pairedToolResultIds.add(matchingResult.id);
+          idMapping.set(matchingResult.id, syncId);
+        }
+
+        // For empty IDs, we use empty string as key with unique suffix
+        if (!call.id) {
+          const emptyCallKey = `__empty_call_${call.index}`;
+          pairedToolCallIds.add(emptyCallKey);
+          idMapping.set(emptyCallKey, syncId);
+        }
+        if (!matchingResult.id) {
+          const emptyResultKey = `__empty_result_${matchingResult.index}`;
+          pairedToolResultIds.add(emptyResultKey);
+          idMapping.set(emptyResultKey, syncId);
+        }
+
+        usedResultIndices.add(matchingResult.index);
+      }
+    }
+
+    // PHASE 3: Match remaining by position (fallback for edge cases)
+    const unmatchedCalls = toolCalls.filter(
+      c => !c.id || !pairedToolCallIds.has(c.id),
+    );
+    const unmatchedResults = toolResults.filter(
+      r => !usedResultIndices.has(r.index),
+    );
+
+    // Simple positional matching for remaining unmatched items
+    const minLength = Math.min(unmatchedCalls.length, unmatchedResults.length);
+    for (let i = 0; i < minLength; i++) {
+      const call = unmatchedCalls[i];
+      const result = unmatchedResults[i];
+
+      // Only match if result comes after call in the conversation
+      if (result.contentIndex > call.contentIndex) {
+        const syncId = call.id || result.id || this.generateToolCallId();
+
+        if (call.id) {
+          pairedToolCallIds.add(call.id);
+          idMapping.set(call.id, syncId);
+        }
+        if (result.id) {
+          pairedToolResultIds.add(result.id);
+          idMapping.set(result.id, syncId);
+        }
+      }
+    }
+
+    return {pairedToolCallIds, pairedToolResultIds, idMapping};
   }
 
   /**
@@ -405,5 +572,142 @@ export class MessageConversionStrategy {
     }
 
     return merged;
+  }
+
+  /**
+   * Validate tool_use/tool_result adjacency and remove non-adjacent pairs
+   *
+   * Anthropic requires: "Each tool_result block must have a corresponding
+   * tool_use block in the previous message."
+   *
+   * After compression, tool_use and tool_result may exist but not be adjacent.
+   * This method removes any:
+   * - tool_use that is not immediately followed by a tool message with matching tool_result
+   * - tool_result that doesn't have a matching tool_use in the immediately preceding assistant message
+   */
+  private validateToolAdjacency(messages: CoreMessage[]): CoreMessage[] {
+    if (messages.length === 0) {
+      return messages;
+    }
+
+    const result: CoreMessage[] = [];
+
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i];
+      const nextMsg = messages[i + 1];
+      const prevMsg = i > 0 ? result[result.length - 1] : undefined;
+
+      if (msg.role === 'assistant') {
+        const content = msg.content;
+
+        // Check if this assistant message has tool_call parts
+        if (Array.isArray(content)) {
+          const toolCallParts = content.filter(
+            (p): p is VercelContentPart =>
+              typeof p === 'object' &&
+              p !== null &&
+              (p as {type?: string}).type === 'tool-call',
+          );
+
+          if (toolCallParts.length > 0) {
+            // Get tool_use IDs from this assistant message
+            const toolUseIds = new Set(
+              toolCallParts
+                .map(p => (p as {toolCallId?: string}).toolCallId)
+                .filter(Boolean),
+            );
+
+            // Get tool_result IDs from the next message (if it's a tool message)
+            const nextToolResultIds = new Set<string>();
+            if (
+              nextMsg &&
+              nextMsg.role === 'tool' &&
+              Array.isArray(nextMsg.content)
+            ) {
+              for (const part of nextMsg.content as VercelContentPart[]) {
+                if ((part as {type?: string}).type === 'tool-result') {
+                  const id = (part as {toolCallId?: string}).toolCallId;
+                  if (id) nextToolResultIds.add(id);
+                }
+              }
+            }
+
+            // Filter tool_call parts to only those with matching tool_result in next message
+            const validToolCalls = toolCallParts.filter(p => {
+              const id = (p as {toolCallId?: string}).toolCallId;
+              return id && nextToolResultIds.has(id);
+            });
+
+            // Keep non-tool-call parts (text, etc.) + valid tool calls
+            const nonToolCallParts = content.filter(
+              (p): p is VercelContentPart =>
+                typeof p === 'object' &&
+                p !== null &&
+                (p as {type?: string}).type !== 'tool-call',
+            );
+
+            const newContent = [...nonToolCallParts, ...validToolCalls];
+
+            // Only add message if there's content left
+            if (newContent.length > 0) {
+              result.push({
+                role: 'assistant',
+                content: newContent,
+              } as CoreMessage);
+            } else if (
+              nonToolCallParts.length === 0 &&
+              toolCallParts.length > 0 &&
+              validToolCalls.length === 0
+            ) {
+              // All tool_calls were filtered out, skip this message entirely
+              continue;
+            }
+            continue;
+          }
+        }
+
+        // No tool_call parts, keep as-is
+        result.push(msg);
+      } else if (msg.role === 'tool') {
+        const content = msg.content as VercelContentPart[];
+
+        // Get tool_use IDs from the previous assistant message
+        const prevToolUseIds = new Set<string>();
+        if (
+          prevMsg &&
+          prevMsg.role === 'assistant' &&
+          Array.isArray(prevMsg.content)
+        ) {
+          for (const part of prevMsg.content as VercelContentPart[]) {
+            if ((part as {type?: string}).type === 'tool-call') {
+              const id = (part as {toolCallId?: string}).toolCallId;
+              if (id) prevToolUseIds.add(id);
+            }
+          }
+        }
+
+        // Filter tool_result parts to only those with matching tool_use in previous message
+        const validToolResults = content.filter(part => {
+          if ((part as {type?: string}).type !== 'tool-result') {
+            return true; // Keep non-tool-result parts
+          }
+          const id = (part as {toolCallId?: string}).toolCallId;
+          return id && prevToolUseIds.has(id);
+        });
+
+        // Only add message if there are valid tool results
+        if (validToolResults.length > 0) {
+          result.push({
+            role: 'tool',
+            content: validToolResults,
+          } as unknown as CoreMessage);
+        }
+      } else {
+        // User or other messages, keep as-is
+        result.push(msg);
+      }
+    }
+
+    return result;
   }
 }


### PR DESCRIPTION
Comprehensive Provider Requirements Matrix

  1. Anthropic Claude API

  Sources: https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview, https://github.com/anthropics/claude-code/issues/11064

  | Requirement  | Details                                                        | Error if Violated                                                                       |
  |--------------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------|
  | ID Format    | toolu_01... (always generated)                                 | N/A                                                                                     |
  | ID Matching  | tool_result.tool_use_id MUST exactly match tool_use.id         | unexpected tool_use_id found in tool_result blocks                                      |
  | Adjacency    | tool_result MUST be in IMMEDIATELY NEXT message after tool_use | Each tool_result block must have a corresponding tool_use block in the previous message |
  | Completeness | ALL tool_use must have corresponding tool_result               | tool_use ids were found without tool_result blocks                                      |
  | Grouping     | Multiple tool_result must be in SINGLE message                 | Same as adjacency error                                                                 |

  Anthropic's 4 Strict Rules:
  1. Each tool_use MUST have a corresponding tool_result
  2. tool_result MUST be in the IMMEDIATELY NEXT message
  3. Multiple tool_use → ALL tool_result in ONE message
  4. tool_use_id MUST EXACTLY match

  ---
  2. OpenAI API

  Sources: https://platform.openai.com/docs/guides/function-calling, https://portkey.ai/error-library/tool-call-response-error-6610000

  | Requirement  | Details                                                         | Error if Violated                                                        |
  |--------------|-----------------------------------------------------------------|--------------------------------------------------------------------------|
  | ID Format    | call_abc123... (always generated)                               | N/A                                                                      |
  | ID Matching  | tool.tool_call_id MUST match assistant.tool_calls[].id          | Missing parameter 'tool_call_id'                                         |
  | Adjacency    | tool messages MUST immediately follow assistant with tool_calls | An assistant message with 'tool_calls' must be followed by tool messages |
  | Completeness | EVERY tool_call_id must have a response                         | Ensure there are response messages for all tool_call_ids                 |
  | Role         | Response uses role: "tool" with tool_call_id field              | messages with role 'tool' must be a response to a preceding message      |

  ---
  3. Google Gemini API

  Sources: https://ai.google.dev/gemini-api/docs/function-calling

  | Requirement      | Details                                           | Error if Violated                     |
  |------------------|---------------------------------------------------|---------------------------------------|
  | ID Format        | Sometimes None/empty (not always generated!)      | N/A                                   |
  | ID Matching      | Match by name when ID is absent                   | N/A                                   |
  | Adjacency        | Less strict - results can be in same user message | N/A                                   |
  | Completeness     | Should provide responses for all function calls   | May cause confusion                   |
  | Role             | functionCall in model, functionResponse in user   | Invalid message structure             |
  | Gemini 3 Special | Must preserve thought_signature in Parts          | API error if signature handling wrong |

  Key Difference: Gemini uses name-based matching when IDs are absent!

  ---
  4. OpenRouter API

  Sources: https://openrouter.ai/docs/api/reference/overview

  | Requirement   | Details                                                                      | Notes                                  |
  |---------------|------------------------------------------------------------------------------|----------------------------------------|
  | Format        | OpenAI-compatible API                                                        | Uses OpenAI message format             |
  | ID Format     | Depends on backend model                                                     | Anthropic: toolu_..., OpenAI: call_... |
  | Normalization | finish_reason normalized to: tool_calls, stop, length, content_filter, error |                                        |
  | Pass-through  | Provider-specific params may be ignored if not supported                     |                                        |

  Critical: When routing to Anthropic models, ALL Anthropic rules apply!

  ---
  5. Ollama / LMStudio / OpenAI-Compatible

  Sources: https://docs.ollama.com/capabilities/tool-calling

  | Requirement                | Details                                             | Notes                             |
  |----------------------------|-----------------------------------------------------|-----------------------------------|
  | Native Ollama              | Uses tool_name (NOT tool_call_id)                   | Different from OpenAI!            |
  | OpenAI-Compatible Endpoint | Uses tool_call_id like OpenAI                       | /v1/... endpoints                 |
  | ID Generation              | Model-dependent, may be empty                       | Llama 3.1, Qwen 2.5 support tools |
  | Adjacency                  | Follows OpenAI rules when using compatible endpoint |                                   |

  ---
  Validation: Does message.ts Handle All Cases?

  | Scenario              | Provider                   | How message.ts Handles                      | Status |
  |-----------------------|----------------------------|---------------------------------------------|--------|
  | Matching IDs          | Anthropic, OpenAI, Bedrock | PHASE 1: Exact ID match                     | ✅     |
  | Empty IDs             | Gemini, Ollama             | PHASE 2: Match by name                      | ✅     |
  | Mixed IDs             | Any                        | PHASE 2: Falls back to name if ID unmatched | ✅     |
  | Orphan tool_use       | Any                        | Filtered in main loop                       | ✅     |
  | Orphan tool_result    | Any                        | Filtered in main loop                       | ✅     |
  | Non-adjacent pairs    | Anthropic (strict)         | validateToolAdjacency() removes             | ✅     |
  | Consecutive tool msgs | Any                        | mergeConsecutiveToolMessages()              | ✅     |
  | Duplicate results     | Any                        | seenToolResultIds deduplication             | ✅     |
  | ID synchronization    | All                        | idMapping ensures same ID for pair          | ✅     |
  
  Message.test.ts also cover all test cases now!