### PR TITLE
fix: standardize workspace selector dropdown style

### DIFF
--- a/apps/agent/components/elements/workspace-selector.tsx
+++ b/apps/agent/components/elements/workspace-selector.tsx
@@ -1,7 +1,14 @@
-import { Check, ChevronDown, Folder, FolderOpen, Globe, X } from 'lucide-react'
+import { Check, Folder, FolderOpen, Globe, X } from 'lucide-react'
 import type { FC, PropsWithChildren } from 'react'
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
 import {
   Popover,
   PopoverContent,
@@ -20,6 +27,7 @@ export const WorkspaceSelector: FC<
   PropsWithChildren<WorkspaceSelectorProps>
 > = ({ children, side = 'top' }) => {
   const [open, setOpen] = useState(false)
+  const [filterText, setFilterText] = useState('')
   const {
     recentFolders,
     selectedFolder,
@@ -28,6 +36,13 @@ export const WorkspaceSelector: FC<
     removeFolder,
     clearSelection,
   } = useWorkspace()
+
+  const query = filterText.toLowerCase()
+  const filteredFolders = recentFolders.filter(
+    (f) =>
+      f.name.toLowerCase().includes(query) ||
+      f.path.toLowerCase().includes(query),
+  )
 
   const handleChooseFolder = async () => {
     try {
@@ -73,120 +88,100 @@ export const WorkspaceSelector: FC<
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        {children || (
-          <Button
-            variant="ghost"
-            size="sm"
-            className={cn(
-              'flex items-center gap-1.5 text-muted-foreground hover:text-foreground',
-              selectedFolder && 'text-foreground',
-            )}
-          >
-            <Folder className="h-4 w-4" />
-            <span>
-              {selectedFolder ? selectedFolder.name : 'Add workspace'}
-            </span>
-            <ChevronDown className="h-3 w-3" />
-          </Button>
-        )}
-      </PopoverTrigger>
-
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent
         side={side}
         align="start"
-        className="w-80 p-0"
+        className="w-72 p-0"
         role="dialog"
         aria-label="Select workspace folder"
       >
-        <div
-          onClick={handleUseDefault}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              handleUseDefault()
-            }
-          }}
-          role="option"
-          aria-selected={!selectedFolder}
-          tabIndex={0}
-          className={cn(
-            'flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-muted',
-            !selectedFolder && 'bg-muted',
-          )}
+        <Command
+          className="[&_svg:not([class*='text-'])]:text-muted-foreground"
+          shouldFilter={false}
         >
-          <Globe className="h-4 w-4 text-muted-foreground" />
-          <div className="flex-1">
-            <div className="text-sm">No workspace</div>
-            <div className="text-muted-foreground text-xs">
-              AI works with tabs only
-            </div>
-          </div>
-          {!selectedFolder && (
-            <Check className="h-4 w-4 text-[var(--accent-orange)]" />
-          )}
-        </div>
-
-        {recentFolders.length > 0 && (
-          <>
-            <div className="border-t" />
-            <div className="px-3 py-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
-              Recent
-            </div>
-            <div className="max-h-64 overflow-y-auto">
-              {recentFolders.map((folder) => (
-                <div
-                  key={folder.id}
-                  onClick={() => handleSelectFolder(folder)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      handleSelectFolder(folder)
-                    }
-                  }}
-                  role="option"
-                  aria-selected={selectedFolder?.id === folder.id}
-                  tabIndex={0}
-                  className={cn(
-                    'group flex cursor-pointer items-start gap-3 px-3 py-2 transition-colors hover:bg-muted',
-                    selectedFolder?.id === folder.id && 'bg-muted',
-                  )}
-                >
-                  <Folder className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium text-sm">
-                      {folder.name}
-                    </div>
-                    <div className="truncate text-muted-foreground text-xs">
-                      {folder.path}
-                    </div>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-1">
-                    {selectedFolder?.id === folder.id && (
-                      <Check className="h-4 w-4 text-[var(--accent-orange)]" />
-                    )}
-                    <button
-                      type="button"
-                      onClick={(e) => handleRemoveFolder(e, folder.id)}
-                      className="rounded p-0.5 opacity-0 transition-opacity hover:bg-muted-foreground/20 group-hover:opacity-100"
-                      aria-label={`Remove ${folder.name} from recents`}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </div>
+          <CommandInput
+            placeholder="Search folders..."
+            className="h-9"
+            value={filterText}
+            onValueChange={setFilterText}
+          />
+          <CommandList className="max-h-64 overflow-auto">
+            <CommandGroup>
+              <CommandItem
+                value="no-workspace"
+                onSelect={handleUseDefault}
+                className="flex items-center gap-3 px-3 py-2"
+              >
+                <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <span className="block text-sm">No workspace</span>
+                  <span className="block text-muted-foreground text-xs">
+                    AI works with tabs only
+                  </span>
                 </div>
-              ))}
-            </div>
-            <div className="border-t" />
-          </>
-        )}
+                {!selectedFolder && (
+                  <Check className="h-4 w-4 shrink-0 text-[var(--accent-orange)]" />
+                )}
+              </CommandItem>
+            </CommandGroup>
 
