### PR TITLE
feat: scheduled tasks ux improvement

### DIFF
--- a/apps/agent/components/ai-elements/run-result-dialog.tsx
+++ b/apps/agent/components/ai-elements/run-result-dialog.tsx
@@ -6,6 +6,8 @@ import {
   CheckCircle2,
   Copy,
   Loader2,
+  RotateCcw,
+  Square,
   XCircle,
 } from 'lucide-react'
 import { type FC, useState } from 'react'
@@ -27,6 +29,8 @@ interface RunResultDialogProps {
   run: ScheduledJobRun | null
   jobName?: string
   onOpenChange: (open: boolean) => void
+  onCancelRun?: (runId: string) => void
+  onRetryRun?: (jobId: string) => void
 }
 
 const formatDateTime = (dateStr: string) =>
@@ -46,6 +50,8 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
   run,
   jobName,
   onOpenChange,
+  onCancelRun,
+  onRetryRun,
 }) => {
   const [copied, setCopied] = useState(false)
 
@@ -99,6 +105,24 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
         </ScrollArea>
 
         <DialogFooter>
+          {run.status === 'running' && onCancelRun && (
+            <Button variant="destructive" onClick={() => onCancelRun(run.id)}>
+              <Square className="h-4 w-4" />
+              Cancel
+            </Button>
+          )}
+          {run.status === 'failed' && onRetryRun && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                onRetryRun(run.jobId)
+                onOpenChange(false)
+              }}
+            >
+              <RotateCcw className="h-4 w-4" />
+              Retry
+            </Button>
+          )}
           {run.result && (
             <Button
               variant="outline"

--- a/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskCard.tsx
+++ b/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskCard.tsx
@@ -7,6 +7,8 @@ import {
   Loader2,
   Pencil,
   Play,
+  RotateCcw,
+  Square,
   Trash2,
   XCircle,
 } from 'lucide-react'
@@ -31,6 +33,8 @@ interface ScheduledTaskCardProps {
   onToggle: (enabled: boolean) => void
   onRun: () => void
   onViewRun: (run: ScheduledJobRun) => void
+  onCancelRun: (runId: string) => void
+  onRetryRun: (jobId: string) => void
 }
 
 function formatSchedule(job: ScheduledJob): string {
@@ -72,6 +76,8 @@ export const ScheduledTaskCard: FC<ScheduledTaskCardProps> = ({
   onToggle,
   onRun,
   onViewRun,
+  onCancelRun,
+  onRetryRun,
 }) => {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -180,14 +186,44 @@ export const ScheduledTaskCard: FC<ScheduledTaskCardProps> = ({
                       </p>
                     )}
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onViewRun(run)}
-                    className="shrink-0 text-muted-foreground hover:text-foreground"
-                  >
-                    View
-                  </Button>
+                  <div className="flex shrink-0 items-center gap-1">
+                    {run.status === 'running' && (
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onCancelRun(run.id)
+                        }}
+                        className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                        aria-label="Cancel run"
+                      >
+                        <Square className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                    {run.status === 'failed' && (
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onRetryRun(run.jobId)
+                        }}
+                        className="text-muted-foreground hover:text-foreground"
+                        aria-label="Retry run"
+                      >
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onViewRun(run)}
+                      className="shrink-0 text-muted-foreground hover:text-foreground"
+                    >
+                      View
+                    </Button>
+                  </div>
                 </div>
               ))}
             </div>

--- a/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResults.tsx
+++ b/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResults.tsx
@@ -1,6 +1,14 @@
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import { Calendar, CheckCircle2, Clock, Loader2, XCircle } from 'lucide-react'
+import {
+  Calendar,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  RotateCcw,
+  Square,
+  XCircle,
+} from 'lucide-react'
 import type { FC } from 'react'
 import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
@@ -21,6 +29,8 @@ interface JobRunWithDetails extends ScheduledJobRun {
 
 interface ScheduledTaskResultsProps {
   onViewRun: (run: ScheduledJobRun) => void
+  onCancelRun: (runId: string) => void
+  onRetryRun: (jobId: string) => void
 }
 
 const getStatusIcon = (status: JobRunWithDetails['status']) => {
@@ -38,6 +48,8 @@ const formatTimestamp = (dateString: string) => dayjs(dateString).fromNow()
 
 export const ScheduledTaskResults: FC<ScheduledTaskResultsProps> = ({
   onViewRun,
+  onCancelRun,
+  onRetryRun,
 }) => {
   const { jobRuns } = useScheduledJobRuns()
   const { jobs } = useScheduledJobs()
@@ -99,6 +111,34 @@ export const ScheduledTaskResults: FC<ScheduledTaskResultsProps> = ({
                 </p>
               )}
             </div>
+            {run.status === 'running' && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onCancelRun(run.id)
+                }}
+                className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                aria-label="Cancel run"
+              >
+                <Square className="h-3.5 w-3.5" />
+              </Button>
+            )}
+            {run.status === 'failed' && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onRetryRun(run.jobId)
+                }}
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label="Retry run"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+              </Button>
+            )}
           </div>
         </Button>
       ))}

