### PR TITLE
fix: added loading indicator to ensure chat history is consistent when loading from history

### DIFF
--- a/apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx
+++ b/apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx
@@ -1,5 +1,6 @@
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query'
 import type { UIMessage } from 'ai'
+import { Loader2 } from 'lucide-react'
 import type { FC } from 'react'
 import { useMemo } from 'react'
 import { useSessionInfo } from '@/lib/auth/sessionStorage'
@@ -30,6 +31,7 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
 
   const {
     data: graphqlData,
+    isLoading: isLoadingConversations,
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
@@ -92,6 +94,14 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
     () => groupConversations(conversations),
     [conversations],
   )
+
+  if (!profileId || isLoadingConversations) {
+    return (
+      <div className="flex flex-1 items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
 
   return (
     <ConversationList

--- a/apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx
+++ b/apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx
@@ -1,4 +1,4 @@
-import { useQueryClient } from '@tanstack/react-query'
+import { keepPreviousData, useQueryClient } from '@tanstack/react-query'
 import type { UIMessage } from 'ai'
 import type { FC } from 'react'
 import { useMemo } from 'react'
@@ -43,6 +43,7 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
         lastPage.conversations?.pageInfo.hasNextPage
           ? lastPage.conversations.pageInfo.endCursor
           : undefined,
+      placeholderData: keepPreviousData,
     },
   )
 

--- a/apps/agent/entrypoints/sidepanel/index/Chat.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/Chat.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { createBrowserOSAction } from '@/lib/chat-actions/types'
 import { SIDEPANEL_AI_TRIGGERED_EVENT } from '@/lib/constants/analyticsEvents'
@@ -27,6 +28,7 @@ export const Chat = () => {
     onClickLike,
     disliked,
     onClickDislike,
+    isRestoringConversation,
   } = useChatSessionContext()
 
   const {
@@ -134,7 +136,11 @@ export const Chat = () => {
   return (
     <>
       <main className="mt-4 flex h-full flex-1 flex-col space-y-4 overflow-y-auto">
-        {messages.length === 0 ? (
+        {isRestoringConversation ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : messages.length === 0 ? (
           <ChatEmptyState
             mode={mode}
             mounted={mounted}

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -19,7 +19,7 @@ import {
   useConversations,
 } from '@/lib/conversations/conversationStorage'
 import { formatConversationHistory } from '@/lib/conversations/formatConversationHistory'
-import { execute } from '@/lib/graphql/execute'
+import { useGraphqlQuery } from '@/lib/graphql/useGraphqlQuery'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { track } from '@/lib/metrics/track'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
@@ -299,51 +299,55 @@ export const useChatSession = () => {
     conversationId: conversationIdRef.current,
   })
 
+  const { data: remoteConversationData } = useGraphqlQuery(
+    GetConversationWithMessagesDocument,
+    { conversationId: conversationIdParam ?? '' },
+    {
+      enabled: !!conversationIdParam && isLoggedIn,
+    },
+  )
+
+  const restoredConversationRef = useRef<string | null>(null)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: restore should only run when query data arrives or conversationIdParam changes
   useEffect(() => {
     if (!conversationIdParam) return
+    if (restoredConversationRef.current === conversationIdParam) return
 
-    const restoreConversation = async () => {
-      if (isLoggedIn) {
-        const result = await execute(GetConversationWithMessagesDocument, {
-          conversationId: conversationIdParam,
-        })
+    if (isLoggedIn) {
+      if (!remoteConversationData?.conversation) return
 
-        if (result.conversation) {
-          const messages = result.conversation.conversationMessages.nodes
-            .filter((node): node is NonNullable<typeof node> => node !== null)
-            .map((node) => node.message as UIMessage)
+      const restoredMessages =
+        remoteConversationData.conversation.conversationMessages.nodes
+          .filter((node): node is NonNullable<typeof node> => node !== null)
+          .map((node) => node.message as UIMessage)
 
-          setConversationId(
-            conversationIdParam as ReturnType<typeof crypto.randomUUID>,
-          )
-          setMessages(messages)
-          markMessagesAsSaved(conversationIdParam, messages)
-        }
-      } else {
+      restoredConversationRef.current = conversationIdParam
+      setConversationId(
+        conversationIdParam as ReturnType<typeof crypto.randomUUID>,
+      )
+      setMessages(restoredMessages)
+      markMessagesAsSaved(conversationIdParam, restoredMessages)
+      setSearchParams({}, { replace: true })
+    } else {
+      const restoreLocal = async () => {
         const conversations = await conversationStorage.getValue()
         const conversation = conversations?.find(
           (c) => c.id === conversationIdParam,
         )
 
         if (conversation) {
+          restoredConversationRef.current = conversationIdParam
           setConversationId(
             conversation.id as ReturnType<typeof crypto.randomUUID>,
           )
           setMessages(conversation.messages)
         }
+        setSearchParams({}, { replace: true })
       }
-
-      setSearchParams({}, { replace: true })
+      restoreLocal()
     }
-
-    restoreConversation()
-  }, [
-    conversationIdParam,
-    setMessages,
-    setSearchParams,
-    isLoggedIn,
-    markMessagesAsSaved,
-  ])
+  }, [conversationIdParam, remoteConversationData, isLoggedIn])
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: only need to run when messages change
   useEffect(() => {

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -425,6 +425,7 @@ export const useChatSession = () => {
     setTextToAction(new Map())
     setLiked({})
     setDisliked({})
+    setRestoredConversationId(null)
     resetRemoteConversation()
   }
 

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -317,7 +317,11 @@ export const useChatSession = () => {
     if (restoredConversationId === conversationIdParam) return
 
     if (isLoggedIn) {
-      if (!remoteConversationData?.conversation) return
+      if (!remoteConversationData?.conversation) {
+        setRestoredConversationId(conversationIdParam)
+        setSearchParams({}, { replace: true })
+        return
+      }
 
       const restoredMessages =
         remoteConversationData.conversation.conversationMessages.nodes
@@ -339,12 +343,12 @@ export const useChatSession = () => {
         )
 
         if (conversation) {
-          setRestoredConversationId(conversationIdParam)
           setConversationId(
             conversation.id as ReturnType<typeof crypto.randomUUID>,
           )
           setMessages(conversation.messages)
         }
+        setRestoredConversationId(conversationIdParam)
         setSearchParams({}, { replace: true })
       }
       restoreLocal()

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -421,6 +421,10 @@ export const useChatSession = () => {
     resetRemoteConversation()
   }
 
+  const isRestoringConversation =
+    !!conversationIdParam &&
+    restoredConversationRef.current !== conversationIdParam
+
   return {
     mode,
     setMode,
@@ -431,6 +435,7 @@ export const useChatSession = () => {
     providers,
     selectedProvider,
     isLoading: isLoadingProviders || isLoadingAgentUrl,
+    isRestoringConversation,
     agentUrlError,
     chatError,
     handleSelectProvider,

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -317,11 +317,7 @@ export const useChatSession = () => {
     if (restoredConversationId === conversationIdParam) return
 
     if (isLoggedIn) {
-      if (!remoteConversationData?.conversation) {
-        setRestoredConversationId(conversationIdParam)
-        setSearchParams({}, { replace: true })
-        return
-      }
+      if (!remoteConversationData?.conversation) return
 
       const restoredMessages =
         remoteConversationData.conversation.conversationMessages.nodes
@@ -343,12 +339,12 @@ export const useChatSession = () => {
         )
 
         if (conversation) {
+          setRestoredConversationId(conversationIdParam)
           setConversationId(
             conversation.id as ReturnType<typeof crypto.randomUUID>,
           )
           setMessages(conversation.messages)
         }
-        setRestoredConversationId(conversationIdParam)
         setSearchParams({}, { replace: true })
       }
       restoreLocal()

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -307,12 +307,14 @@ export const useChatSession = () => {
     },
   )
 
-  const restoredConversationRef = useRef<string | null>(null)
+  const [restoredConversationId, setRestoredConversationId] = useState<
+    string | null
+  >(null)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: restore should only run when query data arrives or conversationIdParam changes
   useEffect(() => {
     if (!conversationIdParam) return
-    if (restoredConversationRef.current === conversationIdParam) return
+    if (restoredConversationId === conversationIdParam) return
 
     if (isLoggedIn) {
       if (!remoteConversationData?.conversation) return
@@ -322,7 +324,7 @@ export const useChatSession = () => {
           .filter((node): node is NonNullable<typeof node> => node !== null)
           .map((node) => node.message as UIMessage)
 
-      restoredConversationRef.current = conversationIdParam
+      setRestoredConversationId(conversationIdParam)
       setConversationId(
         conversationIdParam as ReturnType<typeof crypto.randomUUID>,
       )
@@ -337,7 +339,7 @@ export const useChatSession = () => {
         )
 
         if (conversation) {
-          restoredConversationRef.current = conversationIdParam
+          setRestoredConversationId(conversationIdParam)
           setConversationId(
             conversation.id as ReturnType<typeof crypto.randomUUID>,
           )
@@ -422,8 +424,7 @@ export const useChatSession = () => {
   }
 
   const isRestoringConversation =
-    !!conversationIdParam &&
-    restoredConversationRef.current !== conversationIdParam
+    !!conversationIdParam && restoredConversationId !== conversationIdParam
 
   return {
     mode,


### PR DESCRIPTION
This pull request improves the chat session restoration experience and optimizes data fetching in the chat sidepanel. The main changes include adding a loading spinner while restoring conversations, refactoring how remote conversation data is fetched, and ensuring a smoother user experience during chat history loading.

**User experience improvements:**

* Added a loading spinner (`Loader2`) to the chat UI that is displayed while a conversation is being restored, improving feedback to the user when loading previous chat sessions. [[1]](diffhunk://#diff-25d11845eb2d511396dac47c7ecc419bf9f1eb4d9ac3c1446e28b900a6402d1aR1) [[2]](diffhunk://#diff-25d11845eb2d511396dac47c7ecc419bf9f1eb4d9ac3c1446e28b900a6402d1aR31) [[3]](diffhunk://#diff-25d11845eb2d511396dac47c7ecc419bf9f1eb4d9ac3c1446e28b900a6402d1aL137-R143) [[4]](diffhunk://#diff-84f02a89c12f3cdff4d676bfdea63094119aaa19be12f8d5722a6965dfb2be69R439) [[5]](diffhunk://#diff-84f02a89c12f3cdff4d676bfdea63094119aaa19be12f8d5722a6965dfb2be69R426-R428)

**Data fetching and restoration logic:**

* Refactored conversation restoration logic to use the `useGraphqlQuery` hook instead of the lower-level `execute` function, streamlining remote data fetching and handling. [[1]](diffhunk://#diff-84f02a89c12f3cdff4d676bfdea63094119aaa19be12f8d5722a6965dfb2be69L22-R22) [[2]](diffhunk://#diff-84f02a89c12f3cdff4d676bfdea63094119aaa19be12f8d5722a6965dfb2be69R302-R352)
* Improved restoration state tracking by introducing `restoredConversationId` and the `isRestoringConversation` flag, ensuring the UI accurately reflects loading state and avoids redundant fetches. [[1]](diffhunk://#diff-84f02a89c12f3cdff4d676bfdea63094119aaa19be12f8d5722a6965dfb2be69R302-R352) [[2]](diffhunk://#diff-84f02a89c12f3cdff4d676bfdea63094119aaa19be12f8d5722a6965dfb2be69R426-R428) [[3]](diffhunk://#diff-84f02a89c12f3cdff4d676bfdea63094119aaa19be12f8d5722a6965dfb2be69R439)

**Chat history pagination optimization:**

* Utilized `keepPreviousData` from `@tanstack/react-query` in the chat history pagination to provide a smoother experience when fetching additional pages, preventing UI flicker. [[1]](diffhunk://#diff-11295aed65c4f2f245714ae67dd7fd147b8a479512348c04e98079a95723b14eL1-R1) [[2]](diffhunk://#diff-11295aed65c4f2f245714ae67dd7fd147b8a479512348c04e98079a95723b14eR46)