### PR TITLE
if lets say user has connected MCP servers with klavis, we want it to accessible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/server/src/api/routes/chat.ts
+++ b/apps/server/src/api/routes/chat.ts
@@ -9,7 +9,6 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { SessionManager } from '../../agent/session'
-import { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import type { RateLimiter } from '../../lib/rate-limiter/rate-limiter'
@@ -33,11 +32,9 @@ export function createChatRoutes(deps: ChatRouteDeps) {
   const executionDir = deps.executionDir || PATHS.DEFAULT_EXECUTION_DIR
 
   const sessionManager = new SessionManager()
-  const klavisClient = new KlavisClient()
 
   const chatService = new ChatService({
     sessionManager,
-    klavisClient,
     executionDir,
     mcpServerUrl,
     browserosId,

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -64,6 +64,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     controllerContext,
     mutexPool,
     allowRemote,
+    klavisMcpProxy,
   } = config
 
   const { onShutdown } = config
@@ -78,7 +79,10 @@ export async function createHttpServer(config: HttpServerConfig) {
     )
     .route('/status', createStatusRoute({ controllerContext }))
     .route('/test-provider', createProviderRoutes())
-    .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))
+    .route(
+      '/klavis',
+      createKlavisRoutes({ browserosId: browserosId || '', klavisMcpProxy }),
+    )
     .route(
       '/mcp',
       createMcpRoutes({
@@ -88,6 +92,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         controllerContext,
         mutexPool,
         allowRemote,
+        klavisMcpProxy,
       }),
     )
     .route(

--- a/apps/server/src/api/types.ts
+++ b/apps/server/src/api/types.ts
@@ -18,6 +18,7 @@ import { VercelAIConfigSchema } from '../agent/provider-adapter/types'
 import type { McpContext } from '../browser/cdp/context'
 import type { ControllerContext } from '../browser/extension/context'
 
+import type { KlavisMcpProxy } from '../lib/klavis-mcp-proxy'
 import type { MutexPool } from '../lib/mutex'
 import type { RateLimiter } from '../lib/rate-limiter/rate-limiter'
 import type { ToolDefinition } from '../tools/types/tool-definition'
@@ -73,6 +74,9 @@ export interface HttpServerConfig {
   controllerContext: ControllerContext
   mutexPool: MutexPool
   allowRemote: boolean
+
+  // For Klavis MCP proxy
+  klavisMcpProxy?: KlavisMcpProxy
 
   // For Chat/Klavis routes
   browserosId?: string

--- a/apps/server/src/lib/klavis-mcp-proxy.ts
+++ b/apps/server/src/lib/klavis-mcp-proxy.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Upstream Klavis MCP proxy: connects to Strata, discovers tools,
+ * proxies tool calls, and handles periodic refresh.
+ */
+
+import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
+import type { KlavisClient } from './clients/klavis/klavis-client'
+import { logger } from './logger'
+
+export class KlavisMcpProxy {
+  private client: Client | null = null
+  private transport: StreamableHTTPClientTransport | null = null
+  private tools: Tool[] = []
+  private authenticatedServerNames: string[] = []
+  private refreshInterval: ReturnType<typeof setInterval> | null = null
+
+  onToolsChanged: (() => void) | null = null
+
+  constructor(
+    private klavisClient: KlavisClient,
+    private browserosId: string,
+  ) {}
+
+  async connect(): Promise<void> {
+    try {
+      const integrations = await this.klavisClient.getUserIntegrations(
+        this.browserosId,
+      )
+      const authenticated = integrations.filter((i) => i.isAuthenticated)
+      const names = authenticated.map((i) => i.name)
+
+      if (names.length === 0) {
+        this.tools = []
+        this.authenticatedServerNames = []
+        logger.info('No authenticated Klavis integrations found')
+        return
+      }
+
+      const result = await this.klavisClient.createStrata(
+        this.browserosId,
+        names,
+      )
+
+      const client = new Client({
+        name: 'browseros-klavis-proxy',
+        version: '1.0.0',
+      })
+
+      const transport = new StreamableHTTPClientTransport(
+        new URL(result.strataServerUrl),
+      )
+
+      await client.connect(transport)
+
+      const listResult = await client.listTools(undefined, {
+        signal: AbortSignal.timeout(TIMEOUTS.MCP_UPSTREAM_LIST_TOOLS),
+      })
+
+      this.client = client
+      this.transport = transport
+      this.tools = listResult.tools as Tool[]
+      this.authenticatedServerNames = names
+
+      logger.info('Connected to Klavis Strata', {
+        toolCount: this.tools.length,
+        servers: names,
+      })
+
+      this.onToolsChanged?.()
+
+      this.refreshInterval = setInterval(() => {
+        this.refresh().catch((e) => {
+          logger.warn('Periodic Klavis MCP proxy refresh failed', {
+            error: e instanceof Error ? e.message : String(e),
+          })
+        })
+      }, TIMEOUTS.MCP_UPSTREAM_REFRESH_INTERVAL)
+    } catch (error) {
+      logger.warn('Failed to connect to Klavis Strata', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      this.tools = []
+    }
+  }
+
+  getTools(): Tool[] {
+    return this.tools
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<CallToolResult> {
+    if (!this.client) {
+      return {
+        content: [{ type: 'text', text: 'Klavis MCP proxy is not connected' }],
+        isError: true,
+      }
+    }
+
+    const result = await this.client.callTool(
+      { name, arguments: args },
+      undefined,
+      { signal: AbortSignal.timeout(TIMEOUTS.MCP_UPSTREAM_TOOL_CALL) },
+    )
+
+    // The SDK may return { toolResult } for compatibility — normalize to CallToolResult
+    if ('toolResult' in result) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result.toolResult) }],
+      }
+    }
+
+    return result as CallToolResult
+  }
+
+  async refresh(): Promise<void> {
+    try {
+      const integrations = await this.klavisClient.getUserIntegrations(
+        this.browserosId,
+      )
+      const authenticated = integrations.filter((i) => i.isAuthenticated)
+      const names = authenticated.map((i) => i.name).sort()
+      const currentNames = [...this.authenticatedServerNames].sort()
+
+      if (
+        names.length === currentNames.length &&
+        names.every((n, i) => n === currentNames[i])
+      ) {
+        return
+      }
+
+      logger.info('Klavis integration set changed, reconnecting', {
+        previous: currentNames,
+        current: names,
+      })
+
+      await this.disconnectClient()
+      await this.connect()
+    } catch (error) {
+      logger.warn('Failed to refresh Klavis MCP proxy', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval)
+      this.refreshInterval = null
+    }
+    await this.disconnectClient()
+  }
+
+  isConnected(): boolean {
+    return this.client !== null && this.tools.length > 0
+  }
+
+  private async disconnectClient(): Promise<void> {
+    try {
+      await this.transport?.close()
+    } catch {
+      // Ignore close errors
+    }
+    this.client = null
+    this.transport = null
+    this.tools = []
+  }
+}

