### PR TITLE
fix: prevent input field flowing out of view

### DIFF
--- a/apps/agent/entrypoints/options/create-graph/GraphChat.tsx
+++ b/apps/agent/entrypoints/options/create-graph/GraphChat.tsx
@@ -109,8 +109,8 @@ export const GraphChat: FC<GraphChatProps> = ({
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex h-full w-full flex-1 flex-col pb-2">
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="min-h-0 flex-1 overflow-y-auto pb-2">
         <ChatMessages
           liked={liked}
           disliked={disliked}
@@ -126,7 +126,7 @@ export const GraphChat: FC<GraphChatProps> = ({
       </div>
       {agentUrlError && <ChatError error={agentUrlError} />}
       {chatError && <ChatError error={chatError} />}
-      <div className="border-border/40 border-t bg-background/80 p-2 backdrop-blur-md">
+      <div className="shrink-0 border-border/40 border-t bg-background/80 p-2 backdrop-blur-md">
         <form
           onSubmit={onSubmit}
           className="relative flex w-full items-end gap-2"

--- a/apps/agent/entrypoints/options/create-graph/GraphChat.tsx
+++ b/apps/agent/entrypoints/options/create-graph/GraphChat.tsx
@@ -110,7 +110,7 @@ export const GraphChat: FC<GraphChatProps> = ({
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="min-h-0 flex-1 overflow-y-auto pb-2">
+      <div className="styled-scrollbar min-h-0 flex-1 overflow-y-auto pb-2">
         <ChatMessages
           liked={liked}
           disliked={disliked}


### PR DESCRIPTION
This pull request makes improvements to the layout and scrolling behavior of the `GraphChat` component in `GraphChat.tsx`. The changes ensure that the chat area scrolls properly and the input area remains fixed at the bottom, resulting in a better user experience.

Layout and scrolling improvements:

* Added `overflow-hidden` to the outer container and changed the inner chat area to use `min-h-0 flex-1 overflow-y-auto` so that chat messages are scrollable and the layout is more robust.
* Added `shrink-0` to the input area container to ensure it stays fixed at the bottom and does not shrink when the chat area grows.