### PR TITLE
feat: delay the loading text in create graph

### DIFF
--- a/apps/agent/biome.json
+++ b/apps/agent/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "root": false,
   "extends": "//",
   "vcs": {

--- a/apps/agent/entrypoints/app/create-graph/CreateGraph.tsx
+++ b/apps/agent/entrypoints/app/create-graph/CreateGraph.tsx
@@ -384,7 +384,13 @@ export const CreateGraph: FC = () => {
   }, [status, lastAssistantMessageWithGraph ?? {}])
 
   if (!isInitialized || isLoadingProviders || !selectedProviderForHeader) {
-    return <div className="h-screen w-screen bg-background" />
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-background text-foreground">
+        <div className="fade-in animate-in text-muted-foreground duration-200 [animation-delay:300ms] [animation-fill-mode:backwards]">
+          Loading...
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
This pull request makes a small UI improvement to the loading state in the `CreateGraph` component. Instead of displaying a blank screen while loading, it now shows a centered "Loading..." message with a fade-in animation for better user feedback.

* Improved loading state UI by displaying a centered "Loading..." message with animation in `CreateGraph.tsx`.