### PR TITLE
feat: Kimi/Moonshot partnership promotion POC

### DIFF
--- a/apps/agent/.env.example
+++ b/apps/agent/.env.example
@@ -15,6 +15,9 @@ VITE_PUBLIC_SENTRY_DSN=
 # BrowserOS API URL
 VITE_PUBLIC_BROWSEROS_API=https://api.browseros.com
 
+# Launch feature flags
+VITE_PUBLIC_KIMI_LAUNCH=false
+
 # GraphQL Schema Path (optional — falls back to schema/schema.graphql)
 GRAPHQL_SCHEMA_PATH=
 

--- a/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -45,6 +45,7 @@ import { track } from '@/lib/metrics/track'
 import { getModelContextLength, getModelOptions } from './models'
 
 const providerTypeEnum = z.enum([
+  'moonshot',
   'anthropic',
   'openai',
   'openai-compatible',

--- a/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -414,6 +414,12 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   const providerTemplate = getProviderTemplate(watchedType as ProviderType)
   const setupGuideUrl = providerTemplate?.setupGuideUrl
   const providerName = providerTemplate?.name
+  const setupGuideText =
+    watchedType === 'moonshot'
+      ? 'How to get a Kimi API key'
+      : providerName
+        ? `${providerName} setup guide`
+        : 'Provider setup guide'
 
   const handleSetupGuideClick = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -597,7 +603,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                       className="inline-flex cursor-pointer items-center gap-1 text-primary hover:underline"
                     >
                       <ExternalLink className="h-3 w-3" />
-                      {providerName} setup guide
+                      {setupGuideText}
                     </a>
                   )}
                 </FormDescription>

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -79,17 +79,15 @@ export const ProviderCard: FC<ProviderCardProps> = ({
             </Badge>
           )}
         </div>
