### PR TITLE
fix: resolve window ownership race condition with async polling

### DIFF
--- a/apps/agent/entrypoints/background/scheduledJobRuns.ts
+++ b/apps/agent/entrypoints/background/scheduledJobRuns.ts
@@ -113,11 +113,8 @@ export const scheduledJobRuns = async () => {
       type: 'normal',
     })
 
-    // FIXME: Race condition - the controller-ext extension sends a window_created
-    // WebSocket message to register window ownership, but our HTTP request may arrive
-    // at the server before that registration completes. This delay is a temporary fix.
-    // Proper solution: ControllerBridge should wait/poll for window ownership registration.
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    // Note: Window ownership race condition is now handled by ControllerBridge.sendRequest()
+    // which polls for up to 500ms waiting for window registration before falling back.
 
     const backgroundTab = backgroundWindow?.tabs?.[0]
 


### PR DESCRIPTION
Fixes #277

Resolves a critical race condition where HTTP requests arrive before window_created WebSocket message is processed.

## Changes

1. Added waitForWindowOwnership() method - polls for up to 500ms for window registration
2. Updated sendRequest() to wait for window registration before routing  
3. Removed hacky 1-second delay from scheduledJobRuns.ts

## Benefits

- Proper multi-window support
- Multi-profile routing works correctly
- Better UX (no arbitrary delays)
- More reliable scheduled job execution