### PR TITLE
Add health endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/server/src/api/routes/health.ts
+++ b/apps/server/src/api/routes/health.ts
@@ -8,6 +8,6 @@ import { Hono } from 'hono'
 
 export function createHealthRoute() {
   return new Hono().get('/', (c) => {
-    return c.json({ status: 'ok' })
+    return c.json({ status: 'ok', uptime: process.uptime() })
   })
 }

--- a/apps/server/tests/api/routes/health.test.ts
+++ b/apps/server/tests/api/routes/health.test.ts
@@ -15,6 +15,8 @@ describe('createHealthRoute', () => {
 
     assert.strictEqual(response.status, 200)
     const body = await response.json()
-    assert.deepStrictEqual(body, { status: 'ok' })
+    assert.strictEqual(body.status, 'ok')
+    assert.strictEqual(typeof body.uptime, 'number')
+    assert.ok(body.uptime >= 0)
   })
 })


### PR DESCRIPTION
## Summary
Add a GET /health endpoint that returns { status: 'ok', uptime: process.uptime() } to the main server

## Changes
```

```

## Test Results
✅ All tests passed

## Agent Metadata
- Total cost: $2.2178
- Phases:
  - ✅ intake ($0.0000, 1.0s)
  - ✅ setup ($0.0000, 8.5s)
  - ✅ plan ($1.1379, 65.5s)
  - ✅ execute ($1.0799, 34.8s)
  - ✅ test ($0.0000, 0.2s)

---
*Generated by coding-agent*