--- a/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksList.tsx
+++ b/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksList.tsx
@@ -9,6 +9,8 @@ interface ScheduledTasksListProps {
   onToggle: (jobId: string, enabled: boolean) => void
   onRun: (jobId: string) => void
   onViewRun: (run: ScheduledJobRun) => void
+  onCancelRun: (runId: string) => void
+  onRetryRun: (jobId: string) => void
 }
 
 export const ScheduledTasksList: FC<ScheduledTasksListProps> = ({
@@ -18,6 +20,8 @@ export const ScheduledTasksList: FC<ScheduledTasksListProps> = ({
   onToggle,
   onRun,
   onViewRun,
+  onCancelRun,
+  onRetryRun,
 }) => {
   if (jobs.length === 0) {
     return (
@@ -42,6 +46,8 @@ export const ScheduledTasksList: FC<ScheduledTasksListProps> = ({
           onToggle={(enabled) => onToggle(job.id, enabled)}
           onRun={() => onRun(job.id)}
           onViewRun={onViewRun}
+          onCancelRun={onCancelRun}
+          onRetryRun={onRetryRun}
         />
       ))}
     </div>

--- a/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx
@@ -84,6 +84,7 @@ export const ScheduledTasksPage: FC = () => {
       })
     } else {
       await addJob(data)
+      setActiveTab('tasks')
       track(NEW_SCHEDULED_TASK_CREATED_EVENT, {
         scheduleType: data.scheduleType,
         interval: data.scheduleInterval,

--- a/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx
@@ -181,6 +181,11 @@ export const ScheduledTasksPage: FC = () => {
             : undefined
         }
         onOpenChange={(open) => !open && setViewingRun(null)}
+        onCancelRun={handleCancelRun}
+        onRetryRun={(jobId) => {
+          handleRetryRun(jobId)
+          setViewingRun(null)
+        }}
       />
 
       <AlertDialog

--- a/apps/agent/entrypoints/background/scheduledJobRuns.ts
+++ b/apps/agent/entrypoints/background/scheduledJobRuns.ts
@@ -11,6 +11,8 @@ const MAX_RUNS_PER_JOB = 15
 const STALE_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000
 
+const runAbortControllers = new Map<string, AbortController>()
+
 export const scheduledJobRuns = async () => {
   const cleanupStaleJobRuns = async () => {
     const current = (await scheduledJobRunStorage.getValue()) ?? []
@@ -127,12 +129,15 @@ export const scheduledJobRuns = async () => {
     }
 
     const jobRun = await createJobRun(jobId, 'running')
+    const abortController = new AbortController()
+    runAbortControllers.set(jobRun.id, abortController)
 
     try {
       const response = await getChatServerResponse({
         message: job.query,
         activeTab: backgroundTab,
         windowId: backgroundWindow.id,
+        signal: abortController.signal,
       })
 
       await updateJobRun(jobRun.id, {
@@ -144,7 +149,12 @@ export const scheduledJobRuns = async () => {
         toolCalls: response.toolCalls,
       })
     } catch (e) {
-      const errorMessage = e instanceof Error ? e.message : String(e)
+      const isCancelled = abortController.signal.aborted
+      const errorMessage = isCancelled
+        ? 'Cancelled by user'
+        : e instanceof Error
+          ? e.message
+          : String(e)
       await updateJobRun(jobRun.id, {
         status: 'failed',
         completedAt: new Date().toISOString(),
@@ -152,6 +162,7 @@ export const scheduledJobRuns = async () => {
         error: errorMessage,
       })
     } finally {
+      runAbortControllers.delete(jobRun.id)
       await updateJobLastRunAt(jobId)
       if (backgroundWindow.id) {
         await chrome.windows.remove(backgroundWindow.id)
@@ -226,6 +237,15 @@ export const scheduledJobRuns = async () => {
         error: e instanceof Error ? e.message : String(e),
       }
     }
+  })
+
+  onScheduleMessage('cancelScheduledJobRun', async ({ data }) => {
+    const controller = runAbortControllers.get(data.runId)
+    if (!controller) {
+      return { success: false, error: 'Run not found or already completed' }
+    }
+    controller.abort()
+    return { success: true }
   })
 
   chrome.runtime.onStartup.addListener(async () => {

--- a/apps/agent/entrypoints/background/scheduledJobRuns.ts
+++ b/apps/agent/entrypoints/background/scheduledJobRuns.ts
@@ -163,10 +163,14 @@ export const scheduledJobRuns = async () => {
       })
     } finally {
       runAbortControllers.delete(jobRun.id)
-      await updateJobLastRunAt(jobId)
       if (backgroundWindow.id) {
-        await chrome.windows.remove(backgroundWindow.id)
+        try {
+          await chrome.windows.remove(backgroundWindow.id)
+        } catch {
+          // Window may already be closed
+        }
       }
+      await updateJobLastRunAt(jobId)
     }
   }
 

--- a/apps/agent/lib/constants/analyticsEvents.ts
+++ b/apps/agent/lib/constants/analyticsEvents.ts
@@ -98,4 +98,11 @@ export const JTBD_POPUP_SHOWN_EVENT = 'ui.jtbd_popup.shown'
 export const JTBD_POPUP_CLICKED_EVENT = 'ui.jtbd_popup.clicked'
 
 /** @public */
+export const SCHEDULED_TASK_CANCELLED_EVENT =
+  'settings.scheduled_task.cancelled'
+
+/** @public */
+export const SCHEDULED_TASK_RETRIED_EVENT = 'settings.scheduled_task.retried'
+
+/** @public */
 export const JTBD_POPUP_DISMISSED_EVENT = 'ui.jtbd_popup.dismissed'

--- a/apps/agent/lib/messaging/schedules/scheduleMessages.ts
+++ b/apps/agent/lib/messaging/schedules/scheduleMessages.ts
@@ -4,6 +4,10 @@ interface RunScheduledJobData {
   jobId: string
 }
 
+interface CancelScheduledJobRunData {
+  runId: string
+}
+
 interface RunScheduledJobResponse {
   success: boolean
   error?: string
@@ -11,6 +15,9 @@ interface RunScheduledJobResponse {
 
 type ScheduleMessagesProtocol = {
   runScheduledJob(data: RunScheduledJobData): RunScheduledJobResponse
+  cancelScheduledJobRun(
+    data: CancelScheduledJobRunData,
+  ): RunScheduledJobResponse
 }
 
 const { sendMessage, onMessage } =

--- a/apps/agent/lib/schedules/getChatServerResponse.ts
+++ b/apps/agent/lib/schedules/getChatServerResponse.ts
@@ -23,6 +23,7 @@ interface ChatServerRequest {
   conversationId?: string
   windowId?: number
   activeTab?: ActiveTab
+  signal?: AbortSignal
 }
 
 interface ChatServerResponse {
@@ -93,6 +94,7 @@ export async function getChatServerResponse(
 
   const response = await fetch(`${agentServerUrl}/chat`, {
     method: 'POST',
+    signal: request.signal,
     headers: {
       'Content-Type': 'application/json',
     },

--- a/apps/agent/lib/schedules/scheduleStorage.ts
+++ b/apps/agent/lib/schedules/scheduleStorage.ts
@@ -142,7 +142,11 @@ export function useScheduledJobRuns() {
     )
   }
 
-  return { jobRuns, addJobRun, removeJobRun, editJobRun }
+  const cancelJobRun = async (runId: string) => {
+    return sendScheduleMessage('cancelScheduledJobRun', { runId })
+  }
+
+  return { jobRuns, addJobRun, removeJobRun, editJobRun, cancelJobRun }
 }
 
 export async function syncScheduledJobs(): Promise<void> {


### PR DESCRIPTION
This pull request adds the ability to cancel running scheduled job runs and retry failed runs from the UI, improving user control over scheduled tasks. The changes introduce new UI buttons for these actions, update the background job runner to support cancellation via `AbortController`, and wire up the necessary event handling and analytics tracking throughout the scheduled tasks pages and components.

**New scheduled job run controls:**

* Added "Cancel" and "Retry" buttons to scheduled job run UI components (`ScheduledTaskCard`, `ScheduledTaskResults`, `RunResultDialog`, and `ScheduleResults`), allowing users to cancel running jobs and retry failed ones directly from the interface. [[1]](diffhunk://#diff-447b28ecee5395ebf789cc21bf1d8c05a40bee8fa9cda4f4e86fe84eb5a709e9R108-R125) [[2]](diffhunk://#diff-4b7dbe345d6d2ac4dd69ecf033ac9f7af2720c4a34a157e713577778a82d19e0R189-R217) [[3]](diffhunk://#diff-c818cf9595baad21807fcfdf1164a93ffc8f7d36e72f05c2542f17318b631cc3R114-R141) [[4]](diffhunk://#diff-8594ec5fc4243e3acd7e537a71327991532e82f04dfa6f13ef00b125c9f4139eR9-R10)
* Updated component props and handlers throughout the scheduled tasks UI to pass down `onCancelRun` and `onRetryRun` callbacks. [[1]](diffhunk://#diff-447b28ecee5395ebf789cc21bf1d8c05a40bee8fa9cda4f4e86fe84eb5a709e9R32-R33) [[2]](diffhunk://#diff-4b7dbe345d6d2ac4dd69ecf033ac9f7af2720c4a34a157e713577778a82d19e0R36-R37) [[3]](diffhunk://#diff-c818cf9595baad21807fcfdf1164a93ffc8f7d36e72f05c2542f17318b631cc3R32-R33) [[4]](diffhunk://#diff-78a84cdf19b31511cbbef65801f572011b6feef97a416a6edc6dba80685b47d5R12-R13) [[5]](diffhunk://#diff-e599d62b20fd1387868ad44e2df90abcaf1507ada039a3b9307f10e2f96c5650R184-R188)

**Background job run cancellation:**

* Implemented job run cancellation in the background process using `AbortController`, allowing in-progress runs to be aborted and marked as cancelled by the user. [[1]](diffhunk://#diff-cff1189c3a1f7ff825198bb057f72c18b64af63ee578c1f0f8d2dd2086eb4879R14-R15) [[2]](diffhunk://#diff-cff1189c3a1f7ff825198bb057f72c18b64af63ee578c1f0f8d2dd2086eb4879R132-R140) [[3]](diffhunk://#diff-cff1189c3a1f7ff825198bb057f72c18b64af63ee578c1f0f8d2dd2086eb4879L147-R165) [[4]](diffhunk://#diff-cff1189c3a1f7ff825198bb057f72c18b64af63ee578c1f0f8d2dd2086eb4879R242-R250)

**Analytics and user experience improvements:**

* Added analytics events for cancelled and retried scheduled tasks, and updated event tracking in relevant handlers. [[1]](diffhunk://#diff-e599d62b20fd1387868ad44e2df90abcaf1507ada039a3b9307f10e2f96c5650R16-R31) [[2]](diffhunk://#diff-8594ec5fc4243e3acd7e537a71327991532e82f04dfa6f13ef00b125c9f4139eR24-R25) [[3]](diffhunk://#diff-e599d62b20fd1387868ad44e2df90abcaf1507ada039a3b9307f10e2f96c5650R110-R130)
* Improved tab state management in the scheduled tasks page to reflect the presence of results and ensure the UI responds to user actions. [[1]](diffhunk://#diff-e599d62b20fd1387868ad44e2df90abcaf1507ada039a3b9307f10e2f96c5650R91) [[2]](diffhunk://#diff-e599d62b20fd1387868ad44e2df90abcaf1507ada039a3b9307f10e2f96c5650L114-R151)

**Propagating new controls throughout the UI:**

* Updated all scheduled task-related components and their props to propagate the new cancel and retry actions, ensuring consistent behavior and UI updates across the app. [[1]](diffhunk://#diff-78a84cdf19b31511cbbef65801f572011b6feef97a416a6edc6dba80685b47d5R49-R50) [[2]](diffhunk://#diff-e599d62b20fd1387868ad44e2df90abcaf1507ada039a3b9307f10e2f96c5650R162-R167) [[3]](diffhunk://#diff-e599d62b20fd1387868ad44e2df90abcaf1507ada039a3b9307f10e2f96c5650R46-R50) [[4]](diffhunk://#diff-e599d62b20fd1387868ad44e2df90abcaf1507ada039a3b9307f10e2f96c5650R184-R188)

These changes together provide a more robust and interactive experience for managing scheduled jobs, especially in handling failures and long-running tasks.