### PR TITLE
fix: show only last received loading message on workflow creation

### DIFF
--- a/apps/agent/entrypoints/app/create-graph/GraphChat.tsx
+++ b/apps/agent/entrypoints/app/create-graph/GraphChat.tsx
@@ -162,9 +162,7 @@ export const GraphChat: FC<GraphChatProps> = ({
             value={input}
             onChange={(e) => onInputChange(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={
-              'Visit Amazon and add sensodyne toothpaste to the cart.'
-            }
+            placeholder={'Describe your workflow...'}
             rows={1}
           />
           {status === 'streaming' ? (

--- a/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
@@ -1,4 +1,5 @@
 import type { UIMessage } from 'ai'
+import { compact } from 'es-toolkit/compat'
 import { Bot } from 'lucide-react'
 import { type FC, Fragment, type RefObject } from 'react'
 import {
@@ -72,6 +73,8 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
               ?.map((each) => each.text)
               ?.join('\n\n')
 
+            const lastText = compact(messageText.split('\n\n')).at(-1) ?? ''
+
             const likeAction = () => onClickLike(message.id)
             const dislikeAction = (comment?: string) =>
               onClickDislike(message.id, comment)
@@ -80,7 +83,11 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
               <Fragment key={message.id}>
                 <Message from={message.role}>
                   <MessageContent>
-                    {action ? (
+                    {message.role === 'assistant' ? (
+                      <MessageResponse key={message.id}>
+                        {lastText}
+                      </MessageResponse>
+                    ) : action ? (
                       <UserActionMessage action={action} />
                     ) : (
                       segments.map((segment) => {

--- a/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
@@ -65,7 +65,8 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
               isLastMessage,
               isStreaming,
             )
-            const toolBatches = segments.filter((s) => s.type === 'tool-batch')
+            const toolBatches =
+              segments?.filter((s) => s.type === 'tool-batch') ?? []
             const lastToolBatchKey = toolBatches[toolBatches.length - 1]?.key
 
             const messageText =

--- a/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
@@ -68,10 +68,11 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
             const toolBatches = segments.filter((s) => s.type === 'tool-batch')
             const lastToolBatchKey = toolBatches[toolBatches.length - 1]?.key
 
-            const messageText = segments
-              ?.filter((each) => each.type === 'text')
-              ?.map((each) => each.text)
-              ?.join('\n\n')
+            const messageText =
+              segments
+                ?.filter((each) => each.type === 'text')
+                ?.map((each) => each.text)
+                ?.join('\n\n') ?? ''
 
             const lastText = compact(messageText.split('\n\n')).at(-1) ?? ''
 


### PR DESCRIPTION
This pull request updates the chat message handling and UI in the agent app, focusing on improving how assistant messages are displayed and how message content is processed. The main changes involve extracting and displaying only the last non-empty segment of assistant messages, updating the input placeholder for better clarity, and introducing a utility function for message processing.

**Chat Message Processing and Display:**

* Only the last non-empty segment of assistant messages is now displayed in `MessageResponse`, improving clarity and relevance for users. (`apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx`)
* Introduced the `compact` function from `es-toolkit/compat` to filter out empty message segments before displaying the last one. (`apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx`) [[1]](diffhunk://#diff-c890ed0d1db567a2ae67e9e53e37300c6ce0cc973c0be2cf043f09794d8e3496R2) [[2]](diffhunk://#diff-c890ed0d1db567a2ae67e9e53e37300c6ce0cc973c0be2cf043f09794d8e3496R76-R77)

**User Interface Improvements:**

* Updated the chat input placeholder in `GraphChat` to a more general and user-friendly prompt: "Describe your workflow..." (`apps/agent/entrypoints/app/create-graph/GraphChat.tsx`)