### PR TITLE
feat: make dev commands easier to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,21 +72,26 @@ packages/
 
 ### Setup
 
+Requires [process-compose](https://github.com/F1bonacc1/process-compose):
+
+```bash
+brew install process-compose
+```
+
 ```bash
 # Copy environment files for each package
 cp apps/server/.env.example apps/server/.env.development
 cp apps/agent/.env.example apps/agent/.env.development
 
-# Start the full dev environment (installs deps, builds extension, starts server + agent)
+# Start the full dev environment
 process-compose up
 ```
-
-This uses [process-compose](https://github.com/F1bonacc1/process-compose) to run the full dev stack. Install it with `brew install process-compose`.
 
 The `process-compose up` command runs the following in order:
 1. `bun install` — installs dependencies
 2. `bun --cwd apps/controller-ext build` — builds the controller extension
-3. `bun --cwd apps/server start` and `bun --cwd apps/agent dev` — starts server and agent in parallel
+3. `bun --cwd apps/agent codegen` — generates agent code
+4. `bun --cwd apps/server start` and `bun --cwd apps/agent dev` — starts server and agent in parallel
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,20 @@ packages/
 ### Setup
 
 ```bash
-# Install dependencies
-bun install
-
 # Copy environment files for each package
 cp apps/server/.env.example apps/server/.env.development
 cp apps/agent/.env.example apps/agent/.env.development
+
+# Start the full dev environment (installs deps, builds extension, starts server + agent)
+process-compose up
 ```
+
+This uses [process-compose](https://github.com/F1bonacc1/process-compose) to run the full dev stack. Install it with `brew install process-compose`.
+
+The `process-compose up` command runs the following in order:
+1. `bun install` — installs dependencies
+2. `bun --cwd apps/controller-ext build` — builds the controller extension
+3. `bun --cwd apps/server start` and `bun --cwd apps/agent dev` — starts server and agent in parallel
 
 ### Environment Variables
 

--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "bin": {
         "browseros-server": "./src/index.ts",
       },

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,0 +1,19 @@
+version: "0.5"
+
+processes:
+  build-ext:
+    command: bun --cwd apps/controller-ext build
+    availability:
+      restart: no
+
+  server:
+    command: bun --cwd apps/server start
+    depends_on:
+      build-ext:
+        condition: process_completed_successfully
+
+  agent:
+    command: bun --cwd apps/agent dev
+    depends_on:
+      build-ext:
+        condition: process_completed_successfully

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,10 +1,18 @@
 version: "0.5"
 
 processes:
+  install:
+    command: bun install
+    availability:
+      restart: no
+
   build-ext:
     command: bun --cwd apps/controller-ext build
     availability:
       restart: no
+    depends_on:
+      install:
+        condition: process_completed_successfully
 
   server:
     command: bun --cwd apps/server start

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -20,8 +20,18 @@ processes:
       build-ext:
         condition: process_completed_successfully
 
+  agent-codegen:
+    command: bun --cwd apps/agent codegen
+    availability:
+      restart: no
+    depends_on:
+      install:
+        condition: process_completed_successfully
+
   agent:
     command: bun --cwd apps/agent dev
     depends_on:
       build-ext:
+        condition: process_completed_successfully
+      agent-codegen:
         condition: process_completed_successfully


### PR DESCRIPTION
This pull request adds a new `process-compose.yaml` file to the project, introducing a process orchestration setup for development and build workflows. The configuration defines how to install dependencies, build extensions, and start the server and agent processes, including their dependencies and restart policies.

Process orchestration setup:

* Added `process-compose.yaml` to define and coordinate the following processes: `install` (runs `bun install`), `build-ext` (builds the controller extension), `server` (starts the server), and `agent` (runs the agent in dev mode). Each process specifies dependencies to ensure correct execution order and non-restart policies for build steps.