-        {isBuiltIn && provider.type === 'browseros' && (
+        {isBuiltIn && provider.type === 'browseros' && kimiLaunch && (
           <span className="mb-1 inline-block rounded-full border border-orange-300/60 bg-orange-100/70 px-3 py-0.5 font-semibold text-orange-700 text-xs dark:border-orange-400/40 dark:bg-orange-500/15 dark:text-orange-300">
-            {kimiLaunch
-              ? 'Powered by Kimi K2.5 from Moonshot AI'
-              : 'Free Kimi K2.5 model in partnership with Moonshot AI.'}
+            Powered by Kimi K2.5 from Moonshot AI
           </span>
         )}
         <p className="truncate text-muted-foreground text-sm">
           {isBuiltIn ? (
             kimiLaunch ? (
-              'Extended usage for the next two weeks.'
+              'Extended usage limits for the next 2 weeks!'
             ) : (
               <>
                 BrowserOS-hosted model with strict rate limits.{' '}

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -89,7 +89,7 @@ export const ProviderCard: FC<ProviderCardProps> = ({
         <p className="truncate text-muted-foreground text-sm">
           {isBuiltIn ? (
             kimiLaunch ? (
-              'Extended usage for the next two weeks.'
+              'Extended usage limits for the next two weeks.'
             ) : (
               <>
                 BrowserOS-hosted model with strict rate limits.{' '}

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -2,6 +2,7 @@ import { Check, Loader2, Trash2 } from 'lucide-react'
 import type { FC } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { useKimiLaunch } from '@/lib/feature-flags/useKimiLaunch'
 import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { cn } from '@/lib/utils'
@@ -29,6 +30,7 @@ export const ProviderCard: FC<ProviderCardProps> = ({
   isTesting = false,
 }) => {
   const inputId = `provider-${provider.id}`
+  const kimiLaunch = useKimiLaunch()
 
   return (
     <label
@@ -79,24 +81,30 @@ export const ProviderCard: FC<ProviderCardProps> = ({
         </div>
         {isBuiltIn && provider.type === 'browseros' && (
           <span className="mb-1 inline-block rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-3 py-0.5 font-semibold text-white text-xs">
-            Free model Sponsored by Kimi K2.5
+            {kimiLaunch
+              ? 'Powered by Kimi K2.5 from Moonshot AI'
+              : 'Free model Sponsored by Kimi K2.5'}
           </span>
         )}
         <p className="truncate text-muted-foreground text-sm">
           {isBuiltIn ? (
-            <>
-              BrowserOS-hosted model with strict rate limits.{' '}
-              <a
-                href="https://docs.browseros.com/features/bring-your-own-llm"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline hover:text-foreground"
-                onClick={(e) => e.stopPropagation()}
-              >
-                Bring your own key
-              </a>{' '}
-              for better performance.
-            </>
+            kimiLaunch ? (
+              'Extended usage for the next two weeks.'
+            ) : (
+              <>
+                BrowserOS-hosted model with strict rate limits.{' '}
+                <a
+                  href="https://docs.browseros.com/features/bring-your-own-llm"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-foreground"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  Bring your own key
+                </a>{' '}
+                for better performance.
+              </>
+            )
           ) : (
             `${provider.modelId} • ${provider.baseUrl}`
           )}

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -80,7 +80,7 @@ export const ProviderCard: FC<ProviderCardProps> = ({
           )}
         </div>
         {isBuiltIn && provider.type === 'browseros' && (
-          <span className="mb-1 inline-block rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-3 py-0.5 font-semibold text-white text-xs">
+          <span className="mb-1 inline-block rounded-full border border-orange-300/60 bg-orange-100/70 px-3 py-0.5 font-semibold text-orange-700 text-xs dark:border-orange-400/40 dark:bg-orange-500/15 dark:text-orange-300">
             {kimiLaunch
               ? 'Powered by Kimi K2.5 from Moonshot AI'
               : 'Free Kimi K2.5 model in partnership with Moonshot AI.'}

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -77,7 +77,7 @@ export const ProviderCard: FC<ProviderCardProps> = ({
             </Badge>
           )}
         </div>
-        {isBuiltIn && (
+        {isBuiltIn && provider.type === 'browseros' && (
           <span className="mb-1 inline-block rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-3 py-0.5 font-semibold text-white text-xs">
             Free model Sponsored by Kimi K2.5
           </span>

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -89,7 +89,7 @@ export const ProviderCard: FC<ProviderCardProps> = ({
         <p className="truncate text-muted-foreground text-sm">
           {isBuiltIn ? (
             kimiLaunch ? (
-              'Extended usage limits for the next two weeks.'
+              'Extended usage for the next two weeks.'
             ) : (
               <>
                 BrowserOS-hosted model with strict rate limits.{' '}

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -77,6 +77,11 @@ export const ProviderCard: FC<ProviderCardProps> = ({
             </Badge>
           )}
         </div>
+        {isBuiltIn && (
+          <span className="mb-1 inline-block rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-3 py-0.5 font-semibold text-white text-xs">
+            Free model Sponsored by Kimi K2.5
+          </span>
+        )}
         <p className="truncate text-muted-foreground text-sm">
           {isBuiltIn ? (
             <>

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -83,7 +83,7 @@ export const ProviderCard: FC<ProviderCardProps> = ({
           <span className="mb-1 inline-block rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-3 py-0.5 font-semibold text-white text-xs">
             {kimiLaunch
               ? 'Powered by Kimi K2.5 from Moonshot AI'
-              : 'Free model Sponsored by Kimi K2.5'}
+              : 'Free Kimi K2.5 model in partnership with Moonshot AI.'}
           </span>
         )}
         <p className="truncate text-muted-foreground text-sm">

--- a/apps/agent/entrypoints/app/ai-settings/ProviderTemplateCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderTemplateCard.tsx
@@ -22,7 +22,7 @@ export const ProviderTemplateCard: FC<ProviderTemplateCardProps> = ({
       className={cn(
         'group flex w-full items-center gap-3 rounded-lg border bg-background p-4 text-left transition-all hover:border-[var(--accent-orange)] hover:shadow-md',
         highlighted
-          ? 'border-orange-400/60 shadow-[0_0_15px_rgba(251,146,60,0.25)] ring-2 ring-orange-400/40'
+          ? 'border-orange-300/80 bg-orange-50/30 shadow-sm ring-1 ring-orange-300/45 dark:bg-orange-500/5'
           : 'border-border',
       )}
     >
@@ -36,7 +36,7 @@ export const ProviderTemplateCard: FC<ProviderTemplateCardProps> = ({
           <div className="flex flex-wrap items-center gap-2">
             <span className="font-medium text-foreground">{template.name}</span>
             {highlighted && (
-              <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2 py-0.5 font-semibold text-[10px] text-white">
+              <span className="rounded-full border border-orange-300/60 bg-orange-100/70 px-2 py-0.5 font-semibold text-[10px] text-orange-700 dark:border-orange-400/40 dark:bg-orange-500/15 dark:text-orange-300">
                 Recommended
               </span>
             )}
@@ -48,7 +48,7 @@ export const ProviderTemplateCard: FC<ProviderTemplateCardProps> = ({
         className={cn(
           'shrink-0 rounded-md px-3 py-1 transition-colors group-hover:border-[var(--accent-orange)] group-hover:text-[var(--accent-orange)]',
           highlighted &&
-            'border-[var(--accent-orange)] text-[var(--accent-orange)]',
+            'border-[var(--accent-orange)] bg-[var(--accent-orange)]/5 text-[var(--accent-orange)]',
         )}
       >
         USE

--- a/apps/agent/entrypoints/app/ai-settings/ProviderTemplateCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderTemplateCard.tsx
@@ -2,29 +2,46 @@ import type { FC } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderTemplate } from '@/lib/llm-providers/providerTemplates'
+import { cn } from '@/lib/utils'
 
 interface ProviderTemplateCardProps {
   template: ProviderTemplate
+  highlighted?: boolean
   onUseTemplate: (template: ProviderTemplate) => void
 }
 
 export const ProviderTemplateCard: FC<ProviderTemplateCardProps> = ({
   template,
+  highlighted = false,
   onUseTemplate,
 }) => {
   return (
     <button
       type="button"
       onClick={() => onUseTemplate(template)}
-      className="group flex w-full items-center justify-between rounded-lg border border-border bg-background p-4 text-left transition-all hover:border-[var(--accent-orange)] hover:shadow-md"
+      className={cn(
+        'group flex w-full items-center justify-between rounded-lg border bg-background p-4 text-left transition-all hover:border-[var(--accent-orange)] hover:shadow-md',
+        highlighted
+          ? 'border-orange-400/60 shadow-[0_0_15px_rgba(251,146,60,0.25)] ring-2 ring-orange-400/40'
+          : 'border-border',
+      )}
     >
       <div className="flex items-center gap-3 text-accent-orange/70 transition-colors group-hover:text-accent-orange">
         <ProviderIcon type={template.id} size={28} />
         <span className="font-medium text-foreground">{template.name}</span>
+        {highlighted && (
+          <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2 py-0.5 font-medium text-[10px] text-white">
+            Recommended
+          </span>
+        )}
       </div>
       <Badge
         variant="outline"
-        className="rounded-md px-3 py-1 transition-colors group-hover:border-[var(--accent-orange)] group-hover:text-[var(--accent-orange)]"
+        className={cn(
+          'rounded-md px-3 py-1 transition-colors group-hover:border-[var(--accent-orange)] group-hover:text-[var(--accent-orange)]',
+          highlighted &&
+            'border-[var(--accent-orange)] text-[var(--accent-orange)]',
+        )}
       >
         USE
       </Badge>

--- a/apps/agent/entrypoints/app/ai-settings/ProviderTemplateCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderTemplateCard.tsx
@@ -20,25 +20,33 @@ export const ProviderTemplateCard: FC<ProviderTemplateCardProps> = ({
       type="button"
       onClick={() => onUseTemplate(template)}
       className={cn(
-        'group flex w-full items-center justify-between rounded-lg border bg-background p-4 text-left transition-all hover:border-[var(--accent-orange)] hover:shadow-md',
+        'group flex w-full items-center gap-3 rounded-lg border bg-background p-4 text-left transition-all hover:border-[var(--accent-orange)] hover:shadow-md',
         highlighted
           ? 'border-orange-400/60 shadow-[0_0_15px_rgba(251,146,60,0.25)] ring-2 ring-orange-400/40'
           : 'border-border',
       )}
     >
-      <div className="flex items-center gap-3 text-accent-orange/70 transition-colors group-hover:text-accent-orange">
-        <ProviderIcon type={template.id} size={28} />
-        <span className="font-medium text-foreground">{template.name}</span>
-        {highlighted && (
-          <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2 py-0.5 font-medium text-[10px] text-white">
-            Recommended
-          </span>
-        )}
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <ProviderIcon
+          type={template.id}
+          size={28}
+          className="shrink-0 text-accent-orange/70 transition-colors group-hover:text-accent-orange"
+        />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-foreground">{template.name}</span>
+            {highlighted && (
+              <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2 py-0.5 font-semibold text-[10px] text-white">
+                Recommended
+              </span>
+            )}
+          </div>
+        </div>
       </div>
       <Badge
         variant="outline"
         className={cn(
-          'rounded-md px-3 py-1 transition-colors group-hover:border-[var(--accent-orange)] group-hover:text-[var(--accent-orange)]',
+          'shrink-0 rounded-md px-3 py-1 transition-colors group-hover:border-[var(--accent-orange)] group-hover:text-[var(--accent-orange)]',
           highlighted &&
             'border-[var(--accent-orange)] text-[var(--accent-orange)]',
         )}

--- a/apps/agent/entrypoints/app/ai-settings/ProviderTemplatesSection.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderTemplatesSection.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/components/ui/collapsible'
 import { Feature } from '@/lib/browseros/capabilities'
 import { useCapabilities } from '@/lib/browseros/useCapabilities'
+import { useKimiLaunch } from '@/lib/feature-flags/useKimiLaunch'
 import {
   type ProviderTemplate,
   providerTemplates,
@@ -22,6 +23,7 @@ export const ProviderTemplatesSection: FC<ProviderTemplatesSectionProps> = ({
   onUseTemplate,
 }) => {
   const { supports } = useCapabilities()
+  const kimiLaunch = useKimiLaunch()
 
   const filteredTemplates = providerTemplates.filter((template) => {
     if (template.id === 'openai-compatible') {
@@ -54,6 +56,7 @@ export const ProviderTemplatesSection: FC<ProviderTemplatesSectionProps> = ({
               <ProviderTemplateCard
                 key={template.id}
                 template={template}
+                highlighted={kimiLaunch && template.id === 'moonshot'}
                 onUseTemplate={onUseTemplate}
               />
             ))}

--- a/apps/agent/entrypoints/app/ai-settings/ProviderTemplatesSection.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderTemplatesSection.tsx
@@ -7,7 +7,6 @@ import {
 } from '@/components/ui/collapsible'
 import { Feature } from '@/lib/browseros/capabilities'
 import { useCapabilities } from '@/lib/browseros/useCapabilities'
-import { useKimiLaunch } from '@/lib/feature-flags/useKimiLaunch'
 import {
   type ProviderTemplate,
   providerTemplates,
@@ -23,7 +22,6 @@ export const ProviderTemplatesSection: FC<ProviderTemplatesSectionProps> = ({
   onUseTemplate,
 }) => {
   const { supports } = useCapabilities()
-  const kimiLaunch = useKimiLaunch()
 
   const filteredTemplates = providerTemplates.filter((template) => {
     if (template.id === 'openai-compatible') {
@@ -56,7 +54,7 @@ export const ProviderTemplatesSection: FC<ProviderTemplatesSectionProps> = ({
               <ProviderTemplateCard
                 key={template.id}
                 template={template}
-                highlighted={kimiLaunch && template.id === 'moonshot'}
+                highlighted={template.id === 'moonshot'}
                 onUseTemplate={onUseTemplate}
               />
             ))}

--- a/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -30,7 +30,10 @@ export interface ModelsData {
  * Based on: https://github.com/browseros-ai/BrowserOS-agent/blob/main/src/options/data/models.ts
  */
 export const MODELS_DATA: ModelsData = {
-  moonshot: [{ modelId: 'kimi-k2-0905-preview', contextLength: 128000 }],
+  moonshot: [
+    { modelId: 'kimi-k2.5', contextLength: 128000 },
+    { modelId: 'kimi-k2-0905-preview', contextLength: 128000 },
+  ],
   anthropic: [
     { modelId: 'claude-opus-4-5-20251101', contextLength: 200000 },
     { modelId: 'claude-haiku-4-5-20251001', contextLength: 200000 },

--- a/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -1,4 +1,3 @@
-import { isKimiLaunchEnabled } from '@/lib/feature-flags/kimi-launch'
 import type { ProviderType } from '@/lib/llm-providers/types'
 
 /**
@@ -26,19 +25,12 @@ export interface ModelsData {
   moonshot: ModelInfo[]
 }
 
-const KIMI_LAUNCH_MOONSHOT_MODELS: ModelInfo[] = [
-  { modelId: 'kimi-k2.5', contextLength: 128000 },
-]
-
 /**
  * Available models per provider with context lengths
  * Based on: https://github.com/browseros-ai/BrowserOS-agent/blob/main/src/options/data/models.ts
  */
 export const MODELS_DATA: ModelsData = {
-  moonshot: [
-    { modelId: 'kimi-k2.5', contextLength: 128000 },
-    { modelId: 'kimi-k2-0905-preview', contextLength: 128000 },
-  ],
+  moonshot: [{ modelId: 'kimi-k2.5', contextLength: 128000 }],
   anthropic: [
     { modelId: 'claude-opus-4-5-20251101', contextLength: 200000 },
     { modelId: 'claude-haiku-4-5-20251001', contextLength: 200000 },
@@ -104,9 +96,6 @@ export const MODELS_DATA: ModelsData = {
  * Get models for a specific provider type
  */
 export function getModelsForProvider(providerType: ProviderType): ModelInfo[] {
-  if (providerType === 'moonshot' && isKimiLaunchEnabled()) {
-    return KIMI_LAUNCH_MOONSHOT_MODELS
-  }
   return MODELS_DATA[providerType] || []
 }
 

--- a/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -1,3 +1,4 @@
+import { isKimiLaunchEnabled } from '@/lib/feature-flags/kimi-launch'
 import type { ProviderType } from '@/lib/llm-providers/types'
 
 /**
@@ -24,6 +25,10 @@ export interface ModelsData {
   browseros: ModelInfo[]
   moonshot: ModelInfo[]
 }
+
+const KIMI_LAUNCH_MOONSHOT_MODELS: ModelInfo[] = [
+  { modelId: 'kimi-k2.5', contextLength: 128000 },
+]
 
 /**
  * Available models per provider with context lengths
@@ -99,6 +104,9 @@ export const MODELS_DATA: ModelsData = {
  * Get models for a specific provider type
  */
 export function getModelsForProvider(providerType: ProviderType): ModelInfo[] {
+  if (providerType === 'moonshot' && isKimiLaunchEnabled()) {
+    return KIMI_LAUNCH_MOONSHOT_MODELS
+  }
   return MODELS_DATA[providerType] || []
 }
 

--- a/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -22,6 +22,7 @@ export interface ModelsData {
   lmstudio: ModelInfo[]
   bedrock: ModelInfo[]
   browseros: ModelInfo[]
+  moonshot: ModelInfo[]
 }
 
 /**
@@ -29,6 +30,7 @@ export interface ModelsData {
  * Based on: https://github.com/browseros-ai/BrowserOS-agent/blob/main/src/options/data/models.ts
  */
 export const MODELS_DATA: ModelsData = {
+  moonshot: [{ modelId: 'kimi-k2-0905-preview', contextLength: 128000 }],
   anthropic: [
     { modelId: 'claude-opus-4-5-20251101', contextLength: 200000 },
     { modelId: 'claude-haiku-4-5-20251001', contextLength: 200000 },

--- a/apps/agent/entrypoints/app/llm-hub/HubProviderRow.tsx
+++ b/apps/agent/entrypoints/app/llm-hub/HubProviderRow.tsx
@@ -2,6 +2,7 @@ import { Globe2, Trash2 } from 'lucide-react'
 import type { FC } from 'react'
 import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { getFaviconUrl, type LlmHubProvider } from './models'
 
 interface HubProviderRowProps {
@@ -18,9 +19,16 @@ export const HubProviderRow: FC<HubProviderRowProps> = ({
   onDelete,
 }) => {
   const iconUrl = useMemo(() => getFaviconUrl(provider.url), [provider.url])
+  const isKimi = provider.name === 'Kimi'
 
   return (
-    <div className="group flex w-full items-center gap-4 rounded-xl border border-border bg-card p-4 transition-all hover:border-[var(--accent-orange)] hover:shadow-md">
+    <div
+      className={cn(
+        'group flex w-full items-center gap-4 rounded-xl border border-border bg-card p-4 transition-all hover:border-[var(--accent-orange)] hover:shadow-md',
+        isKimi &&
+          'border-orange-400/60 shadow-[0_0_15px_rgba(251,146,60,0.3)] ring-2 ring-orange-400/50',
+      )}
+    >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted">
         {iconUrl ? (
           <img
@@ -34,9 +42,14 @@ export const HubProviderRow: FC<HubProviderRowProps> = ({
       </div>
 
       <div className="min-w-0 flex-1">
-        <span className="mb-0.5 block truncate font-semibold">
-          {provider.name}
-        </span>
+        <div className="mb-0.5 flex items-center gap-2">
+          <span className="block truncate font-semibold">{provider.name}</span>
+          {isKimi && (
+            <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2.5 py-0.5 font-medium text-white text-xs">
+              Try Kimi
+            </span>
+          )}
+        </div>
         <p className="truncate text-muted-foreground/70 text-xs">
           {provider.url}
         </p>

--- a/apps/agent/entrypoints/app/llm-hub/HubProviderRow.tsx
+++ b/apps/agent/entrypoints/app/llm-hub/HubProviderRow.tsx
@@ -20,7 +20,9 @@ export const HubProviderRow: FC<HubProviderRowProps> = ({
   onDelete,
 }) => {
   const iconUrl = useMemo(() => getFaviconUrl(provider.url), [provider.url])
-  const isKimi = provider.name === 'Kimi'
+  const normalizedName = provider.name.trim().toLowerCase()
+  const normalizedUrl = provider.url.trim().toLowerCase()
+  const isKimi = normalizedName === 'kimi' || normalizedUrl.includes('kimi.com')
   const kimiLaunch = useKimiLaunch()
   const showKimiFlare = isKimi && kimiLaunch
 
@@ -48,9 +50,14 @@ export const HubProviderRow: FC<HubProviderRowProps> = ({
         <div className="mb-0.5 flex items-center gap-2">
           <span className="block truncate font-semibold">{provider.name}</span>
           {showKimiFlare && (
-            <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2.5 py-0.5 font-medium text-white text-xs">
-              Powered by Moonshot AI
-            </span>
+            <div className="flex flex-wrap items-center gap-1">
+              <span className="rounded-full border border-orange-300/60 bg-orange-50 px-2 py-0.5 font-semibold text-[11px] text-orange-700">
+                Recommended
+              </span>
+              <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2.5 py-0.5 font-medium text-white text-xs">
+                Powered by Moonshot AI
+              </span>
+            </div>
           )}
         </div>
         <p className="truncate text-muted-foreground/70 text-xs">

--- a/apps/agent/entrypoints/app/llm-hub/HubProviderRow.tsx
+++ b/apps/agent/entrypoints/app/llm-hub/HubProviderRow.tsx
@@ -2,7 +2,6 @@ import { Globe2, Trash2 } from 'lucide-react'
 import type { FC } from 'react'
 import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
-import { useKimiLaunch } from '@/lib/feature-flags/useKimiLaunch'
 import { cn } from '@/lib/utils'
 import { getFaviconUrl, type LlmHubProvider } from './models'
 
@@ -23,15 +22,14 @@ export const HubProviderRow: FC<HubProviderRowProps> = ({
   const normalizedName = provider.name.trim().toLowerCase()
   const normalizedUrl = provider.url.trim().toLowerCase()
   const isKimi = normalizedName === 'kimi' || normalizedUrl.includes('kimi.com')
-  const kimiLaunch = useKimiLaunch()
-  const showKimiFlare = isKimi && kimiLaunch
+  const showKimiFlare = isKimi
 
   return (
     <div
       className={cn(
         'group flex w-full items-center gap-4 rounded-xl border border-border bg-card p-4 transition-all hover:border-[var(--accent-orange)] hover:shadow-md',
         showKimiFlare &&
-          'border-orange-400/60 shadow-[0_0_15px_rgba(251,146,60,0.3)] ring-2 ring-orange-400/40',
+          'border-orange-300/80 bg-orange-50/20 shadow-sm ring-1 ring-orange-300/45 dark:bg-orange-500/5',
       )}
     >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted">
@@ -51,10 +49,10 @@ export const HubProviderRow: FC<HubProviderRowProps> = ({
           <span className="block truncate font-semibold">{provider.name}</span>
           {showKimiFlare && (
             <div className="flex flex-wrap items-center gap-1">
-              <span className="rounded-full border border-orange-300/60 bg-orange-50 px-2 py-0.5 font-semibold text-[11px] text-orange-700">
+              <span className="rounded-full border border-orange-300/60 bg-orange-100/70 px-2 py-0.5 font-semibold text-[11px] text-orange-700 dark:border-orange-400/40 dark:bg-orange-500/15 dark:text-orange-300">
                 Recommended
               </span>
-              <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2.5 py-0.5 font-medium text-white text-xs">
+              <span className="rounded-full border border-orange-300/60 bg-orange-100/60 px-2.5 py-0.5 font-medium text-orange-700 text-xs dark:border-orange-400/40 dark:bg-orange-500/15 dark:text-orange-300">
                 Powered by Moonshot AI
               </span>
             </div>

--- a/apps/agent/entrypoints/app/llm-hub/HubProviderRow.tsx
+++ b/apps/agent/entrypoints/app/llm-hub/HubProviderRow.tsx
@@ -2,6 +2,7 @@ import { Globe2, Trash2 } from 'lucide-react'
 import type { FC } from 'react'
 import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
+import { useKimiLaunch } from '@/lib/feature-flags/useKimiLaunch'
 import { cn } from '@/lib/utils'
 import { getFaviconUrl, type LlmHubProvider } from './models'
 
@@ -20,13 +21,15 @@ export const HubProviderRow: FC<HubProviderRowProps> = ({
 }) => {
   const iconUrl = useMemo(() => getFaviconUrl(provider.url), [provider.url])
   const isKimi = provider.name === 'Kimi'
+  const kimiLaunch = useKimiLaunch()
+  const showKimiFlare = isKimi && kimiLaunch
 
   return (
     <div
       className={cn(
         'group flex w-full items-center gap-4 rounded-xl border border-border bg-card p-4 transition-all hover:border-[var(--accent-orange)] hover:shadow-md',
-        isKimi &&
-          'border-orange-400/60 shadow-[0_0_15px_rgba(251,146,60,0.3)] ring-2 ring-orange-400/50',
+        showKimiFlare &&
+          'border-orange-400/60 shadow-[0_0_15px_rgba(251,146,60,0.3)] ring-2 ring-orange-400/40',
       )}
     >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted">
@@ -44,9 +47,9 @@ export const HubProviderRow: FC<HubProviderRowProps> = ({
       <div className="min-w-0 flex-1">
         <div className="mb-0.5 flex items-center gap-2">
           <span className="block truncate font-semibold">{provider.name}</span>
-          {isKimi && (
+          {showKimiFlare && (
             <span className="rounded-full bg-gradient-to-r from-orange-500 to-amber-500 px-2.5 py-0.5 font-medium text-white text-xs">
-              Try Kimi
+              Powered by Moonshot AI
             </span>
           )}
         </div>

--- a/apps/agent/entrypoints/app/llm-hub/HubProvidersList.tsx
+++ b/apps/agent/entrypoints/app/llm-hub/HubProvidersList.tsx
@@ -34,7 +34,7 @@ export const HubProvidersList: FC<HubProvidersListProps> = ({
     return (
       <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
         <div className="mb-4 flex items-center justify-between">
-          <h3 className="font-medium">Configured Providers</h3>
+          <h3 className="font-medium">Configured AI Providers</h3>
           <Button
             variant="outline"
             size="sm"
@@ -57,7 +57,7 @@ export const HubProvidersList: FC<HubProvidersListProps> = ({
   return (
     <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
       <div className="mb-4 flex items-center justify-between">
-        <h3 className="font-medium">Configured Providers</h3>
+        <h3 className="font-medium">Configured AI Providers</h3>
         <Button
           variant="outline"
           size="sm"

--- a/apps/agent/entrypoints/app/llm-hub/models.ts
+++ b/apps/agent/entrypoints/app/llm-hub/models.ts
@@ -1,5 +1,4 @@
 export {
-  DEFAULT_PROVIDERS,
   getFaviconUrl,
   type LlmHubProvider,
 } from '@/lib/llm-hub/storage'

--- a/apps/agent/lib/env.ts
+++ b/apps/agent/lib/env.ts
@@ -6,6 +6,7 @@ const EnvSchema = z.object({
   VITE_PUBLIC_POSTHOG_HOST: z.string().optional(),
   VITE_PUBLIC_SENTRY_DSN: z.string().optional(),
   VITE_PUBLIC_BROWSEROS_API: z.string().optional(),
+  VITE_PUBLIC_KIMI_LAUNCH: z.string().optional(),
   PROD: z.boolean(),
 })
 

--- a/apps/agent/lib/feature-flags/kimi-launch.ts
+++ b/apps/agent/lib/feature-flags/kimi-launch.ts
@@ -1,0 +1,17 @@
+import { storage } from '@wxt-dev/storage'
+
+const KIMI_LAUNCH_KEY = 'local:feature-flag-kimi-launch'
+
+const kimiLaunchStorage = storage.defineItem<boolean>(KIMI_LAUNCH_KEY, {
+  fallback: true,
+})
+
+export async function isKimiLaunchEnabled(): Promise<boolean> {
+  return (await kimiLaunchStorage.getValue()) ?? true
+}
+
+export function setKimiLaunchEnabled(enabled: boolean): Promise<void> {
+  return kimiLaunchStorage.setValue(enabled)
+}
+
+export { kimiLaunchStorage }

--- a/apps/agent/lib/feature-flags/kimi-launch.ts
+++ b/apps/agent/lib/feature-flags/kimi-launch.ts
@@ -1,17 +1,14 @@
-import { storage } from '@wxt-dev/storage'
+import { env } from '@/lib/env'
 
-const KIMI_LAUNCH_KEY = 'local:feature-flag-kimi-launch'
+const ENABLED_VALUES = new Set(['1', 'true', 'yes', 'on'])
 
-const kimiLaunchStorage = storage.defineItem<boolean>(KIMI_LAUNCH_KEY, {
-  fallback: true,
-})
-
-export async function isKimiLaunchEnabled(): Promise<boolean> {
-  return (await kimiLaunchStorage.getValue()) ?? true
+function parseKimiLaunchFlag(value: string | undefined): boolean {
+  if (!value) return false
+  return ENABLED_VALUES.has(value.trim().toLowerCase())
 }
 
-export function setKimiLaunchEnabled(enabled: boolean): Promise<void> {
-  return kimiLaunchStorage.setValue(enabled)
-}
+const kimiLaunchEnabled = parseKimiLaunchFlag(env.VITE_PUBLIC_KIMI_LAUNCH)
 
-export { kimiLaunchStorage }
+export function isKimiLaunchEnabled(): boolean {
+  return kimiLaunchEnabled
+}

--- a/apps/agent/lib/feature-flags/useKimiLaunch.ts
+++ b/apps/agent/lib/feature-flags/useKimiLaunch.ts
@@ -1,18 +1,5 @@
-import { useEffect, useState } from 'react'
-import { kimiLaunchStorage } from './kimi-launch'
+import { isKimiLaunchEnabled } from './kimi-launch'
 
 export function useKimiLaunch(): boolean {
-  const [enabled, setEnabled] = useState(true)
-
-  useEffect(() => {
-    kimiLaunchStorage.getValue().then((val) => setEnabled(val ?? true))
-
-    const unwatch = kimiLaunchStorage.watch((val) => {
-      setEnabled(val ?? true)
-    })
-
-    return unwatch
-  }, [])
-
-  return enabled
+  return isKimiLaunchEnabled()
 }

--- a/apps/agent/lib/feature-flags/useKimiLaunch.ts
+++ b/apps/agent/lib/feature-flags/useKimiLaunch.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+import { kimiLaunchStorage } from './kimi-launch'
+
+export function useKimiLaunch(): boolean {
+  const [enabled, setEnabled] = useState(true)
+
+  useEffect(() => {
+    kimiLaunchStorage.getValue().then((val) => setEnabled(val ?? true))
+
+    const unwatch = kimiLaunchStorage.watch((val) => {
+      setEnabled(val ?? true)
+    })
+
+    return unwatch
+  }, [])
+
+  return enabled
+}

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -14,8 +14,20 @@ export const DEFAULT_PROVIDERS: LlmHubProvider[] = [
   { name: 'Gemini', url: 'https://gemini.google.com' },
 ]
 
+const LEGACY_DEFAULT_NAMES = new Set([
+  'ChatGPT',
+  'Claude',
+  'Grok',
+  'Gemini',
+  'Perplexity',
+])
+
+function isLegacyDefaults(providers: LlmHubProvider[]): boolean {
+  if (providers.length !== LEGACY_DEFAULT_NAMES.size) return false
+  return providers.every((p) => LEGACY_DEFAULT_NAMES.has(p.name))
+}
+
 export async function loadProviders(): Promise<LlmHubProvider[]> {
-  const defaults = DEFAULT_PROVIDERS
   try {
     const adapter = getBrowserOSAdapter()
     const providersPref = await adapter.getPref(
@@ -23,13 +35,13 @@ export async function loadProviders(): Promise<LlmHubProvider[]> {
     )
     const providers = (providersPref?.value as LlmHubProvider[]) || []
 
-    if (providers.length === 0) {
-      return defaults
+    if (providers.length === 0 || isLegacyDefaults(providers)) {
+      return DEFAULT_PROVIDERS
     }
 
     return providers
   } catch {
-    return defaults
+    return DEFAULT_PROVIDERS
   }
 }
 

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -1,6 +1,5 @@
 import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
 import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
-import { isKimiLaunchEnabled } from '@/lib/feature-flags/kimi-launch'
 
 /** @public */
 export interface LlmHubProvider {
@@ -9,27 +8,14 @@ export interface LlmHubProvider {
 }
 
 export const DEFAULT_PROVIDERS: LlmHubProvider[] = [
-  { name: 'ChatGPT', url: 'https://chatgpt.com' },
-  { name: 'Claude', url: 'https://claude.ai' },
-  { name: 'Grok', url: 'https://grok.com' },
-  { name: 'Gemini', url: 'https://gemini.google.com' },
-  { name: 'Perplexity', url: 'https://www.perplexity.ai' },
-]
-
-export const KIMI_LAUNCH_DEFAULT_PROVIDERS: LlmHubProvider[] = [
   { name: 'Kimi', url: 'https://www.kimi.com' },
   { name: 'ChatGPT', url: 'https://chatgpt.com' },
   { name: 'Claude', url: 'https://claude.ai' },
   { name: 'Gemini', url: 'https://gemini.google.com' },
 ]
 
-async function getDefaultProviders(): Promise<LlmHubProvider[]> {
-  const kimiEnabled = await isKimiLaunchEnabled()
-  return kimiEnabled ? KIMI_LAUNCH_DEFAULT_PROVIDERS : DEFAULT_PROVIDERS
-}
-
 export async function loadProviders(): Promise<LlmHubProvider[]> {
-  const defaults = await getDefaultProviders()
+  const defaults = DEFAULT_PROVIDERS
   try {
     const adapter = getBrowserOSAdapter()
     const providersPref = await adapter.getPref(

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -7,26 +7,16 @@ export interface LlmHubProvider {
   url: string
 }
 
-const LEGACY_DEFAULTS_MAP = new Map([
-  ['ChatGPT', 'https://chatgpt.com'],
-  ['Claude', 'https://claude.ai'],
-  ['Grok', 'https://grok.com'],
-  ['Gemini', 'https://gemini.google.com'],
-  ['Perplexity', 'https://www.perplexity.ai'],
-])
-
-function isLegacyDefaults(providers: LlmHubProvider[]): boolean {
-  if (providers.length !== LEGACY_DEFAULTS_MAP.size) return false
-  return providers.every((p) => LEGACY_DEFAULTS_MAP.get(p.name) === p.url)
+const KIMI_PROVIDER: LlmHubProvider = {
+  name: 'Kimi',
+  url: 'https://www.kimi.com',
 }
 
-async function clearLegacyDefaults(): Promise<void> {
-  try {
-    const adapter = getBrowserOSAdapter()
-    await adapter.setPref(BROWSEROS_PREFS.THIRD_PARTY_LLM_PROVIDERS, [])
-  } catch {
-    // best effort
-  }
+function ensureKimiFirst(providers: LlmHubProvider[]): LlmHubProvider[] {
+  const hasKimi = providers.some(
+    (p) => p.name === 'Kimi' || p.url.includes('kimi.com'),
+  )
+  return hasKimi ? providers : [KIMI_PROVIDER, ...providers]
 }
 
 export async function loadProviders(): Promise<LlmHubProvider[]> {
@@ -37,14 +27,13 @@ export async function loadProviders(): Promise<LlmHubProvider[]> {
     )
     const providers = (providersPref?.value as LlmHubProvider[]) || []
 
-    if (isLegacyDefaults(providers)) {
-      await clearLegacyDefaults()
-      return []
+    if (providers.length === 0) {
+      return [KIMI_PROVIDER]
     }
 
-    return providers
+    return ensureKimiFirst(providers)
   } catch {
-    return []
+    return [KIMI_PROVIDER]
   }
 }
 

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -27,6 +27,17 @@ function isLegacyDefaults(providers: LlmHubProvider[]): boolean {
   return providers.every((p) => LEGACY_DEFAULT_NAMES.has(p.name))
 }
 
+async function migrateToDefaultProviders(): Promise<LlmHubProvider[]> {
+  const defaults = DEFAULT_PROVIDERS.map((provider) => ({ ...provider }))
+  try {
+    const adapter = getBrowserOSAdapter()
+    await adapter.setPref(BROWSEROS_PREFS.THIRD_PARTY_LLM_PROVIDERS, defaults)
+  } catch {
+    // Best effort migration: still return defaults for UI consistency
+  }
+  return defaults
+}
+
 export async function loadProviders(): Promise<LlmHubProvider[]> {
   try {
     const adapter = getBrowserOSAdapter()
@@ -36,12 +47,12 @@ export async function loadProviders(): Promise<LlmHubProvider[]> {
     const providers = (providersPref?.value as LlmHubProvider[]) || []
 
     if (providers.length === 0 || isLegacyDefaults(providers)) {
-      return DEFAULT_PROVIDERS
+      return await migrateToDefaultProviders()
     }
 
     return providers
   } catch {
-    return DEFAULT_PROVIDERS
+    return DEFAULT_PROVIDERS.map((provider) => ({ ...provider }))
   }
 }
 

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -1,5 +1,6 @@
 import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
 import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
+import { isKimiLaunchEnabled } from '@/lib/feature-flags/kimi-launch'
 
 /** @public */
 export interface LlmHubProvider {
@@ -8,7 +9,6 @@ export interface LlmHubProvider {
 }
 
 export const DEFAULT_PROVIDERS: LlmHubProvider[] = [
-  { name: 'Kimi', url: 'https://www.kimi.com' },
   { name: 'ChatGPT', url: 'https://chatgpt.com' },
   { name: 'Claude', url: 'https://claude.ai' },
   { name: 'Grok', url: 'https://grok.com' },
@@ -16,7 +16,20 @@ export const DEFAULT_PROVIDERS: LlmHubProvider[] = [
   { name: 'Perplexity', url: 'https://www.perplexity.ai' },
 ]
 
+export const KIMI_LAUNCH_DEFAULT_PROVIDERS: LlmHubProvider[] = [
+  { name: 'Kimi', url: 'https://www.kimi.com' },
+  { name: 'ChatGPT', url: 'https://chatgpt.com' },
+  { name: 'Claude', url: 'https://claude.ai' },
+  { name: 'Gemini', url: 'https://gemini.google.com' },
+]
+
+async function getDefaultProviders(): Promise<LlmHubProvider[]> {
+  const kimiEnabled = await isKimiLaunchEnabled()
+  return kimiEnabled ? KIMI_LAUNCH_DEFAULT_PROVIDERS : DEFAULT_PROVIDERS
+}
+
 export async function loadProviders(): Promise<LlmHubProvider[]> {
+  const defaults = await getDefaultProviders()
   try {
     const adapter = getBrowserOSAdapter()
     const providersPref = await adapter.getPref(
@@ -25,12 +38,12 @@ export async function loadProviders(): Promise<LlmHubProvider[]> {
     const providers = (providersPref?.value as LlmHubProvider[]) || []
 
     if (providers.length === 0) {
-      return DEFAULT_PROVIDERS
+      return defaults
     }
 
     return providers
   } catch {
-    return DEFAULT_PROVIDERS
+    return defaults
   }
 }
 

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -8,6 +8,7 @@ export interface LlmHubProvider {
 }
 
 export const DEFAULT_PROVIDERS: LlmHubProvider[] = [
+  { name: 'Kimi', url: 'https://www.kimi.com' },
   { name: 'ChatGPT', url: 'https://chatgpt.com' },
   { name: 'Claude', url: 'https://claude.ai' },
   { name: 'Grok', url: 'https://grok.com' },

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -7,13 +7,6 @@ export interface LlmHubProvider {
   url: string
 }
 
-export const DEFAULT_PROVIDERS: LlmHubProvider[] = [
-  { name: 'Kimi', url: 'https://www.kimi.com' },
-  { name: 'ChatGPT', url: 'https://chatgpt.com' },
-  { name: 'Claude', url: 'https://claude.ai' },
-  { name: 'Gemini', url: 'https://gemini.google.com' },
-]
-
 const LEGACY_DEFAULTS_MAP = new Map([
   ['ChatGPT', 'https://chatgpt.com'],
   ['Claude', 'https://claude.ai'],
@@ -27,15 +20,13 @@ function isLegacyDefaults(providers: LlmHubProvider[]): boolean {
   return providers.every((p) => LEGACY_DEFAULTS_MAP.get(p.name) === p.url)
 }
 
-async function migrateToDefaultProviders(): Promise<LlmHubProvider[]> {
-  const defaults = DEFAULT_PROVIDERS.map((provider) => ({ ...provider }))
+async function clearLegacyDefaults(): Promise<void> {
   try {
     const adapter = getBrowserOSAdapter()
-    await adapter.setPref(BROWSEROS_PREFS.THIRD_PARTY_LLM_PROVIDERS, defaults)
+    await adapter.setPref(BROWSEROS_PREFS.THIRD_PARTY_LLM_PROVIDERS, [])
   } catch {
-    // Best effort migration: still return defaults for UI consistency
+    // best effort
   }
-  return defaults
 }
 
 export async function loadProviders(): Promise<LlmHubProvider[]> {
@@ -46,13 +37,14 @@ export async function loadProviders(): Promise<LlmHubProvider[]> {
     )
     const providers = (providersPref?.value as LlmHubProvider[]) || []
 
-    if (providers.length === 0 || isLegacyDefaults(providers)) {
-      return await migrateToDefaultProviders()
+    if (isLegacyDefaults(providers)) {
+      await clearLegacyDefaults()
+      return []
     }
 
     return providers
   } catch {
-    return DEFAULT_PROVIDERS.map((provider) => ({ ...provider }))
+    return []
   }
 }
 

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -14,17 +14,17 @@ export const DEFAULT_PROVIDERS: LlmHubProvider[] = [
   { name: 'Gemini', url: 'https://gemini.google.com' },
 ]
 
-const LEGACY_DEFAULT_NAMES = new Set([
-  'ChatGPT',
-  'Claude',
-  'Grok',
-  'Gemini',
-  'Perplexity',
+const LEGACY_DEFAULTS_MAP = new Map([
+  ['ChatGPT', 'https://chatgpt.com'],
+  ['Claude', 'https://claude.ai'],
+  ['Grok', 'https://grok.com'],
+  ['Gemini', 'https://gemini.google.com'],
+  ['Perplexity', 'https://www.perplexity.ai'],
 ])
 
 function isLegacyDefaults(providers: LlmHubProvider[]): boolean {
-  if (providers.length !== LEGACY_DEFAULT_NAMES.size) return false
-  return providers.every((p) => LEGACY_DEFAULT_NAMES.has(p.name))
+  if (providers.length !== LEGACY_DEFAULTS_MAP.size) return false
+  return providers.every((p) => LEGACY_DEFAULTS_MAP.get(p.name) === p.url)
 }
 
 async function migrateToDefaultProviders(): Promise<LlmHubProvider[]> {

--- a/apps/agent/lib/llm-hub/useLlmHubProviders.ts
+++ b/apps/agent/lib/llm-hub/useLlmHubProviders.ts
@@ -1,10 +1,5 @@
 import { useEffect, useState } from 'react'
-import {
-  DEFAULT_PROVIDERS,
-  type LlmHubProvider,
-  loadProviders,
-  saveProviders,
-} from './storage'
+import { type LlmHubProvider, loadProviders, saveProviders } from './storage'
 
 /** @public */
 export interface UseLlmHubProvidersReturn {
@@ -26,7 +21,7 @@ export function useLlmHubProviders(): UseLlmHubProvidersReturn {
         const data = await loadProviders()
         setProviders(data)
       } catch {
-        setProviders(DEFAULT_PROVIDERS)
+        setProviders([])
       } finally {
         setIsLoading(false)
       }

--- a/apps/agent/lib/llm-providers/providerIcons.tsx
+++ b/apps/agent/lib/llm-providers/providerIcons.tsx
@@ -3,6 +3,7 @@ import {
   Azure,
   Bedrock,
   Gemini,
+  Kimi,
   LmStudio,
   Ollama,
   OpenAI,
@@ -30,6 +31,7 @@ const providerIconMap: Record<ProviderType, IconComponent | null> = {
   lmstudio: LmStudio,
   bedrock: Bedrock,
   browseros: null,
+  moonshot: Kimi,
 }
 
 interface ProviderIconProps {

--- a/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -24,10 +24,11 @@ export const providerTemplates: ProviderTemplate[] = [
     id: 'moonshot',
     name: 'Moonshot / Kimi',
     defaultBaseUrl: 'https://api.moonshot.ai/v1',
-    defaultModelId: 'kimi-k2-0905-preview',
+    defaultModelId: 'kimi-k2.5',
     supportsImages: true,
     contextWindow: 128000,
     apiKeyUrl: 'https://platform.moonshot.ai/console/api-keys',
+    setupGuideUrl: 'https://platform.moonshot.ai/console/api-keys',
   },
   {
     id: 'openai',

--- a/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -21,6 +21,15 @@ export interface ProviderTemplate {
  */
 export const providerTemplates: ProviderTemplate[] = [
   {
+    id: 'moonshot',
+    name: 'Moonshot / Kimi',
+    defaultBaseUrl: 'https://api.moonshot.ai/v1',
+    defaultModelId: 'kimi-k2-0905-preview',
+    supportsImages: true,
+    contextWindow: 128000,
+    apiKeyUrl: 'https://platform.moonshot.ai/console/api-keys',
+  },
+  {
     id: 'openai',
     name: 'OpenAI',
     defaultBaseUrl: 'https://api.openai.com/v1',
@@ -119,6 +128,7 @@ export const providerTemplates: ProviderTemplate[] = [
  * @public
  */
 export const providerTypeOptions: { value: ProviderType; label: string }[] = [
+  { value: 'moonshot', label: 'Moonshot / Kimi' },
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'openai', label: 'OpenAI' },
   { value: 'openai-compatible', label: 'OpenAI Compatible' },
@@ -146,6 +156,7 @@ export const getProviderTemplate = (
  * Auto-fills when user selects a provider type
  */
 export const DEFAULT_BASE_URLS: Record<ProviderType, string> = {
+  moonshot: 'https://api.moonshot.ai/v1',
   anthropic: 'https://api.anthropic.com/v1',
   openai: 'https://api.openai.com/v1',
   'openai-compatible': '',

--- a/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -22,7 +22,7 @@ export interface ProviderTemplate {
 export const providerTemplates: ProviderTemplate[] = [
   {
     id: 'moonshot',
-    name: 'Moonshot / Kimi',
+    name: 'Moonshot AI',
     defaultBaseUrl: 'https://api.moonshot.ai/v1',
     defaultModelId: 'kimi-k2.5',
     supportsImages: true,
@@ -129,7 +129,7 @@ export const providerTemplates: ProviderTemplate[] = [
  * @public
  */
 export const providerTypeOptions: { value: ProviderType; label: string }[] = [
-  { value: 'moonshot', label: 'Moonshot / Kimi' },
+  { value: 'moonshot', label: 'Moonshot AI' },
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'openai', label: 'OpenAI' },
   { value: 'openai-compatible', label: 'OpenAI Compatible' },

--- a/apps/agent/lib/llm-providers/types.ts
+++ b/apps/agent/lib/llm-providers/types.ts
@@ -13,6 +13,7 @@ export type ProviderType =
   | 'lmstudio'
   | 'bedrock'
   | 'browseros'
+  | 'moonshot'
 
 /**
  * LLM Provider configuration

--- a/apps/server/src/agent/provider-adapter/index.ts
+++ b/apps/server/src/agent/provider-adapter/index.ts
@@ -164,10 +164,11 @@ function createMoonshotFactory(
   config: VercelAIConfig,
 ): (modelId: string) => unknown {
   if (!config.baseUrl) throw new Error('Moonshot provider requires baseUrl')
+  if (!config.apiKey) throw new Error('Moonshot provider requires apiKey')
   return createOpenAICompatible({
     name: 'moonshot',
     baseURL: config.baseUrl,
-    ...(config.apiKey && { apiKey: config.apiKey }),
+    apiKey: config.apiKey,
   })
 }
 

--- a/apps/server/src/agent/provider-adapter/index.ts
+++ b/apps/server/src/agent/provider-adapter/index.ts
@@ -160,6 +160,17 @@ function createOpenAICompatibleFactory(
   })
 }
 
+function createMoonshotFactory(
+  config: VercelAIConfig,
+): (modelId: string) => unknown {
+  if (!config.baseUrl) throw new Error('Moonshot provider requires baseUrl')
+  return createOpenAICompatible({
+    name: 'moonshot',
+    baseURL: config.baseUrl,
+    ...(config.apiKey && { apiKey: config.apiKey }),
+  })
+}
+
 const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [AIProvider.ANTHROPIC]: createAnthropicFactory,
   [AIProvider.OPENAI]: createOpenAIFactory,
@@ -171,6 +182,7 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [AIProvider.BEDROCK]: createBedrockFactory,
   [AIProvider.BROWSEROS]: createBrowserOSFactory,
   [AIProvider.OPENAI_COMPATIBLE]: createOpenAICompatibleFactory,
+  [AIProvider.MOONSHOT]: createMoonshotFactory,
 }
 
 /**

--- a/apps/server/src/agent/provider-adapter/types.ts
+++ b/apps/server/src/agent/provider-adapter/types.ts
@@ -214,6 +214,7 @@ export enum AIProvider {
   BEDROCK = 'bedrock',
   BROWSEROS = 'browseros',
   OPENAI_COMPATIBLE = 'openai-compatible',
+  MOONSHOT = 'moonshot',
 }
 
 /**

--- a/apps/server/src/agent/tool-loop/provider-factory.ts
+++ b/apps/server/src/agent/tool-loop/provider-factory.ts
@@ -136,6 +136,17 @@ function createOpenAICompatibleFactory(
   })
 }
 
+function createMoonshotFactory(
+  config: ResolvedAgentConfig,
+): (modelId: string) => unknown {
+  if (!config.baseUrl) throw new Error('Moonshot provider requires baseUrl')
+  return createOpenAICompatible({
+    name: 'moonshot',
+    baseURL: config.baseUrl,
+    ...(config.apiKey && { apiKey: config.apiKey }),
+  })
+}
+
 const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.ANTHROPIC]: createAnthropicFactory,
   [LLM_PROVIDERS.OPENAI]: createOpenAIFactory,
@@ -147,6 +158,7 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.BEDROCK]: createBedrockFactory,
   [LLM_PROVIDERS.BROWSEROS]: createBrowserOSFactory,
   [LLM_PROVIDERS.OPENAI_COMPATIBLE]: createOpenAICompatibleFactory,
+  [LLM_PROVIDERS.MOONSHOT]: createMoonshotFactory,
 }
 
 export function createLanguageModel(

--- a/apps/server/src/agent/tool-loop/provider-factory.ts
+++ b/apps/server/src/agent/tool-loop/provider-factory.ts
@@ -140,10 +140,11 @@ function createMoonshotFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.baseUrl) throw new Error('Moonshot provider requires baseUrl')
+  if (!config.apiKey) throw new Error('Moonshot provider requires apiKey')
   return createOpenAICompatible({
     name: 'moonshot',
     baseURL: config.baseUrl,
-    ...(config.apiKey && { apiKey: config.apiKey }),
+    apiKey: config.apiKey,
   })
 }
 

--- a/apps/server/src/lib/clients/llm/provider.ts
+++ b/apps/server/src/lib/clients/llm/provider.ts
@@ -124,6 +124,15 @@ function createOpenAICompatibleModel(config: ResolvedLLMConfig): LanguageModel {
   })(config.model)
 }
 
+function createMoonshotModel(config: ResolvedLLMConfig): LanguageModel {
+  if (!config.baseUrl) throw new Error('Moonshot provider requires baseUrl')
+  return createOpenAICompatible({
+    name: 'moonshot',
+    baseURL: config.baseUrl,
+    ...(config.apiKey && { apiKey: config.apiKey }),
+  })(config.model)
+}
+
 const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.ANTHROPIC]: createAnthropicModel,
   [LLM_PROVIDERS.OPENAI]: createOpenAIModel,
@@ -135,6 +144,7 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.BEDROCK]: createBedrockModel,
   [LLM_PROVIDERS.BROWSEROS]: createBrowserOSModel,
   [LLM_PROVIDERS.OPENAI_COMPATIBLE]: createOpenAICompatibleModel,
+  [LLM_PROVIDERS.MOONSHOT]: createMoonshotModel,
 }
 
 export function createLLMProvider(config: ResolvedLLMConfig): LanguageModel {

--- a/apps/server/src/lib/clients/llm/provider.ts
+++ b/apps/server/src/lib/clients/llm/provider.ts
@@ -126,10 +126,11 @@ function createOpenAICompatibleModel(config: ResolvedLLMConfig): LanguageModel {
 
 function createMoonshotModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.baseUrl) throw new Error('Moonshot provider requires baseUrl')
+  if (!config.apiKey) throw new Error('Moonshot provider requires apiKey')
   return createOpenAICompatible({
     name: 'moonshot',
     baseURL: config.baseUrl,
-    ...(config.apiKey && { apiKey: config.apiKey }),
+    apiKey: config.apiKey,
   })(config.model)
 }
 

--- a/packages/shared/src/schemas/llm.ts
+++ b/packages/shared/src/schemas/llm.ts
@@ -23,6 +23,7 @@ export const LLM_PROVIDERS = {
   BEDROCK: 'bedrock',
   BROWSEROS: 'browseros',
   OPENAI_COMPATIBLE: 'openai-compatible',
+  MOONSHOT: 'moonshot',
 } as const
 
 /**
@@ -40,6 +41,7 @@ export const LLMProviderSchema: z.ZodEnum<
     'bedrock',
     'browseros',
     'openai-compatible',
+    'moonshot',
   ]
 > = z.enum([
   LLM_PROVIDERS.ANTHROPIC,
@@ -52,6 +54,7 @@ export const LLMProviderSchema: z.ZodEnum<
   LLM_PROVIDERS.BEDROCK,
   LLM_PROVIDERS.BROWSEROS,
   LLM_PROVIDERS.OPENAI_COMPATIBLE,
+  LLM_PROVIDERS.MOONSHOT,
 ])
 
 export type LLMProvider = z.infer<typeof LLMProviderSchema>


### PR DESCRIPTION
## Summary
- Add **Moonshot / Kimi** as the first quick provider template in LLM Providers settings, pre-configured with Moonshot API (`https://api.moonshot.ai/v1`, model `kimi-k2-0905-preview`)
- Add **"Free model Sponsored by Kimi K2.5"** promotional badge on the BrowserOS built-in provider card
- Add **Kimi** at the top of LLM Chat & Hub with orange glow ring and "Try Kimi" badge
- Register `moonshot` as a recognized provider type across shared schema, all 3 server provider factories, and frontend

## Design
Moonshot API is OpenAI-compatible, so the server uses `createOpenAICompatible` for the factory — no new adapter code. Frontend changes add `moonshot` to the `ProviderType` union, provider templates, icons (using `Kimi` from `@lobehub/icons`), models data, and form schema. The promotional styling uses existing `--accent-orange` CSS variables and Tailwind utilities.

13 files changed across `packages/shared`, `apps/server`, and `apps/agent`.

## Test plan
- [ ] Build the agent extension and verify "Moonshot / Kimi" appears as first template in LLM Providers settings
- [ ] Click "USE" on the Kimi template → verify form pre-fills with Moonshot API URL and kimi-k2-0905-preview model
- [ ] Verify "Free model Sponsored by Kimi K2.5" badge shows on the BrowserOS provider card
- [ ] Navigate to LLM Chat & Hub → verify Kimi is at the top with orange glow and "Try Kimi" badge
- [ ] Test provider connection with a valid Moonshot API key
- [ ] Server typecheck passes (`bun run --filter @browseros/server typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)