### PR TITLE
feat: add stop button to page when agent is running

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -29,6 +29,7 @@ import { GetConversationWithMessagesDocument } from './graphql/chatSessionDocume
 import { useChatRefs } from './useChatRefs'
 import { useNotifyActiveTab } from './useNotifyActiveTab'
 import { useRemoteConversationSave } from './useRemoteConversationSave'
+import { useStopFromContentScript } from './useStopFromContentScript'
 
 const getLastMessageText = (messages: UIMessage[]) => {
   const lastMessage = messages[messages.length - 1]
@@ -297,6 +298,11 @@ export const useChatSession = () => {
     messages,
     status,
     conversationId: conversationIdRef.current,
+  })
+
+  useStopFromContentScript({
+    conversationId: conversationIdRef.current,
+    stop,
   })
 
   const {

--- a/apps/agent/entrypoints/sidepanel/index/useStopFromContentScript.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useStopFromContentScript.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import { CONTENT_SCRIPT_STOP_CLICKED_EVENT } from '@/lib/constants/analyticsEvents'
+import { track } from '@/lib/metrics/track'
+
+interface StopAgentMessage {
+  type: 'BROWSEROS_STOP_AGENT'
+  conversationId: string
+}
+
+function isStopAgentMessage(message: unknown): message is StopAgentMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    (message as StopAgentMessage).type === 'BROWSEROS_STOP_AGENT' &&
+    typeof (message as StopAgentMessage).conversationId === 'string'
+  )
+}
+
+export const useStopFromContentScript = ({
+  conversationId,
+  stop,
+}: {
+  conversationId: string
+  stop: () => void
+}) => {
+  useEffect(() => {
+    const listener = (message: unknown) => {
+      if (!isStopAgentMessage(message)) return
+      if (message.conversationId !== conversationId) return
+
+      track(CONTENT_SCRIPT_STOP_CLICKED_EVENT)
+      stop()
+    }
+
+    chrome.runtime.onMessage.addListener(listener)
+    return () => chrome.runtime.onMessage.removeListener(listener)
+  }, [conversationId, stop])
+}

--- a/apps/agent/lib/constants/analyticsEvents.ts
+++ b/apps/agent/lib/constants/analyticsEvents.ts
@@ -157,3 +157,7 @@ export const SCHEDULED_TASK_RETRIED_EVENT = 'settings.scheduled_task.retried'
 
 /** @public */
 export const JTBD_POPUP_DISMISSED_EVENT = 'ui.jtbd_popup.dismissed'
+
+/** @public */
+export const CONTENT_SCRIPT_STOP_CLICKED_EVENT =
+  'content_script.generation.stopped'


### PR DESCRIPTION
## Summary
- Injects a minimal stop button (dark pill with stop icon) at bottom-center of the viewport alongside the existing orange glow when the agent is streaming
- Clicking the button sends a `chrome.runtime.sendMessage` to the sidepanel, which calls the existing `stop()` from `useChat` to abort the agent
- Button shares the exact lifecycle of the glow overlay (appears/disappears on streaming start/stop, tab switch, visibility change)

## Design
Extends the existing `glow.content/index.ts` content script rather than creating a new one. The stop button is injected alongside the glow overlay in `startGlow()` and removed in `stopGlow()`. A new `useStopFromContentScript` hook in the sidepanel listens for the stop message and triggers the abort. Analytics event `content_script.generation.stopped` is tracked when stop is triggered from the page.

## Files changed
- `apps/agent/entrypoints/glow.content/index.ts` — Stop button DOM injection, styles, and click handler
- `apps/agent/entrypoints/sidepanel/index/useStopFromContentScript.ts` — New hook to listen for stop messages
- `apps/agent/entrypoints/sidepanel/index/useChatSession.ts` — Wire up the new hook
- `apps/agent/lib/constants/analyticsEvents.ts` — New analytics event constant

## Test plan
- [ ] Start a chat with the agent in agent mode, trigger a browser action
- [ ] Verify the stop button appears at bottom-center of the page alongside the orange glow
- [ ] Click the stop button and verify the agent stops (streaming ends)
- [ ] Verify the stop button disappears when the agent stops
- [ ] Verify the stop button disappears on tab switch and page navigation
- [ ] Verify the button has hover/active states and fade-in animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)