### PR TITLE
fix: prevent graph node from resetting on agent replies

### DIFF
--- a/apps/agent/entrypoints/options/create-graph/CreateGraph.tsx
+++ b/apps/agent/entrypoints/options/create-graph/CreateGraph.tsx
@@ -226,7 +226,11 @@ export const CreateGraph: FC = () => {
     }),
   })
 
-  const lastAssistantMessage = messages.findLast((m) => m.role === 'assistant')
+  const lastAssistantMessageWithGraph = messages.findLast((m) => {
+    if (m.role !== 'assistant') return false
+    const metadata = m.metadata as GraphMessageMetadata | undefined
+    return metadata?.graph !== undefined
+  })
 
   const onClickTest = async () => {
     const backgroundWindow = await chrome.windows.create({
@@ -280,14 +284,14 @@ export const CreateGraph: FC = () => {
   }
 
   useDeepCompareEffect(() => {
-    if (status === 'ready' && lastAssistantMessage) {
-      const metadata = lastAssistantMessage.metadata as
+    if (status === 'ready' && lastAssistantMessageWithGraph) {
+      const metadata = lastAssistantMessageWithGraph.metadata as
         | GraphMessageMetadata
         | undefined
       setCodeId(metadata?.codeId)
       setGraphData(metadata?.graph)
     }
-  }, [status, lastAssistantMessage ?? {}])
+  }, [status, lastAssistantMessageWithGraph ?? {}])
 
   if (!isInitialized) {
     return (


### PR DESCRIPTION
This pull request refines how the `CreateGraph` component determines which assistant message to use when updating graph data. The main improvement is ensuring that only assistant messages containing actual graph metadata are considered, which prevents issues when unrelated assistant messages are present.

**Improvements to graph message selection:**

* The component now finds the most recent assistant message that includes graph metadata, instead of any assistant message, by updating the logic in `lastAssistantMessageWithGraph`.
* The effect that updates the graph data now depends on and uses `lastAssistantMessageWithGraph`, ensuring that only relevant messages trigger updates to `codeId` and `graphData`.