--- a/apps/server/tests/lib/klavis-mcp-proxy.test.ts
+++ b/apps/server/tests/lib/klavis-mcp-proxy.test.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, beforeEach, describe, it, mock } from 'bun:test'
+import assert from 'node:assert'
+
+// Mock MCP SDK modules before importing KlavisMcpProxy
+const mockConnect = mock(() => Promise.resolve())
+const mockListTools = mock(() =>
+  Promise.resolve({
+    tools: [
+      {
+        name: 'discover_server_categories_or_actions',
+        description: 'Discover available server categories',
+        inputSchema: { type: 'object' as const },
+      },
+      {
+        name: 'execute_action',
+        description: 'Execute an action',
+        inputSchema: { type: 'object' as const },
+      },
+    ],
+  }),
+)
+const mockCallTool = mock(() =>
+  Promise.resolve({
+    content: [{ type: 'text', text: 'tool result' }],
+  }),
+)
+const mockTransportClose = mock(() => Promise.resolve())
+
+mock.module('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class MockClient {
+    connect = mockConnect
+    listTools = mockListTools
+    callTool = mockCallTool
+  },
+}))
+
+mock.module('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class MockTransport {
+    close = mockTransportClose
+  },
+}))
+
+import { KlavisMcpProxy } from '../../src/lib/klavis-mcp-proxy'
+
+function createMockKlavisClient(
+  overrides: {
+    getUserIntegrations?: () => Promise<
+      Array<{ name: string; isAuthenticated: boolean }>
+    >
+    createStrata?: () => Promise<{
+      strataServerUrl: string
+      strataId: string
+      addedServers: string[]
+    }>
+  } = {},
+) {
+  return {
+    getUserIntegrations:
+      overrides.getUserIntegrations ??
+      mock(() =>
+        Promise.resolve([
+          { name: 'Gmail', isAuthenticated: true },
+          { name: 'Slack', isAuthenticated: false },
+        ]),
+      ),
+    createStrata:
+      overrides.createStrata ??
+      mock(() =>
+        Promise.resolve({
+          strataServerUrl: 'http://strata.test/mcp',
+          strataId: 'test-strata',
+          addedServers: ['Gmail'],
+        }),
+      ),
+    submitApiKey: mock(() => Promise.resolve()),
+    removeServer: mock(() => Promise.resolve()),
+  } as unknown as ConstructorParameters<typeof KlavisMcpProxy>[0]
+}
+
+describe('KlavisMcpProxy', () => {
+  let proxy: KlavisMcpProxy
+
+  beforeEach(() => {
+    mockConnect.mockClear()
+    mockListTools.mockClear()
+    mockCallTool.mockClear()
+    mockTransportClose.mockClear()
+  })
+
+  afterEach(async () => {
+    if (proxy) {
+      await proxy.disconnect()
+    }
+  })
+
+  it('connect() fetches authenticated integrations and connects to Strata', async () => {
+    const klavisClient = createMockKlavisClient()
+    proxy = new KlavisMcpProxy(klavisClient, 'test-browseros-id')
+
+    await proxy.connect()
+
+    assert.strictEqual(proxy.isConnected(), true)
+    assert.strictEqual(proxy.getTools().length, 2)
+    assert.strictEqual(
+      proxy.getTools()[0].name,
+      'discover_server_categories_or_actions',
+    )
+    assert.strictEqual(proxy.getTools()[1].name, 'execute_action')
+    assert.strictEqual(klavisClient.getUserIntegrations.mock.calls.length, 1)
+    assert.strictEqual(klavisClient.createStrata.mock.calls.length, 1)
+    assert.strictEqual(mockConnect.mock.calls.length, 1)
+    assert.strictEqual(mockListTools.mock.calls.length, 1)
+  })
+
+  it('connect() with no authenticated integrations — no connection, empty tools', async () => {
+    const klavisClient = createMockKlavisClient({
+      getUserIntegrations: mock(() =>
+        Promise.resolve([
+          { name: 'Gmail', isAuthenticated: false },
+          { name: 'Slack', isAuthenticated: false },
+        ]),
+      ),
+    })
+    proxy = new KlavisMcpProxy(klavisClient, 'test-browseros-id')
+
+    await proxy.connect()
+
+    assert.strictEqual(proxy.isConnected(), false)
+    assert.deepStrictEqual(proxy.getTools(), [])
+    assert.strictEqual(klavisClient.createStrata.mock.calls.length, 0)
+    assert.strictEqual(mockConnect.mock.calls.length, 0)
+  })
+
+  it('callTool() delegates to upstream client', async () => {
+    const klavisClient = createMockKlavisClient()
+    proxy = new KlavisMcpProxy(klavisClient, 'test-browseros-id')
+    await proxy.connect()
+
+    const result = await proxy.callTool(
+      'discover_server_categories_or_actions',
+      { query: 'email' },
+    )
+
+    assert.strictEqual(mockCallTool.mock.calls.length, 1)
+    const callArgs = mockCallTool.mock.calls[0]
+    assert.deepStrictEqual(callArgs[0], {
+      name: 'discover_server_categories_or_actions',
+      arguments: { query: 'email' },
+    })
+    assert.ok(result.content)
+    assert.strictEqual(
+      (result.content as Array<{ type: string; text: string }>)[0].text,
+      'tool result',
+    )
+  })
+
+  it('callTool() when disconnected returns error result', async () => {
+    const klavisClient = createMockKlavisClient()
+    proxy = new KlavisMcpProxy(klavisClient, 'test-browseros-id')
+
+    const result = await proxy.callTool('some_tool', {})
+
+    assert.strictEqual(result.isError, true)
+    assert.strictEqual(
+      (result.content as Array<{ type: string; text: string }>)[0].text,
+      'Klavis MCP proxy is not connected',
+    )
+  })
+
+  it('refresh() triggers onToolsChanged when server set changes', async () => {
+    let callCount = 0
+    const klavisClient = createMockKlavisClient({
+      getUserIntegrations: mock(() => {
+        callCount++
+        if (callCount <= 1) {
+          return Promise.resolve([{ name: 'Gmail', isAuthenticated: true }])
+        }
+        return Promise.resolve([
+          { name: 'Gmail', isAuthenticated: true },
+          { name: 'Slack', isAuthenticated: true },
+        ])
+      }),
+    })
+
+    proxy = new KlavisMcpProxy(klavisClient, 'test-browseros-id')
+    await proxy.connect()
+
+    const onToolsChanged = mock(() => {})
+    proxy.onToolsChanged = onToolsChanged
+
+    await proxy.refresh()
+
+    // onToolsChanged is called both during reconnect (via connect()) and should be triggered
+    assert.ok(
+      onToolsChanged.mock.calls.length >= 1,
+      'onToolsChanged should have been called at least once',
+    )
+  })
+
+  it('refresh() is a no-op when server set is unchanged', async () => {
+    const klavisClient = createMockKlavisClient({
+      getUserIntegrations: mock(() =>
+        Promise.resolve([{ name: 'Gmail', isAuthenticated: true }]),
+      ),
+    })
+
+    proxy = new KlavisMcpProxy(klavisClient, 'test-browseros-id')
+    await proxy.connect()
+
+    const connectCallsBefore = mockConnect.mock.calls.length
+
+    const onToolsChanged = mock(() => {})
+    proxy.onToolsChanged = onToolsChanged
+
+    await proxy.refresh()
+
+    // Should not have reconnected
+    assert.strictEqual(mockConnect.mock.calls.length, connectCallsBefore)
+    assert.strictEqual(onToolsChanged.mock.calls.length, 0)
+  })
+
+  it('connect() failure is graceful', async () => {
+    const klavisClient = createMockKlavisClient({
+      getUserIntegrations: mock(() => {
+        throw new Error('Network error')
+      }),
+    })
+
+    proxy = new KlavisMcpProxy(klavisClient, 'test-browseros-id')
+
+    // Should not throw
+    await proxy.connect()
+
+    assert.strictEqual(proxy.isConnected(), false)
+    assert.deepStrictEqual(proxy.getTools(), [])
+  })
+})

