### PR TITLE
fix: adds a don't ask again option for sync prompt

### DIFF
--- a/apps/agent/entrypoints/newtab/index/SignInHint.tsx
+++ b/apps/agent/entrypoints/newtab/index/SignInHint.tsx
@@ -10,9 +10,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { useSessionInfo } from '@/lib/auth/sessionStorage'
 
 const DISMISS_DURATION = 24 * 60 * 60 * 1000
+const LONG_DISMISS_DURATION = 90 * 24 * 60 * 60 * 1000
 
 const signInHintDismissedAtStorage = storage.defineItem<number | null>(
   'local:signInHintDismissedAt',
@@ -25,6 +27,7 @@ export const SignInHint = () => {
   const navigate = useNavigate()
   const [visible, setVisible] = useState(false)
   const [dismissed, setDismissed] = useState(false)
+  const [dontAskAgain, setDontAskAgain] = useState(false)
 
   useEffect(() => {
     if (isLoading || isLoggedIn) return
@@ -49,7 +52,10 @@ export const SignInHint = () => {
 
   const handleDismiss = async () => {
     setDismissed(true)
-    await signInHintDismissedAtStorage.setValue(Date.now())
+    const dismissUntil = dontAskAgain
+      ? Date.now() + LONG_DISMISS_DURATION - DISMISS_DURATION
+      : Date.now()
+    await signInHintDismissedAtStorage.setValue(dismissUntil)
   }
 
   const show = visible && !dismissed && !isLoggedIn
@@ -83,6 +89,19 @@ export const SignInHint = () => {
               <CardDescription>
                 Sign in to sync conversation history to the cloud.
               </CardDescription>
+              <label
+                htmlFor="sync-dont-ask-again"
+                className="flex items-center gap-2 text-muted-foreground text-sm"
+              >
+                <Checkbox
+                  id="sync-dont-ask-again"
+                  checked={dontAskAgain}
+                  onCheckedChange={(checked) =>
+                    setDontAskAgain(checked === true)
+                  }
+                />
+                Don't ask again
+              </label>
               <Button className="w-full" onClick={() => navigate('/login')}>
                 Sign in
               </Button>


### PR DESCRIPTION
This pull request enhances the sign-in hint UI by adding a "Don't ask again" option, allowing users to dismiss the prompt for a much longer period. The logic for dismissing the hint has been updated to respect this new preference.

**User experience improvements:**

* Added a "Don't ask again" checkbox to the sign-in hint, letting users opt out of seeing the prompt for 90 days.
* Introduced new state (`dontAskAgain`) to track the user's preference for not being prompted again.

**Logic updates:**

* Updated the dismissal logic to store a longer expiration if "Don't ask again" is selected, so the prompt stays hidden for 90 days instead of 1 day. [[1]](diffhunk://#diff-47c93edf25343b84cc2c1c7515e172070e588a99b6ec3dcd5de251a09e25f532R13-R17) [[2]](diffhunk://#diff-47c93edf25343b84cc2c1c7515e172070e588a99b6ec3dcd5de251a09e25f532L52-R58)