### PR TITLE
fix: make CDP discovery resilient on localhost-only setups

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/apps/server/src/browser/backends/cdp.ts
+++ b/apps/server/src/browser/backends/cdp.ts
@@ -16,6 +16,13 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>
 }
 
+interface CdpVersion {
+  webSocketDebuggerUrl: string
+}
+
+const LOOPBACK_DISCOVERY_HOSTS = ['127.0.0.1', 'localhost', '[::1]'] as const
+type LoopbackDiscoveryHost = (typeof LOOPBACK_DISCOVERY_HOSTS)[number]
+
 // biome-ignore lint/correctness/noUnusedVariables: declaration merging adds ProtocolApi properties to the class
 interface CdpBackend extends ProtocolApi {}
 // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: intentional — Object.assign fills these at runtime
@@ -31,6 +38,7 @@ class CdpBackend implements ICdpBackend {
   private eventHandlers = new Map<string, ((params: unknown) => void)[]>()
   private sessionCache = new Map<string, ProtocolApi>()
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null
+  private preferredDiscoveryHost: LoopbackDiscoveryHost | null = null
 
   constructor(config: { port: number }) {
     this.port = config.port
@@ -65,78 +73,136 @@ class CdpBackend implements ICdpBackend {
     }
   }
 
-  private attemptConnect(): Promise<void> {
+  private async attemptConnect(): Promise<void> {
+    const { host, version } = await this.discoverVersion()
+    const wsUrl = this.resolveWebSocketUrl(version.webSocketDebuggerUrl, host)
+
     return new Promise<void>((resolve, reject) => {
-      fetch(`http://127.0.0.1:${this.port}/json/version`, {
-        signal: AbortSignal.timeout(TIMEOUTS.CDP_CONNECT),
-      })
-        .then(async (res) => {
-          if (!res.ok) {
-            throw new Error(
-              `CDP /json/version failed with HTTP ${res.status}: ${res.statusText}`,
-            )
-          }
-          return res.json()
-        })
-        .then((version) => {
-          const wsUrl = (version as { webSocketDebuggerUrl: string })
-            .webSocketDebuggerUrl
-          if (!wsUrl) {
-            throw new Error('CDP /json/version missing webSocketDebuggerUrl')
-          }
+      let opened = false
+      let settled = false
+      const ws = new WebSocket(wsUrl)
+      const connectTimeout = setTimeout(() => {
+        if (settled) return
+        settled = true
+        try {
+          ws.close()
+        } catch {
+          // Ignore close errors from half-open sockets
+        }
+        reject(
+          new Error(
+            `CDP WebSocket connect timeout after ${TIMEOUTS.CDP_CONNECT}ms`,
+          ),
+        )
+      }, TIMEOUTS.CDP_CONNECT)
 
-          let opened = false
-          let settled = false
-          const ws = new WebSocket(wsUrl)
-          const connectTimeout = setTimeout(() => {
-            if (settled) return
-            settled = true
-            try {
-              ws.close()
-            } catch {
-              // Ignore close errors from half-open sockets
-            }
-            reject(
-              new Error(
-                `CDP WebSocket connect timeout after ${TIMEOUTS.CDP_CONNECT}ms`,
-              ),
-            )
-          }, TIMEOUTS.CDP_CONNECT)
+      ws.onopen = () => {
+        if (settled) return
+        settled = true
+        clearTimeout(connectTimeout)
+        opened = true
+        this.ws = ws
+        this.connected = true
+        this.disconnecting = false
+        resolve()
+      }
 
-          ws.onopen = () => {
-            if (settled) return
-            settled = true
-            clearTimeout(connectTimeout)
-            opened = true
-            this.ws = ws
-            this.connected = true
-            this.disconnecting = false
-            resolve()
-          }
+      ws.onerror = (event) => {
+        if (!opened && !settled) {
+          settled = true
+          clearTimeout(connectTimeout)
+          reject(new Error(`CDP WebSocket error: ${event}`))
+        }
+      }
 
-          ws.onerror = (event) => {
-            if (!opened && !settled) {
-              settled = true
-              clearTimeout(connectTimeout)
-              reject(new Error(`CDP WebSocket error: ${event}`))
-            }
-          }
+      ws.onclose = () => {
+        clearTimeout(connectTimeout)
+        // Guard against stale onclose from a replaced socket
+        if (this.ws !== ws) return
+        this.connected = false
+        this.ws = null
+        if (opened) this.handleUnexpectedClose()
+      }
 
-          ws.onclose = () => {
-            clearTimeout(connectTimeout)
-            // Guard against stale onclose from a replaced socket
-            if (this.ws !== ws) return
-            this.connected = false
-            this.ws = null
-            if (opened) this.handleUnexpectedClose()
-          }
-
-          ws.onmessage = (event) => {
-            this.handleMessage(event.data as string)
-          }
-        })
-        .catch(reject)
+      ws.onmessage = (event) => {
+        this.handleMessage(event.data as string)
+      }
     })
+  }
+
+  private getDiscoveryHosts(): LoopbackDiscoveryHost[] {
+    if (!this.preferredDiscoveryHost) {
+      return [...LOOPBACK_DISCOVERY_HOSTS]
+    }
+    return [
+      this.preferredDiscoveryHost,
+      ...LOOPBACK_DISCOVERY_HOSTS.filter(
+        (host) => host !== this.preferredDiscoveryHost,
+      ),
+    ]
+  }
+
+  private async discoverVersion(): Promise<{
+    host: LoopbackDiscoveryHost
+    version: CdpVersion
+  }> {
+    const failures: string[] = []
+
+    for (const host of this.getDiscoveryHosts()) {
+      try {
+        const version = await this.fetchVersionFromHost(host)
+        this.preferredDiscoveryHost = host
+        return { host, version }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        failures.push(`${host}: ${msg}`)
+        logger.debug(`CDP discovery failed via ${host}: ${msg}`)
+      }
+    }
+
+    throw new Error(
+      `CDP /json/version failed on all loopback hosts (${failures.join('; ')})`,
+    )
+  }
+
+  private async fetchVersionFromHost(
+    host: LoopbackDiscoveryHost,
+  ): Promise<CdpVersion> {
+    const response = await fetch(`http://${host}:${this.port}/json/version`, {
+      signal: AbortSignal.timeout(TIMEOUTS.CDP_CONNECT),
+    })
+    if (!response.ok) {
+      throw new Error(
+        `CDP /json/version failed with HTTP ${response.status}: ${response.statusText}`,
+      )
+    }
+
+    const version = (await response.json()) as Partial<CdpVersion>
+    if (typeof version.webSocketDebuggerUrl !== 'string') {
+      throw new Error('CDP /json/version missing webSocketDebuggerUrl')
+    }
+
+    return { webSocketDebuggerUrl: version.webSocketDebuggerUrl }
+  }
+
+  private resolveWebSocketUrl(
+    wsUrl: string,
+    host: LoopbackDiscoveryHost,
+  ): string {
+    try {
+      const parsedUrl = new URL(wsUrl)
+      parsedUrl.hostname = this.normalizeHost(host)
+      return parsedUrl.toString()
+    } catch {
+      return wsUrl
+    }
+  }
+
+  private normalizeHost(host: LoopbackDiscoveryHost): string {
+    if (host === '[::1]') {
+      return '::1'
+    }
+    return host
   }
 
   private startKeepalive(): void {

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -71,11 +71,9 @@ export class Application {
 
     const cdp = new CdpBackend({ port: this.config.cdpPort })
     try {
-      logger.debug(
-        `Connecting to CDP at http://127.0.0.1:${this.config.cdpPort}`,
-      )
+      logger.debug(`Connecting to CDP on port ${this.config.cdpPort}`)
       await cdp.connect()
-      logger.info(`Connected to CDP at http://127.0.0.1:${this.config.cdpPort}`)
+      logger.info(`Connected to CDP on port ${this.config.cdpPort}`)
     } catch (error) {
       return this.handleStartupError('CDP', this.config.cdpPort, error)
     }

--- a/apps/server/tests/browser/backends/cdp.test.ts
+++ b/apps/server/tests/browser/backends/cdp.test.ts
@@ -50,10 +50,14 @@ describe('CdpBackend', () => {
   const originalConnectTimeout = TIMEOUTS.CDP_CONNECT
   const originalReconnectDelay = TIMEOUTS.CDP_RECONNECT_DELAY
   let fetchUrls: string[] = []
+  let failIpv4Discovery = false
+  let wsHost = '127.0.0.1'
 
   beforeEach(() => {
     MockWebSocket.instances = []
     fetchUrls = []
+    failIpv4Discovery = false
+    wsHost = '127.0.0.1'
 
     ;(TIMEOUTS as unknown as { CDP_CONNECT: number }).CDP_CONNECT = 200
     ;(
@@ -61,14 +65,18 @@ describe('CdpBackend', () => {
     ).CDP_RECONNECT_DELAY = 1
 
     globalThis.fetch = (async (input: string | URL | Request) => {
-      fetchUrls.push(String(input))
+      const url = String(input)
+      fetchUrls.push(url)
+      if (failIpv4Discovery && url.includes('127.0.0.1')) {
+        throw new Error('Unable to connect')
+      }
       const id = fetchUrls.length
       return {
         ok: true,
         status: 200,
         statusText: 'OK',
         json: async () => ({
-          webSocketDebuggerUrl: `ws://127.0.0.1:9222/devtools/browser/${id}`,
+          webSocketDebuggerUrl: `ws://${wsHost}:9222/devtools/browser/${id}`,
         }),
       } as Response
     }) as typeof fetch
@@ -86,7 +94,9 @@ describe('CdpBackend', () => {
     ).CDP_RECONNECT_DELAY = originalReconnectDelay
   })
 
-  it('uses 127.0.0.1 for /json/version requests', async () => {
+  it('falls back from 127.0.0.1 to localhost for /json/version', async () => {
+    failIpv4Discovery = true
+    wsHost = 'localhost'
     const cdp = new CdpBackend({ port: 9222 })
     const connectPromise = cdp.connect()
 
@@ -95,6 +105,32 @@ describe('CdpBackend', () => {
     await connectPromise
 
     assert.strictEqual(fetchUrls[0], 'http://127.0.0.1:9222/json/version')
+    assert.strictEqual(fetchUrls[1], 'http://localhost:9222/json/version')
+    assert.strictEqual(
+      MockWebSocket.instances[0]?.url,
+      'ws://localhost:9222/devtools/browser/2',
+    )
+    await cdp.disconnect()
+  })
+
+  it('prefers the last successful discovery host during reconnect', async () => {
+    failIpv4Discovery = true
+    wsHost = 'localhost'
+    const cdp = new CdpBackend({ port: 9222 })
+    const connectPromise = cdp.connect()
+
+    await waitFor(() => MockWebSocket.instances.length === 1)
+    const ws1 = MockWebSocket.instances[0]
+    ws1?.open()
+    await connectPromise
+
+    assert.strictEqual(fetchUrls[0], 'http://127.0.0.1:9222/json/version')
+    assert.strictEqual(fetchUrls[1], 'http://localhost:9222/json/version')
+
+    ws1?.close()
+
+    await waitFor(() => fetchUrls.length >= 3)
+    assert.strictEqual(fetchUrls[2], 'http://localhost:9222/json/version')
     await cdp.disconnect()
   })
 


### PR DESCRIPTION
## Summary
- Add loopback host fallback for CDP discovery (`127.0.0.1` -> `localhost` -> `[::1]`) in `CdpBackend`.
- Cache and prefer the last successful discovery host for reconnect attempts.
- Update CDP startup logs and backend tests to validate fallback and reconnect host preference.

## Design
The fix keeps CDP host handling internal to the backend: `attemptConnect()` now resolves `/json/version` through a loopback-only candidate sequence with existing timeouts/retries, then normalizes the websocket host to the successful discovery endpoint. This avoids new config surface area while solving IPv6/localhost-only binding behavior seen in production.

## Test plan
- `cd apps/server && bun test tests/browser/backends/cdp.test.ts`
- `cd apps/server && bun run typecheck`
- `bunx biome check apps/server/src/browser/backends/cdp.ts apps/server/src/main.ts apps/server/tests/browser/backends/cdp.test.ts`
- `cd apps/server && bun -e "import { CdpBackend } from './src/browser/backends/cdp'; const cdp = new CdpBackend({ port: 9344 }); await cdp.connect(); console.log('cdp-connect-ok'); await cdp.disconnect();"`
