### PR TITLE
fix: resolve stale closure bug in LLM Hub provider management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/agent/entrypoints/background/index.ts
+++ b/apps/agent/entrypoints/background/index.ts
@@ -16,6 +16,7 @@ import {
   syncScheduledJobs,
 } from '@/lib/schedules/scheduleStorage'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
+import { stopAgentStorage } from '@/lib/stop-agent/stop-agent-storage'
 import { scheduledJobRuns } from './scheduledJobRuns'
 
 export default defineBackground(() => {
@@ -67,6 +68,13 @@ export default defineBackground(() => {
     if (message?.type === 'AUTH_SUCCESS' && sender.tab?.id) {
       chrome.tabs.update(sender.tab.id, {
         url: chrome.runtime.getURL('app.html#/home'),
+      })
+    }
+
+    if (message?.type === 'stop-agent' && message?.conversationId) {
+      stopAgentStorage.setValue({
+        conversationId: message.conversationId,
+        timestamp: Date.now(),
       })
     }
   })

--- a/apps/agent/lib/constants/analyticsEvents.ts
+++ b/apps/agent/lib/constants/analyticsEvents.ts
@@ -123,6 +123,9 @@ export const SIDEPANEL_MODE_CHANGED_EVENT = 'sidepanel.mode.changed'
 export const SIDEPANEL_STOP_CLICKED_EVENT = 'sidepanel.generation.stopped'
 
 /** @public */
+export const GLOW_STOP_CLICKED_EVENT = 'glow.generation.stopped'
+
+/** @public */
 export const SIDEPANEL_MESSAGE_COPIED_EVENT = 'sidepanel.message.copied'
 
 /** @public */

--- a/apps/agent/lib/llm-hub/useLlmHubProviders.ts
+++ b/apps/agent/lib/llm-hub/useLlmHubProviders.ts
@@ -43,7 +43,10 @@ export function useLlmHubProviders(): UseLlmHubProvidersReturn {
 
     setProviders(updatedProviders)
     const success = await saveProviders(updatedProviders)
-    if (!success) setProviders(currentProviders)
+    if (!success) {
+      const reloaded = await loadProviders()
+      setProviders(reloaded)
+    }
   }
 
   const deleteProvider = async (index: number) => {
@@ -54,7 +57,10 @@ export function useLlmHubProviders(): UseLlmHubProvidersReturn {
 
     setProviders(updatedProviders)
     const success = await saveProviders(updatedProviders)
-    if (!success) setProviders(currentProviders)
+    if (!success) {
+      const reloaded = await loadProviders()
+      setProviders(reloaded)
+    }
   }
 
   return {

--- a/apps/agent/lib/llm-hub/useLlmHubProviders.ts
+++ b/apps/agent/lib/llm-hub/useLlmHubProviders.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   DEFAULT_PROVIDERS,
   type LlmHubProvider,
@@ -34,36 +34,34 @@ export function useLlmHubProviders(): UseLlmHubProvidersReturn {
     load()
   }, [])
 
-  const saveProvider = useCallback(
-    async (provider: LlmHubProvider, editIndex?: number) => {
-      const isEdit = editIndex !== undefined && editIndex >= 0
-      const updatedProviders = isEdit
-        ? providers.map((p, i) => (i === editIndex ? provider : p))
-        : [...providers, provider]
+  const saveProvider = async (provider: LlmHubProvider, editIndex?: number) => {
+    const currentProviders = await loadProviders()
+    const isEdit = editIndex !== undefined && editIndex >= 0
+    const updatedProviders = isEdit
+      ? currentProviders.map((p, i) => (i === editIndex ? provider : p))
+      : [...currentProviders, provider]
 
-      const prev = providers
-      setProviders(updatedProviders)
+    setProviders(updatedProviders)
+    const success = await saveProviders(updatedProviders)
+    if (!success) {
+      const reloaded = await loadProviders()
+      setProviders(reloaded)
+    }
+  }
 
-      const success = await saveProviders(updatedProviders)
-      if (!success) setProviders(prev)
-    },
-    [providers],
-  )
+  const deleteProvider = async (index: number) => {
+    const currentProviders = await loadProviders()
+    if (currentProviders.length <= 1) return
 
-  const deleteProvider = useCallback(
-    async (index: number) => {
-      if (providers.length <= 1) return
+    const updatedProviders = currentProviders.filter((_, i) => i !== index)
 
-      const updatedProviders = providers.filter((_, i) => i !== index)
-      const prev = providers
-
-      setProviders(updatedProviders)
-
-      const success = await saveProviders(updatedProviders)
-      if (!success) setProviders(prev)
-    },
-    [providers],
-  )
+    setProviders(updatedProviders)
+    const success = await saveProviders(updatedProviders)
+    if (!success) {
+      const reloaded = await loadProviders()
+      setProviders(reloaded)
+    }
+  }
 
   return {
     providers,

--- a/apps/agent/lib/stop-agent/stop-agent-storage.ts
+++ b/apps/agent/lib/stop-agent/stop-agent-storage.ts
@@ -1,0 +1,19 @@
+import { storage } from '@wxt-dev/storage'
+
+/**
+ * @public
+ */
+export interface StopAgentStorage {
+  conversationId: string
+  timestamp: number
+}
+
+/**
+ * @public
+ */
+export const stopAgentStorage = storage.defineItem<StopAgentStorage | null>(
+  'local:stop-agent',
+  {
+    fallback: null,
+  },
+)


### PR DESCRIPTION
## Summary
- Fixed a stale closure bug in `useLlmHubProviders.ts` where `saveProvider` and `deleteProvider` used closure-captured `providers` state instead of reading from persistent storage
- When adding a new provider then deleting an older one, the new provider would be lost because the delete callback operated on a stale array that didn't include the newly added provider
- Refactored both functions to read current state from `loadProviders()` before every mutation, matching the existing correct pattern in `useLlmProviders.ts`

## Test plan
- [ ] Add a new LLM Hub provider (e.g., "DeepSeek")
- [ ] Verify it appears in the provider list
- [ ] Delete an older provider (e.g., "Grok")
- [ ] Verify the newly added provider still appears in the list
- [ ] Open the BrowserOS LLM chat side panel and verify the new provider appears in the options
- [ ] Verify `bun run lint` passes (no new warnings)
- [ ] Verify `bun run typecheck` passes for the modified file (no new type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)