### PR TITLE
ci: update dependabot to focus on security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,11 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval:  weekly
       day: 'sunday'
       time: '02:00'
       timezone: Europe/Berlin
+    open-pull-requests-limit: 10
     groups:
       dependencies:
         dependency-type: production
@@ -14,7 +15,7 @@ updates:
           - 'puppeteer*'
         patterns:
           - '*'
-      dev-dependencies:
+      dev-dependencies: 
         dependency-type: development
         exclude-patterns:
           - 'puppeteer*'
@@ -29,8 +30,12 @@ updates:
       interval: weekly
       day: 'sunday'
       time: '04:00'
-      timezone: Europe/Berlin
+      timezone:  Europe/Berlin
+    open-pull-requests-limit: 10
     groups:
-      all:
+      all: 
         patterns:
           - '*'
+
+enable-beta-ecosystems: true
+security-updates-only: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval:  weekly
+      interval: weekly
       day: 'sunday'
       time: '02:00'
       timezone: Europe/Berlin
@@ -15,7 +15,7 @@ updates:
           - 'puppeteer*'
         patterns:
           - '*'
-      dev-dependencies: 
+      dev-dependencies:
         dependency-type: development
         exclude-patterns:
           - 'puppeteer*'
@@ -30,10 +30,10 @@ updates:
       interval: weekly
       day: 'sunday'
       time: '04:00'
-      timezone:  Europe/Berlin
+      timezone: Europe/Berlin
     open-pull-requests-limit: 10
     groups:
-      all: 
+      all:
         patterns:
           - '*'
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly
@@ -10,12 +10,14 @@ updates:
     open-pull-requests-limit: 10
     groups:
       dependencies:
+        applies-to: security-updates
         dependency-type: production
         exclude-patterns:
           - 'puppeteer*'
         patterns:
           - '*'
       dev-dependencies:
+        applies-to: security-updates
         dependency-type: development
         exclude-patterns:
           - 'puppeteer*'
@@ -34,8 +36,6 @@ updates:
     open-pull-requests-limit: 10
     groups:
       all:
+        applies-to: security-updates
         patterns:
           - '*'
-
-enable-beta-ecosystems: true
-security-updates-only: true


### PR DESCRIPTION
Added open-pull-requests-limit, enabled beta ecosystems (for bun support) and only allow only security updates