### PR TITLE
Look how can we use claude code oauth in my server gemini-agent.ts in browseros 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/server/src/agent/types.ts
+++ b/apps/server/src/agent/types.ts
@@ -9,6 +9,7 @@ export interface ProviderConfig {
   provider: LLMProvider
   model: string
   apiKey?: string
+  authToken?: string
   baseUrl?: string
   upstreamProvider?: string
   resourceName?: string
@@ -23,6 +24,7 @@ export interface ResolvedAgentConfig {
   provider: LLMProvider
   model: string
   apiKey?: string
+  authToken?: string
   baseUrl?: string
   upstreamProvider?: string
   resourceName?: string

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -84,6 +84,7 @@ export class ChatService {
       provider: providerConfig.provider,
       model: providerConfig.model,
       apiKey: providerConfig.apiKey,
+      authToken: providerConfig.authToken,
       baseUrl: providerConfig.baseUrl,
       upstreamProvider: providerConfig.upstreamProvider,
       resourceName: providerConfig.resourceName,
@@ -142,6 +143,7 @@ export class ChatService {
         provider: request.provider,
         model: llmConfig.modelName,
         apiKey: llmConfig.apiKey,
+        authToken: request.authToken,
         baseUrl: llmConfig.baseUrl,
         upstreamProvider: llmConfig.providerType,
       }
@@ -151,6 +153,7 @@ export class ChatService {
       provider: request.provider,
       model: request.model,
       apiKey: request.apiKey,
+      authToken: request.authToken,
       baseUrl: request.baseUrl,
       resourceName: request.resourceName,
       region: request.region,

--- a/packages/shared/src/schemas/llm.ts
+++ b/packages/shared/src/schemas/llm.ts
@@ -64,6 +64,7 @@ export const LLMConfigSchema: z.ZodObject<{
   provider: typeof LLMProviderSchema
   model: z.ZodOptional<z.ZodString>
   apiKey: z.ZodOptional<z.ZodString>
+  authToken: z.ZodOptional<z.ZodString>
   baseUrl: z.ZodOptional<z.ZodString>
   resourceName: z.ZodOptional<z.ZodString>
   region: z.ZodOptional<z.ZodString>
@@ -74,6 +75,7 @@ export const LLMConfigSchema: z.ZodObject<{
   provider: LLMProviderSchema,
   model: z.string().optional(),
   apiKey: z.string().optional(),
+  authToken: z.string().optional(),
   baseUrl: z.string().optional(),
   // Azure-specific
   resourceName: z.string().optional(),


### PR DESCRIPTION
## Summary
Look how can we use claude code oauth in my server gemini-agent.ts in browseros provider (currently it calls proxy server/base url)-&gt; There it has that completions, can we add support of claude code oauth, can have claude code oauth token. For testing, start server with bun run start:server and test with/chat endpoint with simple message like what can you do etc, I wanna support claude code oauth

## Changes
```
apps/server/src/agent/provider-adapter/index.ts | 22 +++++++++++++++++++---
 apps/server/src/agent/types.ts                  |  2 ++
 apps/server/src/api/services/chat-service.ts    |  3 +++
 apps/server/src/lib/clients/llm/provider.ts     | 22 +++++++++++++++++++---
 packages/shared/src/schemas/llm.ts              |  2 ++
 5 files changed, 45 insertions(+), 6 deletions(-)
```

## Agent Metadata
- Total cost: $7.0764
- Stages:
  - ok setup ($0.0000, 46.7s)
  - ok plan ($4.8568, 733.2s)
  - ok implement ($2.2196, 731.9s)

---
*Generated by coding-agent v3*