### PR TITLE
chore: added analytics for scheduled tasks

### DIFF
--- a/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
+++ b/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
@@ -18,6 +18,8 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
+import { SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT } from '@/lib/constants/analyticsEvents'
+import { track } from '@/lib/metrics/track'
 import {
   useScheduledJobRuns,
   useScheduledJobs,
@@ -83,6 +85,11 @@ export const ScheduleResults: FC = () => {
     return [...runningJobs, ...completedOrFailed]
   }, [jobRuns, jobs])
 
+  const viewRun = (run: JobRunWithDetails) => {
+    track(SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT)
+    setViewingRun(run)
+  }
+
   return (
     <Collapsible
       open={isOpen}
@@ -116,7 +123,7 @@ export const ScheduleResults: FC = () => {
           <Button
             key={run.id}
             variant="ghost"
-            onClick={() => setViewingRun(run)}
+            onClick={() => viewRun(run)}
             className="h-auto w-full justify-start rounded-xl border border-border/50 bg-card p-4 text-left transition-all hover:border-border"
           >
             <div className="flex w-full items-start gap-3">

--- a/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
+++ b/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
@@ -18,7 +18,10 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
-import { SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT } from '@/lib/constants/analyticsEvents'
+import {
+  SCHEDULED_TASK_VIEW_MORE_IN_NEWTAB_EVENT,
+  SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT,
+} from '@/lib/constants/analyticsEvents'
 import { track } from '@/lib/metrics/track'
 import {
   useScheduledJobRuns,
@@ -147,6 +150,15 @@ export const ScheduleResults: FC = () => {
             </div>
           </Button>
         ))}
+        <Button variant="ghost" asChild className="w-full">
+          {/* biome-ignore lint/a11y/useValidAnchor: click handler is passive */}
+          <a
+            href="/options.html#/scheduled"
+            onClick={() => track(SCHEDULED_TASK_VIEW_MORE_IN_NEWTAB_EVENT)}
+          >
+            View more
+          </a>
+        </Button>
       </CollapsibleContent>
 
       <RunResultDialog

--- a/apps/agent/entrypoints/options/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/apps/agent/entrypoints/options/scheduled-tasks/ScheduledTasksPage.tsx
@@ -55,9 +55,9 @@ export const ScheduledTasksPage: FC = () => {
 
   const confirmDelete = async () => {
     if (deleteJobId) {
-      track(SCHEDULED_TASK_DELETED_EVENT)
       await removeJob(deleteJobId)
       setDeleteJobId(null)
+      track(SCHEDULED_TASK_DELETED_EVENT)
     }
   }
 
@@ -70,28 +70,28 @@ export const ScheduledTasksPage: FC = () => {
         time: data.scheduleTime,
       })
     } else {
+      await addJob(data)
       track(NEW_SCHEDULED_TASK_CREATED_EVENT, {
         scheduleType: data.scheduleType,
         interval: data.scheduleInterval,
         time: data.scheduleTime,
       })
-      await addJob(data)
     }
   }
 
   const handleToggle = async (jobId: string, enabled: boolean) => {
-    track(SCHEDULED_TASK_TOGGLED_EVENT)
     await toggleJob(jobId, enabled)
+    track(SCHEDULED_TASK_TOGGLED_EVENT)
   }
 
   const handleRun = async (jobId: string) => {
-    track(SCHEDULED_TASK_TESTED_EVENT)
     await runJob(jobId)
+    track(SCHEDULED_TASK_TESTED_EVENT)
   }
 
   const handleViewRun = (run: ScheduledJobRun) => {
-    track(SCHEDULED_TASK_VIEW_RESULTS_EVENT)
     setViewingRun(run)
+    track(SCHEDULED_TASK_VIEW_RESULTS_EVENT)
   }
 
   const jobToDelete = deleteJobId

--- a/apps/agent/entrypoints/options/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/apps/agent/entrypoints/options/scheduled-tasks/ScheduledTasksPage.tsx
@@ -10,6 +10,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import {
+  NEW_SCHEDULED_TASK_CREATED_EVENT,
+  SCHEDULED_TASK_DELETED_EVENT,
+  SCHEDULED_TASK_EDITED_EVENT,
+  SCHEDULED_TASK_TESTED_EVENT,
+  SCHEDULED_TASK_TOGGLED_EVENT,
+  SCHEDULED_TASK_VIEW_RESULTS_EVENT,
+} from '@/lib/constants/analyticsEvents'
+import { track } from '@/lib/metrics/track'
 import { useScheduledJobs } from '@/lib/schedules/scheduleStorage'
 import type { ScheduledJobRun } from '@/lib/schedules/scheduleTypes'
 import { NewScheduledTaskDialog } from './NewScheduledTaskDialog'
