### PR TITLE
fix: make combobox input value uncontrolled

### DIFF
--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -83,16 +83,20 @@ export const NewTab = () => {
     reset,
   } = useCombobox<SuggestionItem>({
     items: flatItems,
-    inputValue,
     itemToString: (item) => (item ? getSuggestionLabel(item) : ''),
     onSelectedItemChange({ selectedItem }) {
       if (selectedItem) {
         runSelectedAction(selectedItem)
       }
     },
-    onStateChange: ({ type, inputValue, highlightedIndex, selectedItem }) => {
+    onStateChange: ({
+      type,
+      inputValue: stateInputValue,
+      highlightedIndex,
+      selectedItem,
+    }) => {
       if (type === useCombobox.stateChangeTypes.InputKeyDownEnter) {
-        if (!selectedItem && !highlightedIndex && !inputValue) {
+        if (!selectedItem && !highlightedIndex && !stateInputValue) {
           executeDefaultAction()
         }
       }


### PR DESCRIPTION
Fix issue with newtab input field not preserving cursor position when editing text