### PR TITLE
ci: enable typecheck in code-quality workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,22 +25,22 @@ jobs:
       - name: Run Biome
         run: biome ci .
 
-  # typecheck:
-  #   name: runner / Typecheck
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v5
-  #       with:
-  #         persist-credentials: false
+  typecheck:
+    name: runner / Typecheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
-  #     - name: Setup Bun
-  #       uses: oven-sh/setup-bun@v2
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
-  #     - name: Install dependencies
-  #       run: bun install
+      - name: Install dependencies
+        run: bun install
 
-  #     - name: Run Typecheck
-  #       run: bun run typecheck
+      - name: Run Typecheck
+        run: bun run typecheck

--- a/apps/controller-ext/package.json
+++ b/apps/controller-ext/package.json
@@ -10,7 +10,8 @@
     "build:dev": "webpack --mode development",
     "watch": "webpack --mode development --watch",
     "test": "node tests/test-simple.js",
-    "test:auto": "node tests/test-auto.js"
+    "test:auto": "node tests/test-auto.js",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "browser-automation",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:controller": "bun run --filter @browseros/server test:controller",
     "test:integration": "bun run --filter @browseros/server test:integration",
 
-    "typecheck": "tsc --build",
+    "typecheck": "bun run --filter '*' typecheck",
     "lint": "bunx biome check",
     "lint:fix": "bunx biome check --write --unsafe",
 


### PR DESCRIPTION
This pull request updates the `typecheck` script in the `package.json` file to improve consistency and compatibility with the project's monorepo tooling.

* Script update:
  * Changed the `typecheck` script to use `bun run --filter '*' typecheck` instead of directly calling `tsc --build`, ensuring type checking is run across all filtered packages in the monorepo.