### PR TITLE
Add health endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/server/src/api/routes/health.ts
+++ b/apps/server/src/api/routes/health.ts
@@ -8,6 +8,6 @@ import { Hono } from 'hono'
 
 export function createHealthRoute() {
   return new Hono().get('/', (c) => {
-    return c.json({ status: 'ok' })
+    return c.json({ status: 'ok', uptime: process.uptime() })
   })
 }

--- a/apps/server/tests/api/routes/health.test.ts
+++ b/apps/server/tests/api/routes/health.test.ts
@@ -15,6 +15,7 @@ describe('createHealthRoute', () => {
 
     assert.strictEqual(response.status, 200)
     const body = await response.json()
-    assert.deepStrictEqual(body, { status: 'ok' })
+    assert.strictEqual(body.status, 'ok')
+    assert.strictEqual(typeof body.uptime, 'number')
   })
 })


### PR DESCRIPTION
## Summary
Add a GET /health endpoint that returns { status: 'ok', uptime: process.uptime() } to the main server

## Changes
```
apps/server/src/api/routes/health.ts        | 2 +-
 apps/server/tests/api/routes/health.test.ts | 3 ++-
 2 files changed, 3 insertions(+), 2 deletions(-)
```

## Agent Metadata
- Total cost: $2.6977
- Stages:
  - ok setup ($0.0000, 6.2s)
  - ok plan ($1.3832, 97.1s)
  - ok implement ($1.3146, 129.8s)

---
*Generated by coding-agent v2*