### PR TITLE
[DRAFT] Add a GET /health endpoint that returns { status: 'ok', uptime: process.uptime()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/server/src/api/routes/health.ts
+++ b/apps/server/src/api/routes/health.ts
@@ -8,6 +8,6 @@ import { Hono } from 'hono'
 
 export function createHealthRoute() {
   return new Hono().get('/', (c) => {
-    return c.json({ status: 'ok' })
+    return c.json({ status: 'ok', uptime: process.uptime() })
   })
 }

--- a/apps/server/tests/api/routes/health.test.ts
+++ b/apps/server/tests/api/routes/health.test.ts
@@ -15,6 +15,8 @@ describe('createHealthRoute', () => {
 
     assert.strictEqual(response.status, 200)
     const body = await response.json()
-    assert.deepStrictEqual(body, { status: 'ok' })
+    assert.strictEqual(body.status, 'ok')
+    assert.strictEqual(typeof body.uptime, 'number')
+    assert.ok(body.uptime >= 0)
   })
 })


### PR DESCRIPTION
## Summary
Add a GET /health endpoint that returns { status: 'ok', uptime: process.uptime() } to the main server

**Note**: This is a partial implementation. The pipeline failed with: Claude Code process exited with code 1
Stderr: Claude Code stderr: [DEBUG] Hooks: checkForNewResponses called
[DEBUG] Hooks: Found 0 total hooks in registry
[DEBUG] Hooks: checkForNewResponses returning 0 responses | [DEBUG] Hooks: checkForNewResponses called
[DEBUG] Hooks: Found 0 total hooks in registry
[DEBUG] Hooks: checkForNewResponses returning 0 responses | Claude Code stderr: [DEBUG] Slash commands included in SlashCommand tool: | [DEBUG] Slash commands included in SlashCommand tool: | Claude Code process exited with code 1

## Changes
```
apps/server/src/api/routes/health.ts        | 2 +-
 apps/server/tests/api/routes/health.test.ts | 4 +++-
 2 files changed, 4 insertions(+), 2 deletions(-)
```

## Agent Metadata
- Total cost: $1.9107
- Stages:
  - ok setup ($0.0000, 61.0s)
  - ok plan ($1.7636, 76.3s)

---
*Generated by coding-agent v3*