### PR TITLE
fix: added missing focus grid to the newtab page

### DIFF
--- a/apps/agent/entrypoints/app/App.tsx
+++ b/apps/agent/entrypoints/app/App.tsx
@@ -2,12 +2,11 @@ import { type FC, Suspense } from 'react'
 import { HashRouter, Navigate, Route, Routes, useParams } from 'react-router'
 
 import { NewTab } from '../newtab/index/NewTab'
+import { NewTabLayout } from '../newtab/layout/NewTabLayout'
 import { Personalize } from '../newtab/personalize/Personalize'
-
 import { FeaturesPage } from '../onboarding/features/Features'
 import { Onboarding } from '../onboarding/index/Onboarding'
 import { StepsLayout } from '../onboarding/steps/StepsLayout'
-
 import { AISettingsPage } from './ai-settings/AISettingsPage'
 import { ConnectMCP } from './connect-mcp/ConnectMCP'
 import { CreateGraphWrapper } from './create-graph/CreateGraphWrapper'
@@ -58,7 +57,7 @@ export const App: FC = () => {
           {/* Main app with sidebar */}
           <Route element={<SidebarLayout />}>
             {/* Home routes */}
-            <Route path="home">
+            <Route path="home" element={<NewTabLayout />}>
               <Route index element={<NewTab />} />
               <Route path="personalize" element={<Personalize />} />
             </Route>

--- a/apps/agent/entrypoints/newtab/layout/NewTabFocusGrid.tsx
+++ b/apps/agent/entrypoints/newtab/layout/NewTabFocusGrid.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react'
+
+export const NewTabFocusGrid: FC = () => {
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      <div className="absolute inset-0 bg-grid-pattern"></div>
+      <div className="absolute inset-0 bg-gradient-radial-focus"></div>
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
+++ b/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
@@ -1,0 +1,12 @@
+import type { FC } from 'react'
+import { Outlet } from 'react-router'
+import { NewTabFocusGrid } from './NewTabFocusGrid'
+
+export const NewTabLayout: FC = () => {
+  return (
+    <>
+      <NewTabFocusGrid />
+      <Outlet />
+    </>
+  )
+}


### PR DESCRIPTION
This pull request introduces a new layout for the "home" section of the app, improving the structure and visual presentation of the New Tab experience. The main changes include the addition of a dedicated layout component and a visual grid background, as well as updates to routing to use the new layout.

**NewTab Layout and Visual Enhancements:**

* Added a new `NewTabLayout` component that wraps New Tab-related routes and includes a visual grid background for improved aesthetics. (`apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx`)
* Created the `NewTabFocusGrid` component to render the grid and radial focus background used in the new layout. (`apps/agent/entrypoints/newtab/layout/NewTabFocusGrid.tsx`)

**Routing Updates:**

* Updated routing so the "home" route now uses the `NewTabLayout`, ensuring all child routes (like `NewTab` and `Personalize`) share the new layout and visual enhancements. (`apps/agent/entrypoints/app/App.tsx`) [[1]](diffhunk://#diff-85363bfd24cbc86920856af074f924a9798826f37818737d19472b8de15c3521L61-R60) [[2]](diffhunk://#diff-85363bfd24cbc86920856af074f924a9798826f37818737d19472b8de15c3521R5-L10)