### PR TITLE
feat: assign daily limit survey users to random experiment buckets

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/ChatError.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatError.tsx
@@ -1,6 +1,18 @@
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import type { FC } from 'react'
+import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
+
+const SURVEY_DIRECTIONS = [
+  'competitor',
+  'switching',
+  'workflow',
+  'activation',
+] as const
+
+function pickRandomDirection(): string {
+  return SURVEY_DIRECTIONS[Math.floor(Math.random() * SURVEY_DIRECTIONS.length)]
+}
 
 interface ChatErrorProps {
   error: Error
@@ -55,6 +67,12 @@ export const ChatError: FC<ChatErrorProps> = ({ error, onRetry }) => {
     error.message,
   )
 
+  const surveyUrl = useMemo(
+    () =>
+      `/app.html?page=survey&maxTurns=20&experimentId=daily_limit_${pickRandomDirection()}#/settings/survey`,
+    [],
+  )
+
   const getTitle = () => {
     if (isRateLimit) return 'Daily limit reached'
     if (isConnectionError) return 'Connection failed'
@@ -90,7 +108,7 @@ export const ChatError: FC<ChatErrorProps> = ({ error, onRetry }) => {
           </a>
           {' or '}
           <a
-            href="/app.html?page=survey&maxTurns=20&experimentId=daily_limit#/settings/survey"
+            href={surveyUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="underline hover:text-foreground"


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `experimentId=daily_limit` in the daily limit error survey link with random bucket assignment
- Users are now randomly assigned to one of four survey directions: `daily_limit_competitor`, `daily_limit_switching`, `daily_limit_workflow`, `daily_limit_activation`
- Matches the same bucketing pattern used by the round 2 product survey (`useJtbdPopup`)

## Test plan
- [ ] Trigger daily limit error and verify the "take a quick survey" link has a randomized experimentId (e.g. `daily_limit_competitor`)
- [ ] Verify the survey page loads correctly with the new experimentId format
- [ ] Confirm bucket assignment is stable per component mount (doesn't change on re-renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)