--- a/packages/shared/src/constants/timeouts.ts
+++ b/packages/shared/src/constants/timeouts.ts
@@ -25,6 +25,12 @@ export const TIMEOUTS = {
   // External API calls
   KLAVIS_FETCH: 30_000,
 
+  // Upstream MCP proxy (Klavis Strata)
+  MCP_UPSTREAM_CONNECT: 10_000,
+  MCP_UPSTREAM_TOOL_CALL: 60_000,
+  MCP_UPSTREAM_LIST_TOOLS: 10_000,
+  MCP_UPSTREAM_REFRESH_INTERVAL: 300_000, // 5 minutes
+
   // Navigation/DOM
   NAVIGATION: 10_000,
   PAGE_LOAD_WAIT: 30_000,


### PR DESCRIPTION
## Summary
if lets say user has connected MCP servers with klavis, we want it to accessible over browserOS MCP, so basically this will make only 1 mcp url then, if we can merge klavis to browseros mcp itself

## Changes
```
apps/server/src/api/routes/chat.ts             |   3 -
 apps/server/src/api/routes/klavis.ts           |  25 ++-
 apps/server/src/api/routes/mcp.ts              |  39 +++-
 apps/server/src/api/server.ts                  |   7 +-
 apps/server/src/api/services/chat-service.ts   |  28 +--
 apps/server/src/api/types.ts                   |   4 +
 apps/server/src/lib/klavis-mcp-proxy.ts        | 176 ++++++++++++++++++
 apps/server/src/main.ts                        |  16 +-
 apps/server/tests/lib/klavis-mcp-proxy.test.ts | 242 +++++++++++++++++++++++++
 packages/shared/src/constants/timeouts.ts      |   6 +
 10 files changed, 510 insertions(+), 36 deletions(-)
```

## Agent Metadata
- Total cost: $12.6568
- Stages:
  - ok setup ($0.0000, 43.0s)
  - ok plan ($6.4311, 1011.1s)
  - ok implement ($6.2257, 958.6s)

---
*Generated by coding-agent v3*