### PR TITLE
feat: provide a system prompt for tasks running in a schedule

### DIFF
--- a/apps/agent/lib/schedules/getChatServerResponse.ts
+++ b/apps/agent/lib/schedules/getChatServerResponse.ts
@@ -7,6 +7,7 @@ import {
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { mcpServerStorage } from '@/lib/mcp/mcpServerStorage'
 import { personalizationStorage } from '../personalization/personalizationStorage'
+import { scheduleSystemPrompt } from './scheduleSystemPrompt'
 
 interface ActiveTab {
   id?: number
@@ -96,7 +97,7 @@ export async function getChatServerResponse(
                 customMcpServers.length > 0 ? customMcpServers : undefined,
             }
           : undefined,
-      userSystemPrompt: personalization,
+      userSystemPrompt: `${personalization}\n${scheduleSystemPrompt}`,
     }),
   })
 

--- a/apps/agent/lib/schedules/scheduleSystemPrompt.ts
+++ b/apps/agent/lib/schedules/scheduleSystemPrompt.ts
@@ -1,0 +1,1 @@
+export const scheduleSystemPrompt = `Your running a task that was scheduled for now. There is an external system which manages the schedule, you don't have to worry about it. Just run the task and give the result`

--- a/apps/agent/lib/schedules/scheduleSystemPrompt.ts
+++ b/apps/agent/lib/schedules/scheduleSystemPrompt.ts
@@ -1,1 +1,1 @@
-export const scheduleSystemPrompt = `Your running a task that was scheduled for now. There is an external system which manages the schedule, you don't have to worry about it. Just run the task and give the result`
+export const scheduleSystemPrompt = `You're running a task that was scheduled for now. There is an external system which manages the schedule, you don't have to worry about it. Just run the task and give the result`

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.32",
+      "version": "0.0.36",
       "bin": {
         "browseros-server": "./src/index.ts",
       },


### PR DESCRIPTION
This pull request updates the chat server response logic to include a new system prompt when running scheduled tasks. The main focus is to ensure that the AI receives clear instructions about scheduled tasks by appending a standardized system prompt.

Enhancement to scheduled task prompts:

* Added a new constant `scheduleSystemPrompt` in `scheduleSystemPrompt.ts` to provide a standardized message for scheduled tasks.
* Updated `getChatServerResponse.ts` to import `scheduleSystemPrompt` and append it to the `userSystemPrompt` sent to the chat server, ensuring the AI is aware when a task is scheduled. [[1]](diffhunk://#diff-90a8fec207d81d901783bf53700d64d94005d3280fec58bb8bd9e18f33dcbce7R10) [[2]](diffhunk://#diff-90a8fec207d81d901783bf53700d64d94005d3280fec58bb8bd9e18f33dcbce7L99-R100)