### PR TITLE
fix: hub provider list goes stale after add then delete

### DIFF
--- a/apps/agent/lib/llm-hub/useLlmHubProviders.ts
+++ b/apps/agent/lib/llm-hub/useLlmHubProviders.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   DEFAULT_PROVIDERS,
   type LlmHubProvider,
@@ -34,36 +34,28 @@ export function useLlmHubProviders(): UseLlmHubProvidersReturn {
     load()
   }, [])
 
-  const saveProvider = useCallback(
-    async (provider: LlmHubProvider, editIndex?: number) => {
-      const isEdit = editIndex !== undefined && editIndex >= 0
-      const updatedProviders = isEdit
-        ? providers.map((p, i) => (i === editIndex ? provider : p))
-        : [...providers, provider]
+  const saveProvider = async (provider: LlmHubProvider, editIndex?: number) => {
+    const currentProviders = await loadProviders()
+    const isEdit = editIndex !== undefined && editIndex >= 0
+    const updatedProviders = isEdit
+      ? currentProviders.map((p, i) => (i === editIndex ? provider : p))
+      : [...currentProviders, provider]
 
-      const prev = providers
-      setProviders(updatedProviders)
+    setProviders(updatedProviders)
+    const success = await saveProviders(updatedProviders)
+    if (!success) setProviders(currentProviders)
+  }
 
-      const success = await saveProviders(updatedProviders)
-      if (!success) setProviders(prev)
-    },
-    [providers],
-  )
+  const deleteProvider = async (index: number) => {
+    const currentProviders = await loadProviders()
+    if (currentProviders.length <= 1) return
 
-  const deleteProvider = useCallback(
-    async (index: number) => {
-      if (providers.length <= 1) return
+    const updatedProviders = currentProviders.filter((_, i) => i !== index)
 
-      const updatedProviders = providers.filter((_, i) => i !== index)
-      const prev = providers
-
-      setProviders(updatedProviders)
-
-      const success = await saveProviders(updatedProviders)
-      if (!success) setProviders(prev)
-    },
-    [providers],
-  )
+    setProviders(updatedProviders)
+    const success = await saveProviders(updatedProviders)
+    if (!success) setProviders(currentProviders)
+  }
 
   return {
     providers,


### PR DESCRIPTION
## Summary
- Fixed a stale closure bug in `useLlmHubProviders` hook where `saveProvider` and `deleteProvider` used `useCallback` with a `[providers]` dependency, causing the delete callback to reference an outdated providers array after an add operation
- Now reads current state from storage (`loadProviders()`) before each mutation, matching the pattern used in `useLlmProviders`
- Removed unnecessary `useCallback` wrappers per project conventions

## Root Cause
When a user added a new provider and then deleted an older one, the `deleteProvider` callback's closure still held the **pre-add** providers array. The filter operation would produce a list missing the newly added provider, which then got persisted to storage — effectively losing the new provider.

## Test plan
- [ ] Add a new LLM hub provider (e.g. Kimi)
- [ ] Without refreshing, delete one of the existing providers
- [ ] Verify the newly added provider still appears in both the settings list and the Chat panel dropdown
- [ ] Verify editing an existing provider still works correctly
- [ ] Verify that if save fails, the UI rolls back to the correct previous state

🤖 Generated with [Claude Code](https://claude.com/claude-code)