### PR TITLE
fix: include version in bundled and server package.json files

### DIFF
--- a/scripts/build/server.ts
+++ b/scripts/build/server.ts
@@ -209,6 +209,14 @@ async function bundleWithPlugins(
     for (const entry of result.logs) log.error(String(entry))
     throw new Error('Bundle with plugins failed')
   }
+
+  // Write package.json into the bundle directory so it's available at runtime.
+  // Required by @mariozechner/pi-coding-agent which reads package.json at module
+  // load time via getPackageDir() to extract version and config.
+  writeFileSync(
+    join(BUNDLE_DIR, 'package.json'),
+    JSON.stringify({ type: 'module', version }),
+  )
 }
 
 async function compileTarget(
@@ -299,7 +307,10 @@ async function build(config: BuildConfig): Promise<void> {
   mkdirSync('dist/server', { recursive: true })
 
   // Bun compiled binaries require a package.json next to the executable
-  writeFileSync('dist/server/package.json', JSON.stringify({ type: 'module' }))
+  writeFileSync(
+    'dist/server/package.json',
+    JSON.stringify({ type: 'module', version }),
+  )
 
   if (shouldUploadSourceMaps) {
     log.step('Building source maps...')


### PR DESCRIPTION
## Summary
This change ensures that the `version` field is included in the `package.json` files generated during the build process, making version information available at runtime for modules that need it.

## Key Changes
- Added `version` field to the `package.json` written into the bundle directory in `bundleWithPlugins()`. This is required by `@mariozechner/pi-coding-agent` which reads `package.json` at module load time via `getPackageDir()` to extract version and config information.
- Updated the `package.json` written to `dist/server/package.json` to also include the `version` field for consistency.

## Implementation Details
- Both `package.json` files now include `{ type: 'module', version }` instead of just `{ type: 'module' }`
- The version variable is already available in the build context and is now being utilized in both locations
- Added explanatory comment in `bundleWithPlugins()` documenting why the version is needed for the pi-coding-agent dependency

https://claude.ai/code/session_01RjbFDanzVw73iiFAhh59Kp