-        <button
-          type="button"
-          onClick={handleChooseFolder}
-          className="flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-muted"
-        >
-          <FolderOpen className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm">Choose a different folder</span>
-        </button>
+            {filteredFolders.length > 0 && (
+              <CommandGroup>
+                <div className="my-2 px-2 font-semibold text-muted-foreground text-xs uppercase tracking-wide">
+                  Recent
+                </div>
+                {filteredFolders.map((folder) => (
+                  <CommandItem
+                    key={folder.id}
+                    value={`${folder.id} ${folder.name} ${folder.path}`}
+                    onSelect={() => handleSelectFolder(folder)}
+                    className="group flex items-center gap-3 px-3 py-2"
+                  >
+                    <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <span className="block truncate font-medium text-sm">
+                        {folder.name}
+                      </span>
+                      <span className="block truncate text-muted-foreground text-xs">
+                        {folder.path}
+                      </span>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      {selectedFolder?.id === folder.id && (
+                        <Check className="h-4 w-4 text-[var(--accent-orange)]" />
+                      )}
+                      <button
+                        type="button"
+                        onClick={(e) => handleRemoveFolder(e, folder.id)}
+                        className={cn(
+                          'rounded p-0.5 transition-opacity hover:bg-muted-foreground/20',
+                          'opacity-0 group-hover:opacity-100',
+                        )}
+                        aria-label={`Remove ${folder.name} from recents`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            <CommandEmpty>No folders found</CommandEmpty>
+          </CommandList>
+
+          <div className="border-border/50 border-t">
+            <button
+              type="button"
+              onClick={handleChooseFolder}
+              className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted"
+            >
+              <FolderOpen className="h-4 w-4 text-muted-foreground" />
+              <span>Choose a different folder</span>
+            </button>
+          </div>
+        </Command>
       </PopoverContent>
     </Popover>
   )

--- a/apps/agent/components/elements/workspace-selector.tsx
+++ b/apps/agent/components/elements/workspace-selector.tsx
@@ -25,7 +25,7 @@ interface WorkspaceSelectorProps {
 
 export const WorkspaceSelector: FC<
   PropsWithChildren<WorkspaceSelectorProps>
-> = ({ children, side = 'top' }) => {
+> = ({ children, side = 'bottom' }) => {
   const [open, setOpen] = useState(false)
   const [filterText, setFilterText] = useState('')
   const {


### PR DESCRIPTION
This pull request refactors the `WorkspaceSelector` component to improve its usability and code structure. The main updates include replacing the custom recent folders list with a searchable command palette-style UI, updating the default popover side, and simplifying the trigger logic.

**UI and UX improvements:**

* Replaced the manual folder list and search logic with the `Command` UI component, enabling folder search/filtering, keyboard navigation, and a more consistent selection experience. [[1]](diffhunk://#diff-6facc1aa402ed15d5a80b8a90ce2afe644ae7620492b9aa5bbfe9056c2bc921fL1-R11) [[2]](diffhunk://#diff-6facc1aa402ed15d5a80b8a90ce2afe644ae7620492b9aa5bbfe9056c2bc921fL76-R148) [[3]](diffhunk://#diff-6facc1aa402ed15d5a80b8a90ce2afe644ae7620492b9aa5bbfe9056c2bc921fL169-R184)
* Added a search input (`CommandInput`) to filter recent folders by name or path, and display a "No folders found" message if nothing matches. [[1]](diffhunk://#diff-6facc1aa402ed15d5a80b8a90ce2afe644ae7620492b9aa5bbfe9056c2bc921fR40-R46) [[2]](diffhunk://#diff-6facc1aa402ed15d5a80b8a90ce2afe644ae7620492b9aa5bbfe9056c2bc921fL76-R148)

**Component structure and behavior:**

* Changed the default popover side from `'top'` to `'bottom'` for improved dropdown positioning.
* Simplified the popover trigger to always use the `children` prop, removing the default button logic.
* Adjusted styling and classes for consistency with the new UI and to improve accessibility and appearance. [[1]](diffhunk://#diff-6facc1aa402ed15d5a80b8a90ce2afe644ae7620492b9aa5bbfe9056c2bc921fL76-R148) [[2]](diffhunk://#diff-6facc1aa402ed15d5a80b8a90ce2afe644ae7620492b9aa5bbfe9056c2bc921fL169-R184)