### PR TITLE
fix: pending check before updating session storage

### DIFF
--- a/apps/agent/lib/auth/AuthProvider.tsx
+++ b/apps/agent/lib/auth/AuthProvider.tsx
@@ -4,16 +4,18 @@ import { useSession } from './auth-client'
 import { useSessionInfo } from './sessionStorage'
 
 export const AuthProvider: FC<PropsWithChildren> = ({ children }) => {
-  const { data } = useSession()
+  const { data, isPending } = useSession()
   const { updateSessionInfo } = useSessionInfo()
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: only re-run when data changes
   useEffect(() => {
-    updateSessionInfo({
-      session: data?.session,
-      user: data?.user,
-    })
-  }, [data])
+    if (!isPending) {
+      updateSessionInfo({
+        session: data?.session,
+        user: data?.user,
+      })
+    }
+  }, [data, isPending])
 
   return <>{children}</>
 }


### PR DESCRIPTION
This pull request updates the `AuthProvider` component to improve session state handling by accounting for the loading state of the session data. The main change ensures that session information is only updated when the session data is fully loaded.

Session management improvements:

* Updated the `useSession` hook usage in `AuthProvider.tsx` to destructure the `isPending` property and modified the `useEffect` to only call `updateSessionInfo` when the session data is not pending, preventing premature updates.