### PR TITLE
feat: add chat header to workflows chat -- that is a better UX

### DIFF
--- a/apps/agent/components/chat/ChatProviderSelector.tsx
+++ b/apps/agent/components/chat/ChatProviderSelector.tsx
@@ -17,7 +17,7 @@ import {
 import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderType } from '@/lib/llm-providers/types'
 import { cn } from '@/lib/utils'
-import type { Provider } from './chatTypes'
+import type { Provider } from './types'
 
 interface ChatProviderSelectorProps {
   providers: Provider[]

--- a/apps/agent/components/chat/ChatProviderSelector.tsx
+++ b/apps/agent/components/chat/ChatProviderSelector.tsx
@@ -17,7 +17,7 @@ import {
 import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderType } from '@/lib/llm-providers/types'
 import { cn } from '@/lib/utils'
-import type { Provider } from './types'
+import type { Provider } from './chatComponentTypes'
 
 interface ChatProviderSelectorProps {
   providers: Provider[]

--- a/apps/agent/components/chat/chatComponentTypes.ts
+++ b/apps/agent/components/chat/chatComponentTypes.ts
@@ -1,0 +1,7 @@
+import type { ProviderType } from '@/lib/llm-providers/types'
+
+export interface Provider {
+  id: string
+  name: string
+  type: ProviderType
+}

--- a/apps/agent/entrypoints/options/create-graph/WorkflowsChatHeader.tsx
+++ b/apps/agent/entrypoints/options/create-graph/WorkflowsChatHeader.tsx
@@ -7,25 +7,24 @@ import { productRepositoryUrl } from '@/lib/constants/productUrls'
 import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderType } from '@/lib/llm-providers/types'
 
-interface ChatHeaderProps {
+interface WorkflowsChatHeaderProps {
   selectedProvider: Provider
   providers: Provider[]
   onSelectProvider: (provider: Provider) => void
-  onNewConversation: () => void
+  onNewWorkflow: () => void
   hasMessages: boolean
 }
 
-export const ChatHeader: FC<ChatHeaderProps> = ({
+export const WorkflowsChatHeader: FC<WorkflowsChatHeaderProps> = ({
   selectedProvider,
   providers,
   onSelectProvider,
-  onNewConversation,
+  onNewWorkflow,
   hasMessages,
 }) => {
   return (
-    <header className="flex items-center justify-between border-border/40 border-b bg-background/80 px-3 py-2.5 backdrop-blur-md">
+    <header className="flex shrink-0 items-center justify-between border-border/40 border-b bg-background/80 px-3 py-2.5 backdrop-blur-md">
       <div className="flex items-center gap-2">
-        {/* Provider Selector */}
         <ChatProviderSelector
           providers={providers}
           selectedProvider={selectedProvider}
@@ -55,9 +54,9 @@ export const ChatHeader: FC<ChatHeaderProps> = ({
         {hasMessages && (
           <button
             type="button"
-            onClick={onNewConversation}
+            onClick={onNewWorkflow}
             className="cursor-pointer rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-            title="New conversation"
+            title="New workflow"
           >
             <Plus className="h-4 w-4" />
           </button>

--- a/apps/agent/entrypoints/sidepanel/index/chatTypes.ts
+++ b/apps/agent/entrypoints/sidepanel/index/chatTypes.ts
@@ -1,12 +1,4 @@
-import type { ProviderType } from '@/lib/llm-providers/types'
-
 export type ChatMode = 'chat' | 'agent'
-
-export interface Provider {
-  id: string
-  name: string
-  type: ProviderType
-}
 
 export interface Suggestion {
   display: string

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -3,6 +3,7 @@ import { DefaultChatTransport, type UIMessage } from 'ai'
 import { compact } from 'es-toolkit/array'
 import { useEffect, useRef, useState } from 'react'
 import useDeepCompareEffect from 'use-deep-compare-effect'
+import type { Provider } from '@/components/chat/chatComponentTypes'
 import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
 import type { ChatAction } from '@/lib/chat-actions/types'
 import {
@@ -15,7 +16,7 @@ import {
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { track } from '@/lib/metrics/track'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
-import type { ChatMode, Provider } from './chatTypes'
+import type { ChatMode } from './chatTypes'
 import { useChatRefs } from './useChatRefs'
 import { useNotifyActiveTab } from './useNotifyActiveTab'
 


### PR DESCRIPTION
- moved chatprovider selector to a shared component

- reimplement chat header as it was simple and we can have graph mode specific options there instead of reusing chat header from sidepanel
