### PR TITLE
fix: previous conversation history never injected on resume

### DIFF
--- a/apps/server/src/agent/gemini-agent.ts
+++ b/apps/server/src/agent/gemini-agent.ts
@@ -397,8 +397,7 @@ ${message}
 
     // Inject previous conversation if resuming (no server-side history)
     let fullMessage = userQuery
-    const hasHistory = this.client.getHistory().length > 0
-    if (previousConversation && !hasHistory) {
+    if (previousConversation) {
       fullMessage = `<previous_conversation>
 The user is resuming a previous conversation. Here is the conversation history for context:
 

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -99,13 +99,14 @@ export class ChatService {
       isScheduledTask: request.isScheduledTask,
     }
 
+    const isNewSession = !sessionManager.has(request.conversationId)
     const agent = await sessionManager.getOrCreate(agentConfig, mcpServers)
     await agent.execute(
       request.message,
       rawStream,
       abortSignal,
       request.browserContext,
-      request.previousConversation,
+      isNewSession ? request.previousConversation : undefined,
     )
   }
 


### PR DESCRIPTION
gemini-cli-core initializes GeminiClient with 1 bootstrap history entry, so `getHistory().length > 0` was always true — causing previousConversation to be skipped even for brand new sessions. Store the initial history length at agent creation and compare against that baseline instead.