### PR TITLE
Update settings sidebar MCP labels and order

### DIFF
--- a/apps/agent/entrypoints/options/layout/DashboardLayout.tsx
+++ b/apps/agent/entrypoints/options/layout/DashboardLayout.tsx
@@ -42,17 +42,17 @@ const navigationItems: NavItem[] = [
     enabled: true,
   },
   {
-    name: 'Search Engines',
-    to: '/search',
-    icon: Search,
-    enabled: false,
-  },
-  {
-    name: 'Connect with MCP',
+    name: 'Connect to MCPs',
     to: '/connect-mcp',
     icon: PlugZap,
     enabled: true,
     feature: Feature.MANAGED_MCP_SUPPORT,
+  },
+  {
+    name: 'BrowserOS as MCP',
+    to: '/mcp',
+    icon: Server,
+    enabled: true,
   },
   {
     name: 'Scheduled Tasks',
@@ -61,10 +61,17 @@ const navigationItems: NavItem[] = [
     enabled: true,
   },
   {
-    name: 'BrowserOS MCP',
-    to: '/mcp',
-    icon: Server,
+    name: 'Revisit Onboarding',
+    to: chrome.runtime.getURL('onboarding.html'),
+    icon: RotateCcw,
+    target: '_blank',
     enabled: true,
+  },
+  {
+    name: 'Search Engines',
+    to: '/search',
+    icon: Search,
+    enabled: false,
   },
   {
     name: 'Customization',
@@ -72,13 +79,6 @@ const navigationItems: NavItem[] = [
     icon: Palette,
     enabled: true,
     feature: Feature.CUSTOMIZATION_SUPPORT,
-  },
-  {
-    name: 'Revisit Onboarding',
-    to: chrome.runtime.getURL('onboarding.html'),
-    icon: RotateCcw,
-    target: '_blank',
-    enabled: true,
   },
 ]
 

--- a/apps/agent/entrypoints/options/layout/DashboardLayout.tsx
+++ b/apps/agent/entrypoints/options/layout/DashboardLayout.tsx
@@ -61,6 +61,14 @@ const navigationItems: NavItem[] = [
     enabled: true,
   },
   {
+    name: 'Customization',
+    to: '/customization',
+    icon: Palette,
+    enabled: true,
+    feature: Feature.CUSTOMIZATION_SUPPORT,
+  },
+
+  {
     name: 'Revisit Onboarding',
     to: chrome.runtime.getURL('onboarding.html'),
     icon: RotateCcw,
@@ -72,13 +80,6 @@ const navigationItems: NavItem[] = [
     to: '/search',
     icon: Search,
     enabled: false,
-  },
-  {
-    name: 'Customization',
-    to: '/customization',
-    icon: Palette,
-    enabled: true,
-    feature: Feature.CUSTOMIZATION_SUPPORT,
   },
 ]
 


### PR DESCRIPTION
### Motivation
- Update sidebar copy and ordering for MCP-related entries to match the new product copy and requested sequence.  
- Make the settings navigation more discoverable by placing core MCP items earlier in the list.  
- Keep remaining navigation items available after the core settings list to preserve existing functionality.  

### Description
- Rename `Connect with MCP` to `Connect to MCPs` and `BrowserOS MCP` to `BrowserOS as MCP` in the settings navigation.  
- Reorder entries in the `navigationItems` array in `apps/agent/entrypoints/options/layout/DashboardLayout.tsx` to the requested sequence.  
- Move `Search Engines`, `Customization`, and `Revisit Onboarding` to follow the core settings entries.  
- Only `DashboardLayout.tsx` was modified; no other files were changed.  

### Testing
- Changes were committed locally after updating `apps/agent/entrypoints/options/layout/DashboardLayout.tsx`.  
- A Playwright screenshot attempt was run but failed with `ERR_EMPTY_RESPONSE` because `http://localhost:3000` was not serving (no dev server running).  
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0641d1fc832a8e6266c0813eb62b)