### PR TITLE
feat: update product help urls

### DIFF
--- a/apps/agent/lib/constants/productUrls.ts
+++ b/apps/agent/lib/constants/productUrls.ts
@@ -52,9 +52,10 @@ export const productRepositoryShortUrl = 'https://git.new/browseros'
 /**
  * @public
  */
-export const workflowsHelpUrl = 'https://docs.browseros.com'
+export const workflowsHelpUrl = 'https://docs.browseros.com/features/workflows'
 
 /**
  * @public
  */
-export const scheduledTasksHelpUrl = 'https://docs.browseros.com'
+export const scheduledTasksHelpUrl =
+  'https://docs.browseros.com/features/scheduled-tasks'


### PR DESCRIPTION
This pull request updates the URLs in the `apps/agent/lib/constants/productUrls.ts` file to point directly to more specific documentation pages for workflows and scheduled tasks.

Documentation URL updates:

* Changed `workflowsHelpUrl` to link to the workflows feature documentation instead of the general docs page.
* Changed `scheduledTasksHelpUrl` to link to the scheduled tasks feature documentation instead of the general docs page.