### PR TITLE
fix: prevent browser caching of Klavis MCP servers list

### DIFF
--- a/apps/agent/entrypoints/app/connect-mcp/useGetMCPServersList.tsx
+++ b/apps/agent/entrypoints/app/connect-mcp/useGetMCPServersList.tsx
@@ -10,7 +10,9 @@ interface McpServerResponse {
 }
 
 const getAllManagedServers = async ([hostUrl]: [hostUrl: string]) => {
-  const response = await fetch(`${hostUrl}/klavis/servers`)
+  const response = await fetch(`${hostUrl}/klavis/servers`, {
+    cache: 'no-store',
+  })
   const servers = (await response.json()) as McpServerResponse
   return servers
 }
@@ -23,6 +25,7 @@ export const useGetMCPServersList = () => {
     getAllManagedServers,
     {
       keepPreviousData: true,
+      revalidateOnFocus: true,
     },
   )
 }

--- a/apps/server/src/api/routes/klavis.ts
+++ b/apps/server/src/api/routes/klavis.ts
@@ -49,6 +49,7 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
   // Chain route definitions for proper Hono RPC type inference
   return new Hono()
     .get('/servers', (c) => {
+      c.header('Cache-Control', 'no-store')
       return c.json({
         servers: OAUTH_MCP_SERVERS,
         count: OAUTH_MCP_SERVERS.length,


### PR DESCRIPTION
## Summary

- Fix new Klavis MCP servers not showing up for existing users after OTA updates
- Root cause: `/klavis/servers` endpoint had no `Cache-Control` headers, allowing browsers to serve stale cached responses
- Existing users' browsers would cache the old server list and never fetch the updated one

## Changes

**Backend (1 file):**
- `klavis.ts` — Added `Cache-Control: no-store` header to `/klavis/servers` endpoint to prevent browser caching

**Frontend (1 file):**
- `useGetMCPServersList.tsx` — Added `cache: 'no-store'` to fetch request and `revalidateOnFocus: true` to SWR config (matching the pattern used by `useGetUserMCPIntegrations`)

## Test plan

- [ ] Deploy the update and verify existing users now see all new MCP servers (Stripe, Brave Search, Exa, etc.) without needing to clear cache
- [ ] Verify the "Add built-in app" dialog shows the full list of servers
- [ ] Run `bun test` — all 3 Klavis route tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)