### PR TITLE
fix: minor race condition on sign in prompt

### DIFF
--- a/apps/agent/entrypoints/newtab/index/SignInHint.tsx
+++ b/apps/agent/entrypoints/newtab/index/SignInHint.tsx
@@ -51,7 +51,7 @@ export const SignInHint = () => {
     await signInHintDismissedAtStorage.setValue(Date.now())
   }
 
-  const show = visible && !dismissed
+  const show = visible && !dismissed && !isPending && !session
 
   return (
     <AnimatePresence>

--- a/apps/agent/entrypoints/newtab/index/SignInHint.tsx
+++ b/apps/agent/entrypoints/newtab/index/SignInHint.tsx
@@ -10,7 +10,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { useSession } from '@/lib/auth/auth-client'
+import { useSessionInfo } from '@/lib/auth/sessionStorage'
 
 const DISMISS_DURATION = 24 * 60 * 60 * 1000
 
@@ -20,13 +20,14 @@ const signInHintDismissedAtStorage = storage.defineItem<number | null>(
 )
 
 export const SignInHint = () => {
-  const { data: session, isPending } = useSession()
+  const { sessionInfo, isLoading } = useSessionInfo()
+  const isLoggedIn = !!sessionInfo?.user
   const navigate = useNavigate()
   const [visible, setVisible] = useState(false)
   const [dismissed, setDismissed] = useState(false)
 
   useEffect(() => {
-    if (isPending || session) return
+    if (isLoading || isLoggedIn) return
 
     let cancelled = false
     let timer: ReturnType<typeof setTimeout>
@@ -44,14 +45,14 @@ export const SignInHint = () => {
       cancelled = true
       clearTimeout(timer)
     }
-  }, [isPending, session])
+  }, [isLoading, isLoggedIn])
 
   const handleDismiss = async () => {
     setDismissed(true)
     await signInHintDismissedAtStorage.setValue(Date.now())
   }
 
-  const show = visible && !dismissed && !isPending && !session
+  const show = visible && !dismissed && !isLoggedIn
 
   return (
     <AnimatePresence>

--- a/apps/agent/lib/auth/sessionStorage.ts
+++ b/apps/agent/lib/auth/sessionStorage.ts
@@ -16,9 +16,13 @@ export const sessionStorage = storage.defineItem<SessionInfo>(
 
 export const useSessionInfo = () => {
   const [sessionInfo, setSessionInfo] = useState<SessionInfo>({})
+  const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    sessionStorage.getValue().then(setSessionInfo)
+    sessionStorage.getValue().then((value) => {
+      setSessionInfo(value)
+      setIsLoading(false)
+    })
     const unwatch = sessionStorage.watch((newValue) => {
       setSessionInfo(newValue ?? {})
     })
@@ -29,5 +33,5 @@ export const useSessionInfo = () => {
     await sessionStorage.setValue(info)
   }
 
-  return { sessionInfo, updateSessionInfo }
+  return { sessionInfo, isLoading, updateSessionInfo }
 }


### PR DESCRIPTION
This pull request refactors how session information is accessed and used in the `SignInHint` component, switching from the old `useSession` hook to a new `useSessionInfo` hook that leverages session storage. It also improves the handling of loading state and ensures the sign-in hint is only shown to users who are not logged in.

**Authentication and session management improvements:**

* Replaced usage of `useSession` with the new `useSessionInfo` hook in `SignInHint.tsx`, which now retrieves session information from session storage instead of the previous auth client.
* Updated the logic in `SignInHint` to use `sessionInfo` and `isLoading` from the new hook, and introduced an `isLoggedIn` variable to determine if the user is authenticated.
* Modified the effect dependencies and logic in `SignInHint` to rely on `isLoading` and `isLoggedIn`, ensuring the hint is not shown while loading or if the user is already logged in.

**Session hook enhancements:**

* Updated `useSessionInfo` in `sessionStorage.ts` to include an `isLoading` state, which is set to `false` once the session information is loaded from storage.
* Extended the return value of `useSessionInfo` to include the new `isLoading` property, allowing components to react to the loading state.