### PR TITLE
[DRAFT] Work on Browseros-agent repo Bring Kalvis MCP support to the BrowserOS MCP serve

### DIFF
--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -11,6 +11,7 @@ import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
 import type { ToolRegistry } from '../../tools/tool-registry'
+import type { KlavisMcpClientManager } from '../services/mcp/klavis-mcp-client'
 import { createMcpServer } from '../services/mcp/mcp-server'
 import type { Env } from '../types'
 
@@ -18,6 +19,7 @@ interface McpRouteDeps {
   version: string
   registry: ToolRegistry
   browser: Browser
+  klavisMcpClient?: KlavisMcpClientManager
 }
 
 export function createMcpRoutes(deps: McpRouteDeps) {

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -15,8 +15,8 @@ import { cors } from 'hono/cors'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { HttpAgentError } from '../agent/errors'
 import { SessionManager } from '../agent/session'
+import { KlavisClient } from '../lib/clients/klavis/klavis-client'
 import { logger } from '../lib/logger'
-
 import { createChatRoutes } from './routes/chat'
 import { createChatV2Routes } from './routes/chat-v2'
 import { createGraphRoutes } from './routes/graph'
@@ -27,6 +27,7 @@ import { createProviderRoutes } from './routes/provider'
 import { createSdkRoutes } from './routes/sdk'
 import { createShutdownRoute } from './routes/shutdown'
 import { createStatusRoute } from './routes/status'
+import { KlavisMcpClientManager } from './services/mcp/klavis-mcp-client'
 import type { Env, HttpServerConfig } from './types'
 import { defaultCorsConfig } from './utils/cors'
 
@@ -71,6 +72,21 @@ export async function createHttpServer(config: HttpServerConfig) {
   const { onShutdown } = config
   const sessionManager = new SessionManager()
 
+  // Eagerly initialize Klavis MCP client to expose Klavis tools via /mcp
+  let klavisMcpClient: KlavisMcpClientManager | undefined
+  if (browserosId) {
+    try {
+      const klavisClient = new KlavisClient()
+      klavisMcpClient = new KlavisMcpClientManager(klavisClient, browserosId)
+      await klavisMcpClient.initialize()
+    } catch (error) {
+      logger.warn('Failed to initialize Klavis MCP client for /mcp endpoint', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      klavisMcpClient = undefined
+    }
+  }
+
   const app = new Hono<Env>()
     .use('/*', cors(defaultCorsConfig))
     .route('/health', createHealthRoute({ browser }))
@@ -87,6 +103,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         version,
         registry,
         browser,
+        klavisMcpClient,
       }),
     )
     .route(

--- a/apps/server/src/api/services/mcp/klavis-mcp-client.ts
+++ b/apps/server/src/api/services/mcp/klavis-mcp-client.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Manages a persistent MCP client connection to a Klavis Strata server.
+ * Fetches tool definitions at startup and proxies tool calls at runtime.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
+import { logger } from '../../../lib/logger'
+
+export interface KlavisTool {
+  name: string
+  description?: string
+  inputSchema: {
+    type: 'object'
+    properties?: Record<string, object>
+    required?: string[]
+    [key: string]: unknown
+  }
+}
+
+export class KlavisMcpClientManager {
+  private client: Client | null = null
+  private transport: StreamableHTTPClientTransport | null = null
+  private tools: KlavisTool[] = []
+  private strataServerUrl: string | null = null
+
+  constructor(
+    private klavisClient: KlavisClient,
+    private browserosId: string,
+  ) {}
+
+  async initialize(): Promise<void> {
+    if (!this.browserosId) {
+      logger.info(
+        'No browserosId configured, skipping Klavis MCP initialization',
+      )
+      return
+    }
+
+    let authenticatedServers: string[]
+    try {
+      const integrations = await this.klavisClient.getUserIntegrations(
+        this.browserosId,
+      )
+      authenticatedServers = integrations
+        .filter((i) => i.isAuthenticated)
+        .map((i) => i.name)
+    } catch (error) {
+      logger.warn('Failed to fetch Klavis user integrations', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return
+    }
+
+    if (authenticatedServers.length === 0) {
+      logger.info(
+        'No authenticated Klavis integrations found, skipping Klavis MCP',
+      )
+      return
+    }
+
+    let strataUrl: string
+    try {
+      const result = await this.klavisClient.createStrata(
+        this.browserosId,
+        authenticatedServers,
+      )
+      strataUrl = result.strataServerUrl
+      this.strataServerUrl = strataUrl
+      logger.info('Created Klavis Strata for MCP proxy', {
+        browserosId: this.browserosId.slice(0, 12),
+        servers: authenticatedServers,
+        strataUrl,
+      })
+    } catch (error) {
+      logger.warn('Failed to create Klavis Strata', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return
+    }
+
+    await this.connectAndListTools(strataUrl)
+  }
+
+  private async connectAndListTools(strataUrl: string): Promise<void> {
+    try {
+      this.client = new Client({
+        name: 'browseros-klavis-proxy',
+        version: '1.0.0',
+      })
+
+      this.transport = new StreamableHTTPClientTransport(new URL(strataUrl))
+
+      await this.client.connect(this.transport)
+
+      const result = await this.client.listTools()
+      this.tools = (result.tools ?? []).map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      }))
+
+      logger.info('Fetched Klavis tools via MCP client', {
+        toolCount: this.tools.length,
+        toolNames: this.tools.map((t) => t.name),
+      })
+    } catch (error) {
+      logger.warn('Failed to connect to Klavis Strata MCP server', {
+        error: error instanceof Error ? error.message : String(error),
+        strataUrl,
+      })
+      this.tools = []
+      await this.cleanup()
+    }
+  }
+
+  getTools(): KlavisTool[] {
+    return this.tools
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<{
+    content: Array<{ type: string; text?: string }>
+    isError?: boolean
+  }> {
+    if (!this.client) {
+      // Attempt one reconnect if we have a strata URL
+      if (this.strataServerUrl) {
+        logger.info(
+          'MCP client disconnected, attempting reconnect for callTool',
+        )
+        await this.connectAndListTools(this.strataServerUrl)
+      }
+      if (!this.client) {
+        return {
+          content: [
+            { type: 'text', text: 'Klavis MCP client is not connected' },
+          ],
+          isError: true,
+        }
+      }
+    }
+
+    try {
+      const result = await this.client.callTool({ name, arguments: args })
+      return result as {
+        content: Array<{ type: string; text?: string }>
+        isError?: boolean
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error)
+      logger.warn('Klavis callTool failed, attempting reconnect', {
+        tool: name,
+        error: errorMsg,
+      })
+
+      // Single reconnect attempt on failure
+      await this.cleanup()
+      if (this.strataServerUrl) {
+        await this.connectAndListTools(this.strataServerUrl)
+        if (this.client) {
+          try {
+            const retryResult = await this.client.callTool({
+              name,
+              arguments: args,
+            })
+            return retryResult as {
+              content: Array<{ type: string; text?: string }>
+              isError?: boolean
+            }
+          } catch (retryError) {
+            const retryMsg =
+              retryError instanceof Error
+                ? retryError.message
+                : String(retryError)
+            logger.error('Klavis callTool retry also failed', {
+              tool: name,
+              error: retryMsg,
+            })
+          }
+        }
+      }
+
+      return {
+        content: [
+          { type: 'text', text: `Klavis tool call failed: ${errorMsg}` },
+        ],
+        isError: true,
+      }
+    }
+  }
+
+  private async cleanup(): Promise<void> {
+    try {
+      await this.transport?.close()
+    } catch {
+      // Ignore close errors
+    }
+    this.client = null
+    this.transport = null
+  }
+
+  async close(): Promise<void> {
+    await this.cleanup()
+    this.tools = []
+    this.strataServerUrl = null
+  }
+}

--- a/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/apps/server/src/api/services/mcp/mcp-server.ts
@@ -8,12 +8,15 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { Browser } from '../../../browser/browser'
 import type { ToolRegistry } from '../../../tools/tool-registry'
+import type { KlavisMcpClientManager } from './klavis-mcp-client'
+import { registerKlavisTools } from './register-klavis-tools'
 import { registerTools } from './register-mcp'
 
 export interface McpServiceDeps {
   version: string
   registry: ToolRegistry
   browser: Browser
+  klavisMcpClient?: KlavisMcpClientManager
 }
 
 export function createMcpServer(deps: McpServiceDeps): McpServer {
@@ -31,6 +34,10 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
   })
 
   registerTools(server, deps.registry, { browser: deps.browser })
