### PR TITLE
fix: add scroll support to dialog when content overflows

### DIFF
--- a/apps/agent/components/ui/dialog.tsx
+++ b/apps/agent/components/ui/dialog.tsx
@@ -76,7 +76,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:max-w-lg',
+          'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[85vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:max-w-lg',
           className,
         )}
         {...props}


### PR DESCRIPTION
Added max-h-[85vh] and overflow-y-auto to DialogContent component to enable scrolling when dialog content exceeds viewport height. This fixes the scheduled task dialog not showing scroll when content is too long.

https://claude.ai/code/session_01CP8aUnunJpW9mYwTbt3gpt