### PR TITLE
feat: improve scroll reliability and tool response latency

### DIFF
--- a/apps/server/src/browser/browser.ts
+++ b/apps/server/src/browser/browser.ts
@@ -626,6 +626,12 @@ export class Browser {
   ): Promise<void> {
     const session = await this.resolveSession(page)
     const pixels = amount * 120
+    const deltaX =
+      direction === 'left' ? -pixels : direction === 'right' ? pixels : 0
+    const deltaY =
+      direction === 'up' ? -pixels : direction === 'down' ? pixels : 0
+
+    if (deltaX === 0 && deltaY === 0) return
 
     let x: number
     let y: number
@@ -639,12 +645,64 @@ export class Browser {
       y = metrics.layoutViewport.clientHeight / 2
     }
 
-    const deltaX =
-      direction === 'left' ? -pixels : direction === 'right' ? pixels : 0
-    const deltaY =
-      direction === 'up' ? -pixels : direction === 'down' ? pixels : 0
+    const beforeWindowPosition =
+      element === undefined
+        ? await this.getWindowScrollPosition(session)
+        : undefined
 
     await mouse.dispatchScroll(session, x, y, deltaX, deltaY)
+
+    if (beforeWindowPosition === undefined) return
+
+    const afterWindowPosition = await this.getWindowScrollPosition(session)
+    const moved = this.didScrollInExpectedDirection(
+      beforeWindowPosition,
+      afterWindowPosition,
+      deltaX,
+      deltaY,
+    )
+    if (moved) return
+
+    await this.fallbackWindowScroll(session, deltaX, deltaY)
+  }
+
+  private async getWindowScrollPosition(
+    session: ProtocolApi,
+  ): Promise<{ x: number; y: number }> {
+    const result = await session.Runtime.evaluate({
+      expression:
+        '({ x: window.scrollX ?? window.pageXOffset ?? 0, y: window.scrollY ?? window.pageYOffset ?? 0 })',
+      returnByValue: true,
+    })
+    const value = (result.result?.value ?? {}) as { x?: number; y?: number }
+    return {
+      x: typeof value.x === 'number' ? value.x : 0,
+      y: typeof value.y === 'number' ? value.y : 0,
+    }
+  }
+
+  private didScrollInExpectedDirection(
+    before: { x: number; y: number },
+    after: { x: number; y: number },
+    deltaX: number,
+    deltaY: number,
+  ): boolean {
+    if (deltaX > 0 && after.x > before.x) return true
+    if (deltaX < 0 && after.x < before.x) return true
+    if (deltaY > 0 && after.y > before.y) return true
+    if (deltaY < 0 && after.y < before.y) return true
+    return false
+  }
+
+  private async fallbackWindowScroll(
+    session: ProtocolApi,
+    deltaX: number,
+    deltaY: number,
+  ): Promise<void> {
+    await session.Runtime.evaluate({
+      expression: `window.scrollBy(${deltaX}, ${deltaY})`,
+      returnByValue: true,
+    })
   }
 
   async handleDialog(

--- a/apps/server/src/tools/input.ts
+++ b/apps/server/src/tools/input.ts
@@ -172,7 +172,6 @@ export const scroll = defineTool({
       args.element,
     )
     response.text(`Scrolled ${args.direction} by ${args.amount}`)
-    response.includeSnapshot(args.page)
   },
 })
 

--- a/apps/server/src/tools/response.ts
+++ b/apps/server/src/tools/response.ts
@@ -85,6 +85,7 @@ export class ToolResponse {
           )
           this.text(`[Open pages]\n${lines.join('\n')}`)
         }
+        return
       }
     }
   }

--- a/apps/server/src/tools/response.ts
+++ b/apps/server/src/tools/response.ts
@@ -1,3 +1,4 @@
+import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
 import type { Browser } from '../browser/browser'
 
 export type ContentItem =
@@ -14,10 +15,20 @@ export interface ToolResult {
   isError?: boolean
 }
 
