### PR TITLE
feat: move connect apps to main sidebar

### DIFF
--- a/apps/agent/components/elements/AppSelector.tsx
+++ b/apps/agent/components/elements/AppSelector.tsx
@@ -212,7 +212,7 @@ export const AppSelector: FC<AppSelectorProps> = ({
                       type="button"
                       onClick={() => {
                         const appUrl = chrome.runtime.getURL(
-                          '/app.html#/settings/connect-mcp',
+                          '/app.html#/connect-apps',
                         )
                         window.open(appUrl, '_blank')
                         setOpen(false)

--- a/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -5,7 +5,6 @@ import {
   Info,
   MessageSquare,
   Palette,
-  PlugZap,
   RotateCcw,
   Server,
 } from 'lucide-react'
@@ -26,12 +25,6 @@ type NavItem = {
 const settingsNavItems: NavItem[] = [
   { name: 'BrowserOS AI', to: '/settings/ai', icon: Bot },
   { name: 'LLM Chat & Hub', to: '/settings/chat', icon: MessageSquare },
-  {
-    name: 'Connect Apps',
-    to: '/settings/connect-mcp',
-    icon: PlugZap,
-    feature: Feature.MANAGED_MCP_SUPPORT,
-  },
   { name: 'BrowserOS as MCP', to: '/settings/mcp', icon: Server },
   {
     name: 'Customization',

--- a/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -1,4 +1,11 @@
-import { CalendarClock, GitBranch, Home, Settings, UserPen } from 'lucide-react'
+import {
+  CalendarClock,
+  GitBranch,
+  Home,
+  PlugZap,
+  Settings,
+  UserPen,
+} from 'lucide-react'
 import type { FC } from 'react'
 import { NavLink, useLocation } from 'react-router'
 import {
@@ -30,7 +37,13 @@ const primaryNavItems: NavItem[] = [
     icon: GitBranch,
     feature: Feature.WORKFLOW_SUPPORT,
   },
-  { name: 'Scheduled', to: '/scheduled', icon: CalendarClock },
+  { name: 'Scheduled Tasks', to: '/scheduled', icon: CalendarClock },
+  {
+    name: 'Connect Apps',
+    to: '/connect-apps',
+    icon: PlugZap,
+    feature: Feature.MANAGED_MCP_SUPPORT,
+  },
   {
     name: 'Personalize',
     to: '/home/personalize',

--- a/apps/agent/entrypoints/app/App.tsx
+++ b/apps/agent/entrypoints/app/App.tsx
@@ -39,7 +39,7 @@ const OptionsRedirect: FC = () => {
   const routeMap: Record<string, string> = {
     ai: '/settings/ai',
     chat: '/settings/chat',
-    'connect-mcp': '/settings/connect-mcp',
+    'connect-mcp': '/connect-apps',
     mcp: '/settings/mcp',
     customization: '/settings/customization',
     'jtbd-agent': '/settings/survey',
@@ -75,6 +75,7 @@ export const App: FC = () => {
           </Route>
 
           {/* Primary nav routes */}
+          <Route path="connect-apps" element={<ConnectMCP />} />
           <Route path="workflows" element={<WorkflowsPageWrapper />} />
           <Route path="scheduled" element={<ScheduledTasksPage />} />
         </Route>
@@ -85,7 +86,6 @@ export const App: FC = () => {
             <Route index element={<Navigate to="/settings/ai" replace />} />
             <Route path="ai" element={<AISettingsPage key="ai" />} />
             <Route path="chat" element={<LlmHubPage />} />
-            <Route path="connect-mcp" element={<ConnectMCP />} />
             <Route path="mcp" element={<MCPSettingsPage />} />
             <Route path="customization" element={<CustomizationPage />} />
             <Route path="survey" element={<SurveyPage {...surveyParams} />} />
@@ -107,6 +107,10 @@ export const App: FC = () => {
         <Route
           path="/personalize"
           element={<Navigate to="/home/personalize" replace />}
+        />
+        <Route
+          path="/settings/connect-mcp"
+          element={<Navigate to="/connect-apps" replace />}
         />
         <Route path="/options/*" element={<OptionsRedirect />} />
 


### PR DESCRIPTION
## Summary
- Add a first-class `Connect Apps` item to the main left sidebar, gated by managed MCP capability support.
- Rename the main sidebar label from `Scheduled` to `Scheduled Tasks` while preserving `/scheduled` route behavior.
- Move Connect Apps routing to `/connect-apps`, remove the settings-sidebar duplicate entry, and keep legacy redirects from `/settings/connect-mcp` and `/options/connect-mcp`.

## Design
This change promotes Connect Apps to a top-level navigation destination by reusing the existing `ConnectMCP` page under `SidebarLayout` at `/connect-apps`. The settings-only nav entry is removed to avoid duplicated IA, while backward compatibility is preserved through route redirects and updated internal deep links (App Selector `Manage apps`).

## Test plan
- `bunx biome check apps/agent/components/sidebar/SidebarNavigation.tsx apps/agent/components/sidebar/SettingsSidebar.tsx apps/agent/entrypoints/app/App.tsx apps/agent/components/elements/AppSelector.tsx`
- `bun run test` (fails in this environment due existing infra/CDP startup issues unrelated to changed files)
- Manual verification checklist:
  - Main sidebar shows `Workflows`, `Scheduled Tasks`, and `Connect Apps`.
  - `/connect-apps` renders the Connect Apps page.
  - `/settings/connect-mcp` and `/options/connect-mcp` redirect to `/connect-apps`.
  - App selector `Manage apps` opens `/app.html#/connect-apps`.