@@ -46,6 +55,7 @@ export const ScheduledTasksPage: FC = () => {
 
   const confirmDelete = async () => {
     if (deleteJobId) {
+      track(SCHEDULED_TASK_DELETED_EVENT)
       await removeJob(deleteJobId)
       setDeleteJobId(null)
     }
@@ -54,20 +64,33 @@ export const ScheduledTasksPage: FC = () => {
   const handleSave = async (data: Omit<ScheduledJob, 'id' | 'createdAt'>) => {
     if (editingJob) {
       await editJob(editingJob.id, data)
+      track(SCHEDULED_TASK_EDITED_EVENT, {
+        scheduleType: data.scheduleType,
+        interval: data.scheduleInterval,
+        time: data.scheduleTime,
+      })
     } else {
+      track(NEW_SCHEDULED_TASK_CREATED_EVENT, {
+        scheduleType: data.scheduleType,
+        interval: data.scheduleInterval,
+        time: data.scheduleTime,
+      })
       await addJob(data)
     }
   }
 
   const handleToggle = async (jobId: string, enabled: boolean) => {
+    track(SCHEDULED_TASK_TOGGLED_EVENT)
     await toggleJob(jobId, enabled)
   }
 
   const handleRun = async (jobId: string) => {
+    track(SCHEDULED_TASK_TESTED_EVENT)
     await runJob(jobId)
   }
 
   const handleViewRun = (run: ScheduledJobRun) => {
+    track(SCHEDULED_TASK_VIEW_RESULTS_EVENT)
     setViewingRun(run)
   }
 

--- a/apps/agent/lib/constants/analyticsEvents.ts
+++ b/apps/agent/lib/constants/analyticsEvents.ts
@@ -29,3 +29,31 @@ export const MCP_EXTERNAL_ACCESS_DISABLED_EVENT =
 
 /** @public */
 export const MCP_SERVER_RESTARTED_EVENT = 'settings.mcp_server.restarted'
+
+/** @public */
+export const NEW_SCHEDULED_TASK_CREATED_EVENT =
+  'settings.scheduled_task.created'
+
+/** @public */
+export const SCHEDULED_TASK_EDITED_EVENT = 'settings.scheduled_task.edited'
+
+/** @public */
+export const SCHEDULED_TASK_DELETED_EVENT = 'settings.scheduled_task.deleted'
+
+/** @public */
+export const SCHEDULED_TASK_TOGGLED_EVENT = 'settings.scheduled_task.toggled'
+
+/** @public */
+export const SCHEDULED_TASK_TESTED_EVENT = 'settings.scheduled_task.tested'
+
+/** @public */
+export const SCHEDULED_TASK_VIEW_RESULTS_EVENT =
+  'settings.scheduled_task.viewed_results'
+
+/** @public */
+export const SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT =
+  'newtab.scheduled_task.viewed_results'
+
+/** @public */
+export const SCHEDULED_TASK_VIEW_MORE_IN_NEWTAB_EVENT =
+  'newtab.scheduled_task.view_more'


### PR DESCRIPTION
This pull request adds analytics tracking for scheduled task actions throughout the scheduled tasks UI. The main focus is on instrumenting key user interactions—such as creating, editing, deleting, toggling, testing, and viewing scheduled tasks—with specific analytics events, both in the main options page and in the new tab interface.

Analytics instrumentation for scheduled tasks:

* Introduced new analytics event constants for all major scheduled task actions in `analyticsEvents.ts`, including creation, editing, deletion, toggling, testing, and viewing results, as well as distinct events for actions in the new tab view.
* Added calls to the `track` function in `ScheduledTasksPage.tsx` to log when a scheduled task is created, edited, deleted, toggled, tested, or when results are viewed. Event payloads include relevant schedule details where appropriate. [[1]](diffhunk://#diff-08589e21121c463d607ba22cfb673508eeced7f3f5e950b6ea4b32e3955c8c10R58) [[2]](diffhunk://#diff-08589e21121c463d607ba22cfb673508eeced7f3f5e950b6ea4b32e3955c8c10R67-R93)

Analytics instrumentation for scheduled tasks in new tab view:

* Added analytics tracking for viewing scheduled task run results and for clicking "View more" in the new tab's scheduled tasks interface, using the new event constants. [[1]](diffhunk://#diff-8594ec5fc4243e3acd7e537a71327991532e82f04dfa6f13ef00b125c9f4139eR21-R25) [[2]](diffhunk://#diff-8594ec5fc4243e3acd7e537a71327991532e82f04dfa6f13ef00b125c9f4139eR91-R95) [[3]](diffhunk://#diff-8594ec5fc4243e3acd7e537a71327991532e82f04dfa6f13ef00b125c9f4139eL119-R129) [[4]](diffhunk://#diff-8594ec5fc4243e3acd7e537a71327991532e82f04dfa6f13ef00b125c9f4139eR153-R161)

These changes will help monitor user engagement and behavior around scheduled tasks, enabling better insights and future improvements.