+interface ToolResponseOptions {
+  postActionTimeoutMs?: number
+}
+
 export class ToolResponse {
   private content: ContentItem[] = []
   private hasError = false
   private postActions: PostAction[] = []
+  private postActionTimeoutMs: number
+
+  constructor(options: ToolResponseOptions = {}) {
+    this.postActionTimeoutMs =
+      options.postActionTimeoutMs ?? TIMEOUTS.TOOL_POST_ACTION
+  }
 
   text(value: string): void {
     this.content.push({ type: 'text', text: value })
@@ -44,6 +55,56 @@ export class ToolResponse {
     this.postActions.push({ type: 'pages' })
   }
 
+  private async runPostAction(
+    action: PostAction,
+    browser: Browser,
+  ): Promise<void> {
+    switch (action.type) {
+      case 'snapshot': {
+        const tree = await browser.snapshot(action.page)
+        if (tree) this.text(`[Page ${action.page} snapshot]\n${tree}`)
+        return
+      }
+      case 'screenshot': {
+        const result = await browser.screenshot(action.page, {
+          format: 'png',
+          fullPage: false,
+        })
+        this.text(`[Page ${action.page} screenshot]`)
+        this.image(result.data, result.mimeType)
+        return
+      }
+      case 'pages': {
+        const pages = await browser.listPages()
+        if (pages.length === 0) {
+          this.text('[Open pages] None')
+        } else {
+          const lines = pages.map(
+            (p) =>
+              `  ${p.pageId}. ${p.title || '(untitled)'} — ${p.url}${p.isActive ? ' [ACTIVE]' : ''}`,
+          )
+          this.text(`[Open pages]\n${lines.join('\n')}`)
+        }
+      }
+    }
+  }
+
+  private async withTimeout<T>(task: Promise<T>): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        task,
+        new Promise<T>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(new Error('Post-action timed out'))
+          }, this.postActionTimeoutMs)
+        }),
+      ])
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
+    }
+  }
+
   async build(browser: Browser): Promise<ToolResult> {
     if (this.postActions.length > 0) {
       this.text('\n--- Additional context (auto-included) ---')
@@ -51,35 +112,7 @@ export class ToolResponse {
 
     for (const action of this.postActions) {
       try {
-        switch (action.type) {
-          case 'snapshot': {
-            const tree = await browser.snapshot(action.page)
-            if (tree) this.text(`[Page ${action.page} snapshot]\n${tree}`)
-            break
-          }
-          case 'screenshot': {
-            const result = await browser.screenshot(action.page, {
-              format: 'png',
-              fullPage: false,
-            })
-            this.text(`[Page ${action.page} screenshot]`)
-            this.image(result.data, result.mimeType)
-            break
-          }
-          case 'pages': {
-            const pages = await browser.listPages()
-            if (pages.length === 0) {
-              this.text('[Open pages] None')
-            } else {
-              const lines = pages.map(
-                (p) =>
-                  `  ${p.pageId}. ${p.title || '(untitled)'} — ${p.url}${p.isActive ? ' [ACTIVE]' : ''}`,
-              )
-              this.text(`[Open pages]\n${lines.join('\n')}`)
-            }
-            break
-          }
-        }
+        await this.withTimeout(this.runPostAction(action, browser))
       } catch {
         // Post-action failure doesn't fail the tool
       }

--- a/apps/server/tests/tools/input.test.ts
+++ b/apps/server/tests/tools/input.test.ts
@@ -298,9 +298,14 @@ describe('input tools', () => {
   it('scroll dispatches without error', async () => {
     await withBrowser(async ({ execute }) => {
       const newResult = await execute(new_page, {
-        url: 'https://example.com',
+        url: FORM_PAGE,
       })
       const pageId = Number(textOf(newResult).match(/Page ID:\s*(\d+)/)?.[1])
+
+      const before = await execute(evaluate_script, {
+        page: pageId,
+        expression: 'window.scrollY',
+      })
 
       const scrollResult = await execute(scroll, {
         page: pageId,
@@ -309,6 +314,15 @@ describe('input tools', () => {
       })
       assert.ok(!scrollResult.isError, textOf(scrollResult))
       assert.ok(textOf(scrollResult).includes('Scrolled down'))
+
+      const after = await execute(evaluate_script, {
+        page: pageId,
+        expression: 'window.scrollY',
+      })
+      assert.ok(
+        Number(textOf(after)) > Number(textOf(before)),
+        `Expected scrollY to increase, before=${textOf(before)} after=${textOf(after)}`,
+      )
 
       await execute(close_page, { page: pageId })
     })

--- a/apps/server/tests/tools/response.test.ts
+++ b/apps/server/tests/tools/response.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'bun:test'
+import assert from 'node:assert'
+import type { Browser } from '../../src/browser/browser'
+import { ToolResponse } from '../../src/tools/response'
+
+function textOf(result: {
+  content: { type: string; text?: string }[]
+}): string {
+  return result.content
+    .filter((item) => item.type === 'text')
+    .map((item) => item.text)
+    .join('\n')
+}
+
+describe('ToolResponse', () => {
+  it('times out slow post-actions without failing tool output', async () => {
+    const response = new ToolResponse({ postActionTimeoutMs: 25 })
+    response.text('ok')
+    response.includeSnapshot(1)
+
+    const browser = {
+      snapshot: async () => await new Promise<string>(() => {}),
+    } as unknown as Browser
+
+    const start = Date.now()
+    const result = await response.build(browser)
+    const elapsed = Date.now() - start
+
+    assert.ok(elapsed < 250, `Expected fast timeout, got ${elapsed}ms`)
+    assert.ok(!result.isError)
+
+    const text = textOf(result)
+    assert.ok(text.includes('ok'))
+    assert.ok(!text.includes('[Page 1 snapshot]'))
+  })
+
+  it('includes snapshot output when post-action completes in time', async () => {
+    const response = new ToolResponse({ postActionTimeoutMs: 200 })
+    response.text('ok')
+    response.includeSnapshot(1)
+
+    const browser = {
+      snapshot: async () => '[42] button "Submit"',
+    } as unknown as Browser
+
+    const result = await response.build(browser)
+    const text = textOf(result)
+
+    assert.ok(text.includes('ok'))
+    assert.ok(text.includes('[Page 1 snapshot]'))
+    assert.ok(text.includes('[42] button "Submit"'))
+  })
+})

--- a/packages/shared/src/constants/timeouts.ts
+++ b/packages/shared/src/constants/timeouts.ts
@@ -9,6 +9,7 @@
 export const TIMEOUTS = {
   // Agent/Tool execution
   TOOL_CALL: 120_000,
+  TOOL_POST_ACTION: 2_000,
   TEST_PROVIDER: 15_000,
 
   // Controller communication


### PR DESCRIPTION
## Summary
- Improve `scroll` reliability by keeping wheel-input first and falling back to `window.scrollBy(...)` when page-level movement is not detected.
- Reduce scroll latency by removing automatic post-scroll snapshots in the `scroll` tool response.
- Add bounded post-action execution for auto-included context so slow snapshots/screenshots/pages no longer stall tool responses.

## Design
This change follows a hybrid approach: keep existing CDP interaction semantics, then add deterministic fallback only when scroll movement fails. In parallel, post-action context generation is now best-effort with a shared timeout budget to prevent long-running tool responses. The implementation is contained in the server tool/browsing layers and keeps the MCP `scroll` API backward compatible.

## Test plan
- `bun test tests/tools/response.test.ts`
- `bun test tests/tools/input.test.ts`
- `bun run --filter @browseros/server typecheck`
- `bunx biome check apps/server/src/tools/response.ts apps/server/src/tools/input.ts apps/server/src/browser/browser.ts apps/server/tests/tools/input.test.ts apps/server/tests/tools/response.test.ts packages/shared/src/constants/timeouts.ts`
