### PR TITLE
feat: add Morpheus (mor.org) as LLM provider

### DIFF
--- a/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -55,6 +55,7 @@ const providerTypeEnum = z.enum([
   'lmstudio',
   'bedrock',
   'browseros',
+  'morpheus',
 ])
 
 /**

--- a/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -22,6 +22,7 @@ export interface ModelsData {
   lmstudio: ModelInfo[]
   bedrock: ModelInfo[]
   browseros: ModelInfo[]
+  morpheus: ModelInfo[]
 }
 
 /**
@@ -88,6 +89,14 @@ export const MODELS_DATA: ModelsData = {
   ],
   bedrock: [],
   browseros: [],
+  morpheus: [
+    { modelId: 'glm-5', contextLength: 131072 },
+    { modelId: 'kimi-k2.5', contextLength: 131072 },
+    { modelId: 'hermes-3-llama-3.1-405b', contextLength: 131072 },
+    { modelId: 'qwen3-235b', contextLength: 131072 },
+    { modelId: 'deepseek-r1-0528', contextLength: 131072 },
+    { modelId: 'llama-4-maverick', contextLength: 131072 },
+  ],
 }
 
 /**

--- a/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -112,6 +112,16 @@ export const providerTemplates: ProviderTemplate[] = [
     setupGuideUrl:
       'https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html',
   },
+  {
+    id: 'morpheus',
+    name: 'Morpheus',
+    defaultBaseUrl: 'https://api.mor.org/api/v1',
+    defaultModelId: 'glm-5',
+    supportsImages: false,
+    contextWindow: 131072,
+    apiKeyUrl: 'https://app.mor.org',
+    setupGuideUrl: 'https://apidocs.mor.org',
+  },
 ]
 
 /**
@@ -129,6 +139,7 @@ export const providerTypeOptions: { value: ProviderType; label: string }[] = [
   { value: 'lmstudio', label: 'LM Studio' },
   { value: 'bedrock', label: 'AWS Bedrock' },
   { value: 'browseros', label: 'BrowserOS' },
+  { value: 'morpheus', label: 'Morpheus' },
 ]
 
 /**
@@ -156,6 +167,7 @@ export const DEFAULT_BASE_URLS: Record<ProviderType, string> = {
   lmstudio: 'http://localhost:1234/v1',
   bedrock: '',
   browseros: '',
+  morpheus: 'https://api.mor.org/api/v1',
 }
 
 /**

--- a/apps/agent/lib/llm-providers/types.ts
+++ b/apps/agent/lib/llm-providers/types.ts
@@ -13,6 +13,7 @@ export type ProviderType =
   | 'lmstudio'
   | 'bedrock'
   | 'browseros'
+  | 'morpheus'
 
 /**
  * LLM Provider configuration

--- a/apps/server/src/agent/tool-loop/provider-factory.ts
+++ b/apps/server/src/agent/tool-loop/provider-factory.ts
@@ -136,6 +136,17 @@ function createOpenAICompatibleFactory(
   })
 }
 
+function createMorpheusFactory(
+  config: ResolvedAgentConfig,
+): (modelId: string) => unknown {
+  if (!config.apiKey) throw new Error('Morpheus provider requires apiKey')
+  return createOpenAICompatible({
+    name: 'morpheus',
+    baseURL: config.baseUrl || 'https://api.mor.org/api/v1',
+    apiKey: config.apiKey,
+  })
+}
+
 const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.ANTHROPIC]: createAnthropicFactory,
   [LLM_PROVIDERS.OPENAI]: createOpenAIFactory,
@@ -147,6 +158,7 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.BEDROCK]: createBedrockFactory,
   [LLM_PROVIDERS.BROWSEROS]: createBrowserOSFactory,
   [LLM_PROVIDERS.OPENAI_COMPATIBLE]: createOpenAICompatibleFactory,
+  [LLM_PROVIDERS.MORPHEUS]: createMorpheusFactory,
 }
 
 export function createLanguageModel(

--- a/apps/server/src/lib/clients/llm/provider.ts
+++ b/apps/server/src/lib/clients/llm/provider.ts
@@ -124,6 +124,15 @@ function createOpenAICompatibleModel(config: ResolvedLLMConfig): LanguageModel {
   })(config.model)
 }
 
+function createMorpheusModel(config: ResolvedLLMConfig): LanguageModel {
+  if (!config.apiKey) throw new Error('Morpheus provider requires apiKey')
+  return createOpenAICompatible({
+    name: 'morpheus',
+    baseURL: config.baseUrl || 'https://api.mor.org/api/v1',
+    apiKey: config.apiKey,
+  })(config.model)
+}
+
 const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.ANTHROPIC]: createAnthropicModel,
   [LLM_PROVIDERS.OPENAI]: createOpenAIModel,
@@ -135,6 +144,7 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.BEDROCK]: createBedrockModel,
   [LLM_PROVIDERS.BROWSEROS]: createBrowserOSModel,
   [LLM_PROVIDERS.OPENAI_COMPATIBLE]: createOpenAICompatibleModel,
+  [LLM_PROVIDERS.MORPHEUS]: createMorpheusModel,
 }
 
 export function createLLMProvider(config: ResolvedLLMConfig): LanguageModel {

--- a/packages/shared/src/schemas/llm.ts
+++ b/packages/shared/src/schemas/llm.ts
@@ -23,6 +23,7 @@ export const LLM_PROVIDERS = {
   BEDROCK: 'bedrock',
   BROWSEROS: 'browseros',
   OPENAI_COMPATIBLE: 'openai-compatible',
+  MORPHEUS: 'morpheus',
 } as const
 
 /**
@@ -40,6 +41,7 @@ export const LLMProviderSchema: z.ZodEnum<
     'bedrock',
     'browseros',
     'openai-compatible',
+    'morpheus',
   ]
 > = z.enum([
   LLM_PROVIDERS.ANTHROPIC,
@@ -52,6 +54,7 @@ export const LLMProviderSchema: z.ZodEnum<
   LLM_PROVIDERS.BEDROCK,
   LLM_PROVIDERS.BROWSEROS,
   LLM_PROVIDERS.OPENAI_COMPATIBLE,
+  LLM_PROVIDERS.MORPHEUS,
 ])
 
 export type LLMProvider = z.infer<typeof LLMProviderSchema>


### PR DESCRIPTION
## Summary

Adds [Morpheus](https://mor.org) decentralized AI compute as a provider option in BrowserOS. Morpheus exposes an OpenAI-compatible API at `api.mor.org` with 30+ models including GLM-5, Kimi K2.5, Hermes 3 Llama 3.1 405B, Qwen3-235B, DeepSeek R1, and Llama 4 Maverick.

### Changes (7 files, +48 lines)

- **`packages/shared/src/schemas/llm.ts`** — Added `MORPHEUS: 'morpheus'` to `LLM_PROVIDERS` constant and `LLMProviderSchema` Zod enum
- **`apps/server/src/agent/tool-loop/provider-factory.ts`** — Added `createMorpheusFactory` using `@ai-sdk/openai-compatible`
- **`apps/server/src/lib/clients/llm/provider.ts`** — Added `createMorpheusModel` using `@ai-sdk/openai-compatible`
- **`apps/agent/lib/llm-providers/types.ts`** — Added `'morpheus'` to `ProviderType` union
- **`apps/agent/lib/llm-providers/providerTemplates.ts`** — Added Morpheus template, dropdown option, and default base URL (`https://api.mor.org/api/v1`)
- **`apps/agent/entrypoints/app/ai-settings/models.ts`** — Added Morpheus model list to `ModelsData` and `MODELS_DATA`
- **`apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx`** — Added `'morpheus'` to Zod validation enum

### Morpheus Details

- **API Base URL:** `https://api.mor.org/api/v1`
- **Auth:** Bearer token via API key from [app.mor.org](https://app.mor.org)
- **Protocol:** OpenAI-compatible (`/chat/completions`)
- **Default model:** `glm-5`
- **Docs:** [apidocs.mor.org](https://apidocs.mor.org)
- **Note:** Most models also support `:web` variants (e.g., `glm-5:web`) for internet-enabled search

### Implementation Pattern

Follows the same pattern as existing providers (Ollama, LM Studio) that use `@ai-sdk/openai-compatible`. The default base URL is `https://api.mor.org/api/v1`, with API key required.

## Test plan

- [ ] Verify Morpheus appears in provider type dropdown
- [ ] Verify default base URL auto-fills when Morpheus is selected
- [ ] Verify model dropdown shows available Morpheus models
- [ ] Verify "custom" model option still works for unlisted models
- [ ] Test connection with a valid Morpheus API key
- [ ] Verify existing providers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)