### PR TITLE
feat: add retry button to view page on failure

### DIFF
--- a/apps/agent/components/ai-elements/run-result-dialog.tsx
+++ b/apps/agent/components/ai-elements/run-result-dialog.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   Copy,
   Loader2,
+  Play,
   XCircle,
 } from 'lucide-react'
 import { type FC, useState } from 'react'
@@ -27,6 +28,7 @@ interface RunResultDialogProps {
   run: ScheduledJobRun | null
   jobName?: string
   onOpenChange: (open: boolean) => void
+  onRetry?: () => void
 }
 
 const formatDateTime = (dateStr: string) =>
@@ -46,6 +48,7 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
   run,
   jobName,
   onOpenChange,
+  onRetry,
 }) => {
   const [copied, setCopied] = useState(false)
 
@@ -54,6 +57,11 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
     await navigator.clipboard.writeText(run.result)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleRetry = () => {
+    onRetry?.()
+    onOpenChange(false)
   }
 
   if (!run) return null
@@ -116,6 +124,12 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
                   Copy
                 </>
               )}
+            </Button>
+          )}
+          {run.status === 'failed' && onRetry && (
+            <Button variant="outline" onClick={handleRetry}>
+              <Play className="h-4 w-4" />
+              Retry
             </Button>
           )}
           <Button onClick={() => onOpenChange(false)}>Close</Button>

--- a/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
+++ b/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
@@ -19,6 +19,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import {
+  SCHEDULED_TASK_TESTED_EVENT,
   SCHEDULED_TASK_VIEW_MORE_IN_NEWTAB_EVENT,
   SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT,
 } from '@/lib/constants/analyticsEvents'
@@ -58,7 +59,7 @@ export const ScheduleResults: FC = () => {
   const [viewingRun, setViewingRun] = useState<JobRunWithDetails | null>(null)
 
   const { jobRuns } = useScheduledJobRuns()
-  const { jobs } = useScheduledJobs()
+  const { jobs, runJob } = useScheduledJobs()
 
   const runningCount = jobRuns.filter((r) => r.status === 'running').length
 
@@ -91,6 +92,11 @@ export const ScheduleResults: FC = () => {
   const viewRun = (run: JobRunWithDetails) => {
     track(SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT)
     setViewingRun(run)
+  }
+
+  const handleRetry = async (jobId: string) => {
+    await runJob(jobId)
+    track(SCHEDULED_TASK_TESTED_EVENT)
   }
 
   return (
@@ -165,6 +171,7 @@ export const ScheduleResults: FC = () => {
         run={viewingRun}
         jobName={viewingRun?.job?.name}
         onOpenChange={(open) => !open && setViewingRun(null)}
+        onRetry={viewingRun ? () => handleRetry(viewingRun.jobId) : undefined}
       />
     </Collapsible>
   )

--- a/apps/agent/entrypoints/options/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/apps/agent/entrypoints/options/scheduled-tasks/ScheduledTasksPage.tsx
@@ -126,6 +126,7 @@ export const ScheduledTasksPage: FC = () => {
             : undefined
         }
         onOpenChange={(open) => !open && setViewingRun(null)}
+        onRetry={viewingRun ? () => handleRun(viewingRun.jobId) : undefined}
       />
 
       <AlertDialog


### PR DESCRIPTION
Add a retry button to the RunResultDialog when a scheduled task fails. The button uses the same logic as the Test button to re-run the task.