### PR TITLE
Add health endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/server/src/api/routes/health.ts
+++ b/apps/server/src/api/routes/health.ts
@@ -8,6 +8,6 @@ import { Hono } from 'hono'
 
 export function createHealthRoute() {
   return new Hono().get('/', (c) => {
-    return c.json({ status: 'ok' })
+    return c.json({ status: 'ok', uptime: process.uptime() })
   })
 }

--- a/apps/server/tests/api/routes/health.test.ts
+++ b/apps/server/tests/api/routes/health.test.ts
@@ -14,7 +14,9 @@ describe('createHealthRoute', () => {
     const response = await route.request('/')
 
     assert.strictEqual(response.status, 200)
-    const body = await response.json()
-    assert.deepStrictEqual(body, { status: 'ok' })
+    const body = (await response.json()) as { status: string; uptime: number }
+    assert.strictEqual(body.status, 'ok')
+    assert.strictEqual(typeof body.uptime, 'number')
+    assert.ok(body.uptime >= 0)
   })
 })

--- a/apps/server/tests/server.integration.test.ts
+++ b/apps/server/tests/server.integration.test.ts
@@ -63,8 +63,10 @@ describe('HTTP Server Integration Tests', () => {
       const response = await fetch(`${getBaseUrl()}/health`)
       assert.strictEqual(response.status, 200)
 
-      const json = await response.json()
+      const json = (await response.json()) as { status: string; uptime: number }
       assert.strictEqual(json.status, 'ok')
+      assert.strictEqual(typeof json.uptime, 'number')
+      assert.ok(json.uptime >= 0)
     })
   })
 


### PR DESCRIPTION
## Summary
Add a GET /health endpoint that returns { status: 'ok', uptime: process.uptime() } to the main server

## Changes
```
apps/server/src/api/routes/health.ts         | 2 +-
 apps/server/tests/api/routes/health.test.ts  | 6 ++++--
 apps/server/tests/server.integration.test.ts | 4 +++-
 3 files changed, 8 insertions(+), 4 deletions(-)
```

## Agent Metadata
- Total cost: $4.6407
- Stages:
  - ok setup ($0.0000, 11.0s)
  - ok plan ($2.0895, 93.0s)
  - ok implement ($2.5512, 211.9s)

---
*Generated by coding-agent v2*