+
+  if (deps.klavisMcpClient) {
+    registerKlavisTools(server, deps.klavisMcpClient, deps.registry)
+  }
 
   return server
 }

--- a/apps/server/src/api/services/mcp/register-klavis-tools.ts
+++ b/apps/server/src/api/services/mcp/register-klavis-tools.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Registers Klavis Strata tools on the BrowserOS MCP server as proxy tools.
+ * Each Klavis tool call is forwarded to the Strata MCP server via the client manager.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { logger } from '../../../lib/logger'
+import { metrics } from '../../../lib/metrics'
+import type { ToolRegistry } from '../../../tools/tool-registry'
+import type { KlavisMcpClientManager } from './klavis-mcp-client'
+
+export function registerKlavisTools(
+  mcpServer: McpServer,
+  manager: KlavisMcpClientManager,
+  browserToolRegistry: ToolRegistry,
+): void {
+  const klavisTools = manager.getTools()
+  const browserToolNames = new Set(browserToolRegistry.names())
+  let registeredCount = 0
+
+  for (const tool of klavisTools) {
+    if (browserToolNames.has(tool.name)) {
+      logger.warn(
+        'Skipping Klavis tool due to name conflict with browser tool',
+        {
+          tool: tool.name,
+        },
+      )
+      continue
+    }
+
+    const handler = async (args: Record<string, unknown>) => {
+      const startTime = performance.now()
+
+      try {
+        logger.info(
+          `Klavis tool ${tool.name} request: ${JSON.stringify(args, null, '  ')}`,
+        )
+
+        const result = await manager.callTool(tool.name, args)
+
+        metrics.log('tool_executed', {
+          tool_name: tool.name,
+          duration_ms: Math.round(performance.now() - startTime),
+          success: !result.isError,
+          source: 'klavis',
+        })
+
+        return {
+          content: result.content as Array<{
+            type: 'text'
+            text: string
+          }>,
+          isError: result.isError,
+        }
+      } catch (error) {
+        const errorText = error instanceof Error ? error.message : String(error)
+
+        metrics.log('tool_executed', {
+          tool_name: tool.name,
+          duration_ms: Math.round(performance.now() - startTime),
+          success: false,
+          error_message: errorText,
+          source: 'klavis',
+        })
+
+        return {
+          content: [{ type: 'text' as const, text: errorText }],
+          isError: true,
+        }
+      }
+    }
+
+    mcpServer.registerTool(
+      tool.name,
+      {
+        description: tool.description,
+        inputSchema: tool.inputSchema as unknown as Record<string, never>,
+      },
+      handler,
+    )
+    registeredCount++
+  }
+
+  if (registeredCount > 0) {
+    logger.info(`Registered ${registeredCount} Klavis tools on MCP server`)
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.61",
+      "version": "0.0.62",
       "bin": {
         "browseros-server": "./src/index.ts",
       },


### PR DESCRIPTION
## Summary
Work on Browseros-agent repo Bring Kalvis MCP support to the BrowserOS MCP server.
Basically we have two MCPs:
1. Browser OS MCP
2. Kalvis MCP
Kalvis MCP has all of these tools. We want to expose all of the Kalvis MCP tools inside our browser SMCP server. Think around how we can add this. If, let's say, one uses Browser OS MCP URL, it has all of these tools, that is, all of the browser tools and also tools from Kalvis MCP. Think around how we can add

**Note**: This is a partial implementation. The pipeline failed with: .agent/plan.md is missing required sections

## Changes
```
apps/server/src/api/routes/mcp.ts                  |   2 +
 apps/server/src/api/server.ts                      |  19 +-
 .../src/api/services/mcp/klavis-mcp-client.ts      | 215 +++++++++++++++++++++
 apps/server/src/api/services/mcp/mcp-server.ts     |   7 +
 .../src/api/services/mcp/register-klavis-tools.ts  |  92 +++++++++
 5 files changed, 334 insertions(+), 1 deletion(-)
```

## Agent Metadata
- Total cost: $10.4073
- Stages:
  - ok setup ($0.0000, 57.5s)
  - ok plan ($10.4073, 1994.4s)

---
*Generated by coding-agent v3*