### PR TITLE
Disable deleting conversations on reset

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -353,11 +353,11 @@ export const useChatSession = () => {
     setLiked({})
     setDisliked({})
 
-    if (agentServerUrl && oldConversationId) {
-      fetch(`${agentServerUrl}/chat/${oldConversationId}`, {
-        method: 'DELETE',
-      }).catch(() => {})
-    }
+    // if (agentServerUrl && oldConversationId) {
+    //   fetch(`${agentServerUrl}/chat/${oldConversationId}`, {
+    //     method: 'DELETE',
+    //   }).catch(() => {})
+    // }
   }
 
   return {


### PR DESCRIPTION
### Motivation
- Prevent the client from issuing a server-side delete when starting a new conversation so the new/plus action does not remove conversation history by mistake; stop `resetConversation` from sending the DELETE request.

### Description
- Commented out the `fetch` DELETE call in `resetConversation` in `apps/agent/entrypoints/sidepanel/index/useChatSession.ts` so resetting a conversation no longer calls `${agentServerUrl}/chat/${oldConversationId}`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb90e7564832ab70363a19c951835)