### PR TITLE
fix: stabilize cdp connect and reconnect lifecycle

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/apps/server/src/browser/backends/cdp.ts
+++ b/apps/server/src/browser/backends/cdp.ts
@@ -27,6 +27,7 @@ class CdpBackend implements ICdpBackend {
   private connected = false
   private disconnecting = false
   private reconnecting = false
+  private reconnectRequested = false
   private eventHandlers = new Map<string, ((params: unknown) => void)[]>()
   private sessionCache = new Map<string, ProtocolApi>()
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null
@@ -66,15 +67,46 @@ class CdpBackend implements ICdpBackend {
 
   private attemptConnect(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      fetch(`http://localhost:${this.port}/json/version`)
-        .then((res) => res.json())
+      fetch(`http://127.0.0.1:${this.port}/json/version`, {
+        signal: AbortSignal.timeout(TIMEOUTS.CDP_CONNECT),
+      })
+        .then(async (res) => {
+          if (!res.ok) {
+            throw new Error(
+              `CDP /json/version failed with HTTP ${res.status}: ${res.statusText}`,
+            )
+          }
+          return res.json()
+        })
         .then((version) => {
           const wsUrl = (version as { webSocketDebuggerUrl: string })
             .webSocketDebuggerUrl
+          if (!wsUrl) {
+            throw new Error('CDP /json/version missing webSocketDebuggerUrl')
+          }
+
           let opened = false
+          let settled = false
           const ws = new WebSocket(wsUrl)
+          const connectTimeout = setTimeout(() => {
+            if (settled) return
+            settled = true
+            try {
+              ws.close()
+            } catch {
+              // Ignore close errors from half-open sockets
+            }
+            reject(
+              new Error(
+                `CDP WebSocket connect timeout after ${TIMEOUTS.CDP_CONNECT}ms`,
+              ),
+            )
+          }, TIMEOUTS.CDP_CONNECT)
 
           ws.onopen = () => {
+            if (settled) return
+            settled = true
+            clearTimeout(connectTimeout)
             opened = true
             this.ws = ws
             this.connected = true
@@ -83,10 +115,15 @@ class CdpBackend implements ICdpBackend {
           }
 
           ws.onerror = (event) => {
-            if (!opened) reject(new Error(`CDP WebSocket error: ${event}`))
+            if (!opened && !settled) {
+              settled = true
+              clearTimeout(connectTimeout)
+              reject(new Error(`CDP WebSocket error: ${event}`))
+            }
           }
 
           ws.onclose = () => {
+            clearTimeout(connectTimeout)
             // Guard against stale onclose from a replaced socket
             if (this.ws !== ws) return
             this.connected = false
@@ -162,27 +199,35 @@ class CdpBackend implements ICdpBackend {
   private handleUnexpectedClose(): void {
     if (this.disconnecting) return
 
-    // Allow re-entry if a previous reconnection already finished.
-    // The old guard `if (this.reconnecting) return` caused permanent
-    // death when a freshly reconnected socket closed again before
-    // the .finally() callback reset the flag.
-    if (this.reconnecting) {
-      logger.warn(
-        'CDP closed again while reconnecting — will retry after current attempt',
-      )
-      return
-    }
-
     this.stopKeepalive()
     this.rejectPendingRequests()
+
+    // If a freshly opened socket closes before the previous reconnect loop
+    // finishes, queue another reconnect instead of dropping into a dead state.
+    if (this.reconnecting) {
+      this.reconnectRequested = true
+      logger.warn('CDP closed while reconnecting, queueing another reconnect')
+      return
+    }
 
     logger.error(
       'CDP WebSocket closed unexpectedly, attempting reconnection...',
     )
     this.reconnecting = true
-    this.reconnectWithRetries().finally(() => {
+    this.reconnectRequested = false
+    this.reconnectLoop().finally(() => {
       this.reconnecting = false
     })
+  }
+
+  private async reconnectLoop(): Promise<void> {
+    do {
+      this.reconnectRequested = false
+      await this.reconnectWithRetries()
+    } while (
+      !this.disconnecting &&
+      (this.reconnectRequested || !this.connected)
+    )
   }
 
   private rejectPendingRequests(): void {

--- a/apps/server/tests/browser/backends/cdp.test.ts
+++ b/apps/server/tests/browser/backends/cdp.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, it } from 'bun:test'
+import assert from 'node:assert'
+import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
+import { CdpBackend } from '../../../src/browser/backends/cdp'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+
+  onopen: (() => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+  onclose: (() => void) | null = null
+  onmessage: ((event: { data: string }) => void) | null = null
+
+  readonly url: string
+  sent: string[] = []
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.onclose?.()
+  }
+
+  open(): void {
+    this.onopen?.()
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return
+    await Bun.sleep(1)
+  }
+  throw new Error('Timed out waiting for condition')
+}
+
+describe('CdpBackend', () => {
+  const originalFetch = globalThis.fetch
+  const originalWebSocket = globalThis.WebSocket
+  const originalConnectTimeout = TIMEOUTS.CDP_CONNECT
+  const originalReconnectDelay = TIMEOUTS.CDP_RECONNECT_DELAY
+  let fetchUrls: string[] = []
+
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    fetchUrls = []
+
+    ;(TIMEOUTS as unknown as { CDP_CONNECT: number }).CDP_CONNECT = 200
+    ;(
+      TIMEOUTS as unknown as { CDP_RECONNECT_DELAY: number }
+    ).CDP_RECONNECT_DELAY = 1
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      fetchUrls.push(String(input))
+      const id = fetchUrls.length
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          webSocketDebuggerUrl: `ws://127.0.0.1:9222/devtools/browser/${id}`,
+        }),
+      } as Response
+    }) as typeof fetch
+
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    globalThis.WebSocket = originalWebSocket
+    ;(TIMEOUTS as unknown as { CDP_CONNECT: number }).CDP_CONNECT =
+      originalConnectTimeout
+    ;(
+      TIMEOUTS as unknown as { CDP_RECONNECT_DELAY: number }
+    ).CDP_RECONNECT_DELAY = originalReconnectDelay
+  })
+
+  it('uses 127.0.0.1 for /json/version requests', async () => {
+    const cdp = new CdpBackend({ port: 9222 })
+    const connectPromise = cdp.connect()
+
+    await waitFor(() => MockWebSocket.instances.length === 1)
+    MockWebSocket.instances[0]?.open()
+    await connectPromise
+
+    assert.strictEqual(fetchUrls[0], 'http://127.0.0.1:9222/json/version')
+    await cdp.disconnect()
+  })
+
+  it('reconnects again when a socket closes during reconnect', async () => {
+    const cdp = new CdpBackend({ port: 9222 })
+    const connectPromise = cdp.connect()
+
+    await waitFor(() => MockWebSocket.instances.length === 1)
+    const ws1 = MockWebSocket.instances[0]
+    ws1?.open()
+    await connectPromise
+    assert.strictEqual(cdp.isConnected(), true)
+
+    ws1?.close()
+
+    await waitFor(() => MockWebSocket.instances.length >= 2)
+    const ws2 = MockWebSocket.instances[1]
+    ws2?.open()
+    ws2?.close()
+
+    await waitFor(() => MockWebSocket.instances.length >= 3)
+    const ws3 = MockWebSocket.instances[2]
+    ws3?.open()
+
+    await waitFor(() => cdp.isConnected())
+    assert.strictEqual(cdp.isConnected(), true)
+    assert(fetchUrls.length >= 3)
+    await cdp.disconnect()
+  })
+})


### PR DESCRIPTION
## Summary
- Use `127.0.0.1` for CDP `/json/version` discovery to avoid host-resolution mismatches in `webSocketDebuggerUrl`.
- Add connect-time timeouts and validation for CDP discovery + WebSocket handshake so startup/reconnect attempts fail fast and retry cleanly.
- Fix reconnect race by queuing an additional reconnect when a socket closes during an in-flight reconnect, preventing a permanent disconnected state.

## Design
The CDP backend now performs deterministic loopback discovery (`127.0.0.1`) with explicit timeout/error handling for both HTTP discovery and WebSocket connect. Reconnect orchestration was split into a loop that can queue follow-up retries when closures happen before the previous reconnect cycle fully unwinds. This removes the dead-state window where CDP could remain disconnected despite a prior reconnect path finishing.

## Test plan
- `bun --env-file=apps/server/.env.example test apps/server/tests/browser/backends/cdp.test.ts`
- `bunx biome check apps/server/src/browser/backends/cdp.ts apps/server/tests/browser/backends/cdp.test.ts`
- `bun run --filter @browseros/server typecheck`
- `bun test tests/tools/navigation.test.ts` (from `apps/server`, rerun passed)
- `bun test tests/tools/windows.test.ts` (from `apps/server`)
- `autoninja -C out/Default_arm64 chrome` (from Chromium checkout)
- Smoke test with built `BrowserOS Dev` binary: launch with `--remote-debugging-port`, verify `/json/version`, then connect/disconnect with `CdpBackend`
