### PR TITLE
Add a GET /health endpoint that returns { status: 'ok', uptime: process.uptime()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/server/src/api/routes/health.ts
+++ b/apps/server/src/api/routes/health.ts
@@ -8,6 +8,6 @@ import { Hono } from 'hono'
 
 export function createHealthRoute() {
   return new Hono().get('/', (c) => {
-    return c.json({ status: 'ok' })
+    return c.json({ status: 'ok', uptime: process.uptime() })
   })
 }

--- a/apps/server/tests/api/routes/health.test.ts
+++ b/apps/server/tests/api/routes/health.test.ts
@@ -15,6 +15,7 @@ describe('createHealthRoute', () => {
 
     assert.strictEqual(response.status, 200)
     const body = await response.json()
-    assert.deepStrictEqual(body, { status: 'ok' })
+    assert.strictEqual(body.status, 'ok')
+    assert.strictEqual(typeof body.uptime, 'number')
   })
 })

--- a/apps/server/tests/server.integration.test.ts
+++ b/apps/server/tests/server.integration.test.ts
@@ -65,6 +65,7 @@ describe('HTTP Server Integration Tests', () => {
 
       const json = await response.json()
       assert.strictEqual(json.status, 'ok')
+      assert.strictEqual(typeof json.uptime, 'number')
     })
   })
 


### PR DESCRIPTION
## Summary
Add a GET /health endpoint that returns { status: 'ok', uptime: process.uptime() } to the main server

## Changes
```
apps/server/src/api/routes/health.ts         | 2 +-
 apps/server/tests/api/routes/health.test.ts  | 3 ++-
 apps/server/tests/server.integration.test.ts | 1 +
 3 files changed, 4 insertions(+), 2 deletions(-)
```

## Agent Metadata
- Total cost: $5.6092
- Stages:
  - ok setup ($0.0000, 61.4s)
  - ok plan ($2.0413, 89.8s)
  - ok implement ($3.5679, 491.1s)

---
*Generated by coding-agent v3*