### PR TITLE
feat: inject stop button to pages controlled by agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ log.txt
 
 # Testing iteration temp files
 tmp/
+
+# Coding agent artifacts
+.agent/

--- a/apps/agent/entrypoints/background/index.ts
+++ b/apps/agent/entrypoints/background/index.ts
@@ -16,6 +16,7 @@ import {
   syncScheduledJobs,
 } from '@/lib/schedules/scheduleStorage'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
+import { stopAgentStorage } from '@/lib/stop-agent/stop-agent-storage'
 import { scheduledJobRuns } from './scheduledJobRuns'
 
 export default defineBackground(() => {
@@ -67,6 +68,13 @@ export default defineBackground(() => {
     if (message?.type === 'AUTH_SUCCESS' && sender.tab?.id) {
       chrome.tabs.update(sender.tab.id, {
         url: chrome.runtime.getURL('app.html#/home'),
+      })
+    }
+
+    if (message?.type === 'stop-agent' && message?.conversationId) {
+      stopAgentStorage.setValue({
+        conversationId: message.conversationId,
+        timestamp: Date.now(),
       })
     }
   })

--- a/apps/agent/entrypoints/glow.content/index.ts
+++ b/apps/agent/entrypoints/glow.content/index.ts
@@ -2,9 +2,12 @@ import type { GlowMessage } from './GlowMessage'
 
 const GLOW_OVERLAY_ID = 'browseros-glow-overlay'
 const GLOW_STYLES_ID = 'browseros-glow-styles'
+const GLOW_STOP_BTN_ID = 'browseros-glow-stop-btn'
 
 const GLOW_THICKNESS = 1.0
 const GLOW_OPACITY = 0.6
+
+let activeConversationId: string | null = null
 
 function injectStyles(): void {
   if (document.getElementById(GLOW_STYLES_ID)) {
@@ -45,6 +48,11 @@ function injectStyles(): void {
       to { opacity: ${GLOW_OPACITY}; }
     }
 
+    @keyframes browseros-glow-btn-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
     #${GLOW_OVERLAY_ID} {
       position: fixed !important;
       top: 0 !important;
@@ -58,6 +66,35 @@ function injectStyles(): void {
       animation:
         browseros-glow-pulse 3s ease-in-out infinite,
         browseros-glow-fade-in 420ms cubic-bezier(0.22, 1, 0.36, 1) forwards !important;
+    }
+
+    #${GLOW_STOP_BTN_ID} {
+      position: fixed !important;
+      bottom: 24px !important;
+      left: 50% !important;
+      transform: translateX(-50%) !important;
+      width: 32px !important;
+      height: 32px !important;
+      border-radius: 50% !important;
+      background: rgba(251, 102, 24, 0.9) !important;
+      color: white !important;
+      border: none !important;
+      pointer-events: auto !important;
+      cursor: pointer !important;
+      z-index: 2147483647 !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      font-size: 10px !important;
+      line-height: 1 !important;
+      padding: 0 !important;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2) !important;
+      opacity: 0;
+      animation: browseros-glow-btn-fade-in 420ms cubic-bezier(0.22, 1, 0.36, 1) forwards !important;
+    }
+
+    #${GLOW_STOP_BTN_ID}:hover {
+      background: rgba(251, 102, 24, 1) !important;
     }
   `
   const appendStyle = () => document.head.appendChild(style)
@@ -75,6 +112,20 @@ function startGlow(): void {
 
   const overlay = document.createElement('div')
   overlay.id = GLOW_OVERLAY_ID
+
+  const button = document.createElement('button')
+  button.id = GLOW_STOP_BTN_ID
+  button.textContent = '\u25A0'
+  button.addEventListener('click', () => {
+    if (activeConversationId) {
+      browser.runtime.sendMessage({
+        type: 'stop-agent',
+        conversationId: activeConversationId,
+      })
+    }
+  })
+
+  overlay.appendChild(button)
 
   const appendOverlay = () => document.body.appendChild(overlay)
 
@@ -96,8 +147,6 @@ export default defineContentScript({
   matches: ['*://*/*'],
   runAt: 'document_start',
   main() {
-    let activeConversationId: string | null = null
-
     browser.runtime.onMessage.addListener(
       (message: GlowMessage, _sender, sendResponse) => {
         if (

--- a/apps/agent/entrypoints/glow.content/index.ts
+++ b/apps/agent/entrypoints/glow.content/index.ts
@@ -73,10 +73,10 @@ function injectStyles(): void {
       bottom: 24px !important;
       left: 50% !important;
       transform: translateX(-50%) !important;
-      width: 32px !important;
-      height: 32px !important;
+      width: 48px !important;
+      height: 48px !important;
       border-radius: 50% !important;
-      background: rgba(251, 102, 24, 0.9) !important;
+      background: rgba(220, 38, 38, 0.95) !important;
       color: white !important;
       border: none !important;
       pointer-events: auto !important;
@@ -85,16 +85,15 @@ function injectStyles(): void {
       display: flex !important;
       align-items: center !important;
       justify-content: center !important;
-      font-size: 10px !important;
       line-height: 1 !important;
       padding: 0 !important;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2) !important;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3) !important;
       opacity: 0;
       animation: browseros-glow-btn-fade-in 420ms cubic-bezier(0.22, 1, 0.36, 1) forwards !important;
     }
 
     #${GLOW_STOP_BTN_ID}:hover {
-      background: rgba(251, 102, 24, 1) !important;
+      background: rgba(185, 28, 28, 1) !important;
     }
   `
   const appendStyle = () => document.head.appendChild(style)
@@ -115,7 +114,8 @@ function startGlow(): void {
 
   const button = document.createElement('button')
   button.id = GLOW_STOP_BTN_ID
-  button.textContent = '\u25A0'
+  button.innerHTML =
+    '<svg width="16" height="16" viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="1" width="14" height="14" rx="2"/></svg>'
   button.addEventListener('click', () => {
     if (activeConversationId) {
       browser.runtime.sendMessage({

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -9,6 +9,7 @@ import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
 import type { ChatAction } from '@/lib/chat-actions/types'
 import {
   CONVERSATION_RESET_EVENT,
+  GLOW_STOP_CLICKED_EVENT,
   MESSAGE_DISLIKE_EVENT,
   MESSAGE_LIKE_EVENT,
   MESSAGE_SENT_EVENT,
@@ -23,6 +24,7 @@ import { useGraphqlQuery } from '@/lib/graphql/useGraphqlQuery'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { track } from '@/lib/metrics/track'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
+import { stopAgentStorage } from '@/lib/stop-agent/stop-agent-storage'
 import { selectedWorkspaceStorage } from '@/lib/workspace/workspace-storage'
 import type { ChatMode } from './chatTypes'
 import { GetConversationWithMessagesDocument } from './graphql/chatSessionDocument'
@@ -395,6 +397,17 @@ export const useChatSession = () => {
       if (storageAction) {
         setMode(storageAction.mode)
         sendMessage({ text: storageAction.query, action: storageAction.action })
+      }
+    })
+    return () => unwatch()
+  }, [])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only need to run this once
+  useEffect(() => {
+    const unwatch = stopAgentStorage.watch((signal) => {
+      if (signal && signal.conversationId === conversationIdRef.current) {
+        stop()
+        track(GLOW_STOP_CLICKED_EVENT)
       }
     })
     return () => unwatch()

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -408,6 +408,7 @@ export const useChatSession = () => {
       if (signal && signal.conversationId === conversationIdRef.current) {
         stop()
         track(GLOW_STOP_CLICKED_EVENT)
+        stopAgentStorage.setValue(null)
       }
     })
     return () => unwatch()

--- a/apps/agent/lib/constants/analyticsEvents.ts
+++ b/apps/agent/lib/constants/analyticsEvents.ts
@@ -123,6 +123,9 @@ export const SIDEPANEL_MODE_CHANGED_EVENT = 'sidepanel.mode.changed'
 export const SIDEPANEL_STOP_CLICKED_EVENT = 'sidepanel.generation.stopped'
 
 /** @public */
+export const GLOW_STOP_CLICKED_EVENT = 'glow.generation.stopped'
+
+/** @public */
 export const SIDEPANEL_MESSAGE_COPIED_EVENT = 'sidepanel.message.copied'
 
 /** @public */

--- a/apps/agent/lib/stop-agent/stop-agent-storage.ts
+++ b/apps/agent/lib/stop-agent/stop-agent-storage.ts
@@ -11,5 +11,9 @@ export interface StopAgentStorage {
 /**
  * @public
  */
-export const stopAgentStorage =
-  storage.defineItem<StopAgentStorage>('local:stop-agent')
+export const stopAgentStorage = storage.defineItem<StopAgentStorage | null>(
+  'local:stop-agent',
+  {
+    fallback: null,
+  },
+)

--- a/apps/agent/lib/stop-agent/stop-agent-storage.ts
+++ b/apps/agent/lib/stop-agent/stop-agent-storage.ts
@@ -1,0 +1,15 @@
+import { storage } from '@wxt-dev/storage'
+
+/**
+ * @public
+ */
+export interface StopAgentStorage {
+  conversationId: string
+  timestamp: number
+}
+
+/**
+ * @public
+ */
+export const stopAgentStorage =
+  storage.defineItem<StopAgentStorage>('local:stop-agent')


### PR DESCRIPTION
## Summary
When the agent is running, right now we inject an orange glow. See the `apps/agent` code. Similar to that also inject a stop button so that we can stop the agent. Read through the code thoroughly and implement this feature. The stop button should be very minimal.

## Changes
```
apps/agent/entrypoints/background/index.ts         |  8 ++++
 apps/agent/entrypoints/glow.content/index.ts       | 53 +++++++++++++++++++++-
 .../entrypoints/sidepanel/index/useChatSession.ts  | 13 ++++++
 apps/agent/lib/constants/analyticsEvents.ts        |  3 ++
 apps/agent/lib/stop-agent/stop-agent-storage.ts    | 15 ++++++
 5 files changed, 90 insertions(+), 2 deletions(-)
```

## Agent Metadata
- Total cost: $9.4723
- Stages:
  - ok setup ($0.0000, 39.2s)
  - ok plan ($1.9984, 362.7s)
  - ok implement ($2.4027, 3620.2s)

---
*Generated by coding-agent v3*