### PR TITLE
fix: stabilize Klavis MCP connection/auth compatibility

### DIFF
--- a/apps/server/tests/api/routes/klavis.test.ts
+++ b/apps/server/tests/api/routes/klavis.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, it } from 'bun:test'
+import assert from 'node:assert'
+import { createKlavisRoutes } from '../../../src/api/routes/klavis'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('createKlavisRoutes', () => {
+  it('normalizes string integrations into authenticated entries', async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        integrations: ['Google Docs', 'Slack'],
+      })) as typeof fetch
+
+    const route = createKlavisRoutes({ browserosId: 'user-123' })
+    const response = await route.request('/user-integrations')
+    const body = await response.json()
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(body, {
+      integrations: [
+        { name: 'Google Docs', is_authenticated: true },
+        { name: 'Slack', is_authenticated: true },
+      ],
+      count: 2,
+    })
+  })
+
+  it('supports object integrations with mixed auth flag formats', async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        integrations: [
+          { name: 'Google Docs', isAuthenticated: false },
+          { name: 'Slack', is_authenticated: true },
+        ],
+      })) as typeof fetch
+
+    const route = createKlavisRoutes({ browserosId: 'user-123' })
+    const response = await route.request('/user-integrations')
+    const body = await response.json()
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(body, {
+      integrations: [
+        { name: 'Google Docs', is_authenticated: false },
+        { name: 'Slack', is_authenticated: true },
+      ],
+      count: 2,
+    })
+  })
+
+  it('resolves auth URLs with normalized server name keys', async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        strataServerUrl: 'https://strata.example.com',
+        strataId: 'strata-123',
+        addedServers: ['Google Docs'],
+        oauthUrls: { google_docs: 'https://oauth.example.com/google-docs' },
+        apiKeyUrls: {
+          google_docs: 'https://auth.example.com/setup?instance_id=abc123',
+        },
+      })) as typeof fetch
+
+    const route = createKlavisRoutes({ browserosId: 'user-123' })
+    const response = await route.request('/servers/add', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ serverName: 'Google Docs' }),
+    })
+    const body = await response.json()
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(body, {
+      success: true,
+      serverName: 'Google Docs',
+      strataId: 'strata-123',
+      addedServers: ['Google Docs'],
+      oauthUrl: 'https://oauth.example.com/google-docs',
+      apiKeyUrl: 'https://auth.example.com/setup?instance_id=abc123',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Normalize Klavis integration responses so BrowserOS handles both string-only and object-based payload variants.
- Stabilize `/klavis/user-integrations` with a consistent auth-status DTO used by the agent UI.
- Make auth URL extraction from `createStrata` resilient to key-format differences (exact + normalized lookup).

## Design
This PR adds a compatibility boundary in the server Klavis client and routes. `getUserIntegrations` now normalizes mixed Klavis payload shapes into a single internal model, while `/klavis/user-integrations` returns a stable `is_authenticated` field for the existing agent UI flow. In `/klavis/servers/add`, auth URL lookups now tolerate naming-format differences (for example, `Google Docs` vs `google_docs`) to prevent false "failed to connect" outcomes when URLs exist.

## Test plan
- `bun --env-file=.env.development test apps/server/tests/api/routes/klavis.test.ts`
- `bun run --filter @browseros/server typecheck`
- `bunx biome check apps/server/src/lib/clients/klavis/klavis-client.ts apps/server/src/api/routes/klavis.ts apps/server/tests/api/routes/klavis.test.ts`
- `bun run --filter @browseros/server test` (currently fails in existing suite due environment/dependency issues unrelated to this patch, including missing `sinon` in `tests/common/mcp-context.test.ts`)
