### PR TITLE
fix: prevent layout shifts on clicking collapsible

### DIFF
--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -200,7 +200,7 @@ export const NewTab = () => {
   return (
     <div className="pt-[max(25vh,16px)]">
       {/* Main content */}
-      <div className={'relative w-full max-w-3xl space-y-8'}>
+      <div className={'relative w-full space-y-8 md:w-3xl'}>
         {/* Logo and branding */}
         <NewTabBranding />
         {/* Search bar with context */}

--- a/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
+++ b/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
@@ -97,7 +97,7 @@ export const ScheduleResults: FC = () => {
     <Collapsible
       open={isOpen}
       onOpenChange={setIsOpen}
-      className="mb-16 space-y-3"
+      className="mb-16 w-xl space-y-3 md:w-3xl"
     >
       <CollapsibleTrigger asChild>
         <Button


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `NewTab` component, updating the container's width utility classes for improved layout consistency.

- Changed the main content container in `NewTab.tsx` to use `md:w-3xl` instead of `max-w-3xl`, ensuring the width is set at medium screen sizes and above rather than being capped at a maximum width.