### PR TITLE
fix: restore glow overlay for CDP-based tools

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx
@@ -2,6 +2,19 @@ import type { ChatStatus, ToolUIPart, UIMessage } from 'ai'
 import { useEffect, useRef } from 'react'
 import type { GlowMessage } from '@/entrypoints/glow.content/GlowMessage'
 
+function extractTabId(toolPart: ToolUIPart | null): number | undefined {
+  if (!toolPart) return undefined
+
+  // CDP tools: server includes tabId in tool output
+  const output = (toolPart as ToolUIPart & { output?: { tabId?: number } })
+    ?.output
+  if (output?.tabId) return output.tabId
+
+  // Legacy controller tools: tabId in input
+  const input = (toolPart as ToolUIPart & { input?: { tabId?: number } })?.input
+  return input?.tabId
+}
+
 export const useNotifyActiveTab = ({
   messages,
   status,
@@ -11,7 +24,6 @@ export const useNotifyActiveTab = ({
   status: ChatStatus
   conversationId: string
 }) => {
-  // Ref to store the last active tab ID
   const lastTabIdRef = useRef<number | null>(null)
 
   const lastMessage = messages?.[messages.length - 1]
@@ -20,52 +32,68 @@ export const useNotifyActiveTab = ({
     lastMessage?.parts?.findLast((part) => part?.type?.startsWith('tool-')) ??
     null
 
-  const latestTabId = (
-    latestTool as ToolUIPart & { input?: { tabId?: number } }
-  )?.input?.tabId
+  const hasToolCalls = !!latestTool
+  const toolTabId = extractTabId(latestTool as ToolUIPart | null)
 
   useEffect(() => {
     const isStreaming = status === 'streaming'
     const previousTabId = lastTabIdRef.current
 
-    // Streaming stopped - turn off glow on the last active tab
-    const stoppedStreaming = !isStreaming && previousTabId
-
-    // Switched to a different tab while streaming - need to turn off glow on old tab
-    const switchedTabs =
-      isStreaming &&
-      latestTabId &&
-      previousTabId &&
-      latestTabId !== previousTabId
-
-    if (stoppedStreaming || switchedTabs) {
+    if (!isStreaming) {
       if (previousTabId) {
         const deactivateMessage: GlowMessage = {
           conversationId,
           isActive: false,
         }
-        chrome.tabs.sendMessage(previousTabId, deactivateMessage).catch(() => {
-          // no action needed if the tab is closed or does not exist
-        })
+        chrome.tabs
+          .sendMessage(previousTabId, deactivateMessage)
+          .catch(() => {})
+        lastTabIdRef.current = null
       }
+      return
     }
 
-    // Activate glow on current tab while streaming
-    if (isStreaming && latestTabId) {
+    if (!hasToolCalls) return
+
+    let cancelled = false
+
+    const activate = async () => {
+      let targetTabId = toolTabId
+
+      if (!targetTabId) {
+        const tabs = await chrome.tabs.query({
+          active: true,
+          currentWindow: true,
+        })
+        targetTabId = tabs[0]?.id
+      }
+
+      if (cancelled || !targetTabId) return
+
+      if (previousTabId && previousTabId !== targetTabId) {
+        const deactivateMessage: GlowMessage = {
+          conversationId,
+          isActive: false,
+        }
+        chrome.tabs
+          .sendMessage(previousTabId, deactivateMessage)
+          .catch(() => {})
+      }
+
       const activateMessage: GlowMessage = {
         conversationId,
         isActive: true,
       }
-      chrome.tabs.sendMessage(latestTabId, activateMessage).catch(() => {
-        // no action needed if the tab is closed or does not exist
-      })
+      chrome.tabs.sendMessage(targetTabId, activateMessage).catch(() => {})
+      lastTabIdRef.current = targetTabId
     }
 
-    // Track the latest tab for future comparisons
-    if (latestTabId) {
-      lastTabIdRef.current = latestTabId
+    activate()
+
+    return () => {
+      cancelled = true
     }
-  }, [conversationId, status, latestTabId])
+  }, [conversationId, status, hasToolCalls, toolTabId])
 
   return
 }

--- a/apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx
@@ -5,10 +5,13 @@ import type { GlowMessage } from '@/entrypoints/glow.content/GlowMessage'
 function extractTabId(toolPart: ToolUIPart | null): number | undefined {
   if (!toolPart) return undefined
 
-  // CDP tools: server includes tabId in tool output
-  const output = (toolPart as ToolUIPart & { output?: { tabId?: number } })
-    ?.output
-  if (output?.tabId) return output.tabId
+  // CDP tools: server includes tabId in tool output metadata
+  const output = (
+    toolPart as ToolUIPart & {
+      output?: { metadata?: { tabId?: number } }
+    }
+  )?.output
+  if (output?.metadata?.tabId) return output.metadata.tabId
 
   // Legacy controller tools: tabId in input
   const input = (toolPart as ToolUIPart & { input?: { tabId?: number } })?.input

--- a/apps/server/src/agent/tool-loop/tool-adapter.ts
+++ b/apps/server/src/agent/tool-loop/tool-adapter.ts
@@ -62,16 +62,10 @@ export function buildBrowserToolSet(
             success: !result.isError,
           })
 
-          const pageId = (params as Record<string, unknown>).page
-          const tabId =
-            typeof pageId === 'number'
-              ? browser.getTabIdForPage(pageId)
-              : undefined
-
           return {
             content: result.content,
             isError: result.isError ?? false,
-            tabId,
+            metadata: result.metadata,
           }
         } catch (error) {
           const errorText =

--- a/apps/server/src/agent/tool-loop/tool-adapter.ts
+++ b/apps/server/src/agent/tool-loop/tool-adapter.ts
@@ -62,7 +62,17 @@ export function buildBrowserToolSet(
             success: !result.isError,
           })
 
-          return { content: result.content, isError: result.isError ?? false }
+          const pageId = (params as Record<string, unknown>).page
+          const tabId =
+            typeof pageId === 'number'
+              ? browser.getTabIdForPage(pageId)
+              : undefined
+
+          return {
+            content: result.content,
+            isError: result.isError ?? false,
+            tabId,
+          }
         } catch (error) {
           const errorText =
             error instanceof Error ? error.message : String(error)

--- a/apps/server/src/browser/browser.ts
+++ b/apps/server/src/browser/browser.ts
@@ -210,6 +210,10 @@ export class Browser {
     return [...this.pages.values()].sort((a, b) => a.pageId - b.pageId)
   }
 
+  getTabIdForPage(pageId: number): number | undefined {
+    return this.pages.get(pageId)?.tabId
+  }
+
   async resolveTabIds(tabIds: number[]): Promise<Map<number, number>> {
     await this.listPages()
     const tabToPage = new Map<number, number>()

--- a/apps/server/src/tools/framework.ts
+++ b/apps/server/src/tools/framework.ts
@@ -52,5 +52,15 @@ export async function executeTool(
     response.error(`Internal error in ${tool.name}: ${message}`)
   }
 
-  return response.build(ctx.browser)
+  const result = await response.build(ctx.browser)
+
+  const pageId = (args as Record<string, unknown>).page
+  if (typeof pageId === 'number') {
+    const tabId = ctx.browser.getTabIdForPage(pageId)
+    if (tabId !== undefined) {
+      result.metadata = { ...result.metadata, tabId }
+    }
+  }
+
+  return result
 }

--- a/apps/server/src/tools/framework.ts
+++ b/apps/server/src/tools/framework.ts
@@ -54,6 +54,7 @@ export async function executeTool(
 
   const result = await response.build(ctx.browser)
 
+  // TODO: nikhil -- maybe add to tool context instead of ugly args casting
   const pageId = (args as Record<string, unknown>).page
   if (typeof pageId === 'number') {
     const tabId = ctx.browser.getTabIdForPage(pageId)

--- a/apps/server/src/tools/response.ts
+++ b/apps/server/src/tools/response.ts
@@ -9,9 +9,14 @@ export type PostAction =
   | { type: 'screenshot'; page: number }
   | { type: 'pages' }
 
+export interface ToolResultMetadata {
+  tabId?: number
+}
+
 export interface ToolResult {
   content: ContentItem[]
   isError?: boolean
+  metadata?: ToolResultMetadata
 }
 
 export class ToolResponse {


### PR DESCRIPTION
## Summary
- After migrating all tools to CDP-based backends, the glow overlay (orange pulsing border on active tab) stopped working because useNotifyActiveTab looked for input.tabId in tool calls, but CDP tools use input.page (internal pageId) instead
- Server: Added getTabIdForPage() to Browser class to resolve pageId to Chrome tabId. The tool adapter now includes the Chrome tabId in every tool output for page-specific tools
- Client: Updated useNotifyActiveTab hook to extract tabId from tool output (CDP tools) with fallback to tool input (legacy) and active Chrome tab query

## Test plan
- [ ] Run agent on a tab and verify the orange glow overlay appears during tool execution
- [ ] Verify glow deactivates when the agent stops streaming
- [ ] Verify glow follows tab switches when the agent navigates to different pages
- [ ] Verify the stop button in the glow overlay still works
- [ ] Run bun run test to confirm no regressions (157 pass, 2 pre-existing failures in tab-groups)