### PR TITLE
fix: sidebar toggle behavior and layout

### DIFF
--- a/apps/agent/components/sidebar/AppSidebar.tsx
+++ b/apps/agent/components/sidebar/AppSidebar.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react'
+import { useCallback } from 'react'
 import { cn } from '@/lib/utils'
 import { SidebarBranding } from './SidebarBranding'
 import { SidebarNavigation } from './SidebarNavigation'
@@ -6,26 +7,43 @@ import { SidebarUserFooter } from './SidebarUserFooter'
 
 interface AppSidebarProps {
   expanded?: boolean
+  onToggle?: () => void
   onOpenShortcuts?: () => void
 }
 
 export const AppSidebar: FC<AppSidebarProps> = ({
   expanded = false,
+  onToggle,
   onOpenShortcuts,
 }) => {
+  const handleSidebarClick = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      const target = event.target as HTMLElement
+      if (target.closest('[data-sidebar-interactive]')) {
+        return
+      }
+      onToggle?.()
+    },
+    [onToggle],
+  )
+
   return (
-    <div
-      className={cn(
-        'flex h-full flex-col border-r bg-sidebar text-sidebar-foreground transition-all duration-200 ease-in-out',
-        expanded ? 'w-64' : 'w-14',
-      )}
-    >
-      <SidebarBranding expanded={expanded} />
-      <SidebarNavigation expanded={expanded} />
-      <SidebarUserFooter
-        expanded={expanded}
-        onOpenShortcuts={onOpenShortcuts}
-      />
-    </div>
+    <>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: sidebar toggles via empty-space click */}
+      <aside
+        onClick={handleSidebarClick}
+        className={cn(
+          'relative z-20 flex min-h-screen shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground transition-all duration-200 ease-in-out',
+          expanded ? 'w-64' : 'w-14',
+        )}
+      >
+        <SidebarBranding expanded={expanded} onToggle={onToggle} />
+        <SidebarNavigation expanded={expanded} />
+        <SidebarUserFooter
+          expanded={expanded}
+          onOpenShortcuts={onOpenShortcuts}
+        />
+      </aside>
+    </>
   )
 }

--- a/apps/agent/components/sidebar/SidebarBranding.tsx
+++ b/apps/agent/components/sidebar/SidebarBranding.tsx
@@ -6,18 +6,29 @@ import { useWorkspace } from '@/lib/workspace/use-workspace'
 
 interface SidebarBrandingProps {
   expanded?: boolean
+  onToggle?: () => void
 }
 
 export const SidebarBranding: FC<SidebarBrandingProps> = ({
   expanded = true,
+  onToggle,
 }) => {
   const { selectedFolder } = useWorkspace()
 
   return (
     <div className="flex h-14 items-center border-b">
-      <div className="flex w-14 shrink-0 items-center justify-center">
-        <img src={ProductLogo} alt="BrowserOS" className="size-8" />
-      </div>
+      <button
+        type="button"
+        onClick={(event) => {
+          event.stopPropagation()
+          onToggle?.()
+        }}
+        className="flex w-14 shrink-0 items-center justify-center transition-opacity hover:opacity-70 active:opacity-50"
+        aria-label={expanded ? 'Collapse sidebar' : 'Expand sidebar'}
+        data-sidebar-toggle
+      >
+        <img src={ProductLogo} alt="BrowserOS" className="size-9" />
+      </button>
       <div
         className={cn(
           'flex min-w-0 flex-1 items-center justify-between pr-3 transition-opacity duration-200',
@@ -30,7 +41,9 @@ export const SidebarBranding: FC<SidebarBrandingProps> = ({
           </span>
           <span className="text-muted-foreground text-xs">Personal</span>
         </div>
-        <ThemeToggle className="h-8 w-8 shrink-0" iconClassName="h-4 w-4" />
+        <div data-sidebar-interactive>
+          <ThemeToggle className="h-8 w-8 shrink-0" iconClassName="h-4 w-4" />
+        </div>
       </div>
     </div>
   )

--- a/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -64,13 +64,14 @@ export const SidebarNavigation: FC<SidebarNavigationProps> = ({
             const navItem = (
               <NavLink
                 to={item.to}
+                data-sidebar-interactive
                 className={cn(
                   'flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
                   isActive &&
                     'bg-sidebar-accent text-sidebar-accent-foreground',
                 )}
               >
-                <Icon className="size-4 shrink-0" />
+                <Icon className="size-5 shrink-0" />
                 <span
                   className={cn(
                     'truncate transition-opacity duration-200',

--- a/apps/agent/components/sidebar/SidebarUserFooter.tsx
+++ b/apps/agent/components/sidebar/SidebarUserFooter.tsx
@@ -41,9 +41,10 @@ export const SidebarUserFooter: FC<SidebarUserFooterProps> = ({
       href="https://docs.browseros.com/"
       target="_blank"
       rel="noopener noreferrer"
+      data-sidebar-interactive
       className="flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
     >
-      <Info className="size-4 shrink-0" />
+      <Info className="size-5 shrink-0" />
       <span
         className={cn(
           'truncate transition-opacity duration-200',
@@ -59,9 +60,10 @@ export const SidebarUserFooter: FC<SidebarUserFooterProps> = ({
     <Button
       variant="ghost"
       onClick={onOpenShortcuts}
+      data-sidebar-interactive
       className="flex h-9 w-full items-center justify-start gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
     >
-      <Keyboard className="size-4 shrink-0" />
+      <Keyboard className="size-5 shrink-0" />
       <span
         className={cn(
           'truncate transition-opacity duration-200',


### PR DESCRIPTION
## Summary
- Sidebar toggles only via BrowserOS icon or empty space
- Sidebar pushes content instead of **overlaying** while maintaining the same animation
- Expanded/collapsed state persists across reload
- Slightly larger sidebar icons

## Testing
Manual: verified sidebar toggle, visibility, and layout shift

## Screenshots
#### Before:
![before](https://github.com/user-attachments/assets/e84b01db-0e4d-4504-b382-064814ea0806)
<br>
#### After:
![after](https://github.com/user-attachments/assets/f309a48e-06c6-49a1-a853-eebf29038233)
