### PR TITLE
fix: use JS scrollBy instead of CDP mouseWheel for scroll tool

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/apps/server/src/browser/browser.ts
+++ b/apps/server/src/browser/browser.ts
@@ -627,24 +627,35 @@ export class Browser {
     const session = await this.resolveSession(page)
     const pixels = amount * 120
 
-    let x: number
-    let y: number
-    if (element !== undefined) {
-      const center = await elements.getElementCenter(session, element)
-      x = center.x
-      y = center.y
-    } else {
-      const metrics = await session.Page.getLayoutMetrics()
-      x = metrics.layoutViewport.clientWidth / 2
-      y = metrics.layoutViewport.clientHeight / 2
-    }
-
     const deltaX =
       direction === 'left' ? -pixels : direction === 'right' ? pixels : 0
     const deltaY =
       direction === 'up' ? -pixels : direction === 'down' ? pixels : 0
 
-    await mouse.dispatchScroll(session, x, y, deltaX, deltaY)
+    if (element !== undefined) {
+      await elements.callOnElement(
+        session,
+        element,
+        `function(dx,dy){
+          var el=this;
+          while(el&&el!==document.documentElement){
+            var s=getComputedStyle(el);
+            var oy=s.overflowY,ox=s.overflowX;
+            if(((oy==='auto'||oy==='scroll')&&el.scrollHeight>el.clientHeight)||
+               ((ox==='auto'||ox==='scroll')&&el.scrollWidth>el.clientWidth)){
+              el.scrollBy(dx,dy);return
+            }
+            el=el.parentElement
+          }
+          window.scrollBy(dx,dy)
+        }`,
+        [deltaX, deltaY],
+      )
+    } else {
+      await session.Runtime.evaluate({
+        expression: `window.scrollBy(${deltaX},${deltaY})`,
+      })
+    }
   }
 
   async handleDialog(


### PR DESCRIPTION
## Summary
- CDP `Input.dispatchMouseEvent` with `mouseWheel` type is unreliable — synthetic wheel events are ignored by many modern sites and fail on unfocused/background tabs
- Switched to `window.scrollBy()` via `Runtime.evaluate` for page-level scroll
- For element scroll, walks up DOM to find nearest scrollable ancestor (`overflow: auto/scroll` with actual overflow), then calls `element.scrollBy()`, falling back to `window.scrollBy()`
- Eliminates an extra CDP round-trip (`Page.getLayoutMetrics`) making the tool faster

## Test plan
- [x] All 9 input tool tests pass
- [x] TypeScript typecheck passes for server package
- [x] Biome lint clean
- [ ] Manual test: scroll on HN, X.com, LinkedIn — verify pages actually scroll
- [ ] Manual test: scroll with element parameter on a scrollable container

🤖 Generated with [Claude Code](https://claude.com/claude-code)