### PR TITLE
[DRAFT] my browser agent repo i have 2 MCP, one which i created myself which has all bro

### DIFF
--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -7,6 +7,7 @@
 import { StreamableHTTPTransport } from '@hono/mcp'
 import { Hono } from 'hono'
 import type { Browser } from '../../browser/browser'
+import { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
@@ -18,16 +19,34 @@ interface McpRouteDeps {
   version: string
   registry: ToolRegistry
   browser: Browser
+  browserosId?: string
 }
 
 export function createMcpRoutes(deps: McpRouteDeps) {
-  const mcpServer = createMcpServer(deps)
+  const enabledMcpServers = process.env.BROWSEROS_DEFAULT_MCP_SERVERS?.split(
+    ',',
+  )
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  const klavisClient =
+    deps.browserosId && enabledMcpServers?.length
+      ? new KlavisClient()
+      : undefined
+
+  const mcpServerPromise = createMcpServer({
+    ...deps,
+    klavisClient,
+    enabledMcpServers,
+  })
 
   return new Hono<Env>().all('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
     metrics.log('mcp.request', { scopeId })
 
     try {
+      const mcpServer = await mcpServerPromise
+
       const transport = new StreamableHTTPTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -87,6 +87,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         version,
         registry,
         browser,
+        browserosId,
       }),
     )
     .route(

--- a/apps/server/src/api/services/mcp/klavis-mcp-cache.ts
+++ b/apps/server/src/api/services/mcp/klavis-mcp-cache.ts
@@ -1,0 +1,85 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
+import { logger } from '../../../lib/logger'
+
+const CACHE_TTL_MS = 30 * 60 * 1000 // 30 minutes
+
+interface CachedEntry {
+  client: Client
+  transport: StreamableHTTPClientTransport
+  strataServerUrl: string
+  expiresAt: number
+}
+
+export class KlavisMcpClientCache {
+  private cache = new Map<string, CachedEntry>()
+
+  async getOrCreate(
+    browserosId: string,
+    servers: string[],
+    klavisClient: KlavisClient,
+  ): Promise<Client> {
+    const key = browserosId
+    const cached = this.cache.get(key)
+
+    if (cached && Date.now() < cached.expiresAt) {
+      return cached.client
+    }
+
+    if (cached) {
+      await this.closeEntry(cached)
+      this.cache.delete(key)
+    }
+
+    const result = await klavisClient.createStrata(browserosId, servers)
+
+    const client = new Client({
+      name: 'browseros-klavis-proxy',
+      version: '1.0.0',
+    })
+
+    const transport = new StreamableHTTPClientTransport(
+      new URL(result.strataServerUrl),
+    )
+
+    await client.connect(transport)
+
+    this.cache.set(key, {
+      client,
+      transport,
+      strataServerUrl: result.strataServerUrl,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    })
+
+    logger.info('Created Klavis MCP client connection', {
+      browserosId: browserosId.slice(0, 12),
+      strataUrl: result.strataServerUrl,
+    })
+
+    return client
+  }
+
+  async invalidate(browserosId: string): Promise<void> {
+    const entry = this.cache.get(browserosId)
+    if (entry) {
+      await this.closeEntry(entry)
+      this.cache.delete(browserosId)
+    }
+  }
+
+  async closeAll(): Promise<void> {
+    for (const [key, entry] of this.cache) {
+      await this.closeEntry(entry)
+      this.cache.delete(key)
+    }
+  }
+
+  private async closeEntry(entry: CachedEntry): Promise<void> {
+    try {
+      await entry.transport.close()
+    } catch {
+      // Connection may already be closed
+    }
+  }
+}

--- a/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/apps/server/src/api/services/mcp/mcp-server.ts
@@ -7,16 +7,27 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { Browser } from '../../../browser/browser'
+import type { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
+import { logger } from '../../../lib/logger'
 import type { ToolRegistry } from '../../../tools/tool-registry'
+import { KlavisMcpClientCache } from './klavis-mcp-cache'
+import { registerKlavisTools } from './register-klavis'
 import { registerTools } from './register-mcp'
+
+const klavisMcpClientCache = new KlavisMcpClientCache()
 
 export interface McpServiceDeps {
   version: string
   registry: ToolRegistry
   browser: Browser
+  klavisClient?: KlavisClient
+  browserosId?: string
+  enabledMcpServers?: string[]
 }
 
-export function createMcpServer(deps: McpServiceDeps): McpServer {
+export async function createMcpServer(
+  deps: McpServiceDeps,
+): Promise<McpServer> {
   const server = new McpServer(
     {
       name: 'browseros_mcp',
@@ -31,6 +42,25 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
   })
 
   registerTools(server, deps.registry, { browser: deps.browser })
+
+  if (deps.klavisClient && deps.browserosId && deps.enabledMcpServers?.length) {
+    try {
+      await registerKlavisTools(server, {
+        klavisClient: deps.klavisClient,
+        browserosId: deps.browserosId,
+        enabledServers: deps.enabledMcpServers,
+        registry: deps.registry,
+        cache: klavisMcpClientCache,
+      })
+    } catch (error) {
+      logger.error(
+        'Klavis tool registration failed, browser tools unaffected',
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      )
+    }
+  }
 
   return server
 }

--- a/apps/server/src/api/services/mcp/register-klavis.ts
+++ b/apps/server/src/api/services/mcp/register-klavis.ts
@@ -1,0 +1,145 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import type { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
+import { logger } from '../../../lib/logger'
+import { metrics } from '../../../lib/metrics'
+import type { ToolRegistry } from '../../../tools/tool-registry'
+import type { KlavisMcpClientCache } from './klavis-mcp-cache'
+
+export interface KlavisProxyConfig {
+  klavisClient: KlavisClient
+  browserosId: string
+  enabledServers: string[]
+  registry: ToolRegistry
+  cache: KlavisMcpClientCache
+}
+
+export async function registerKlavisTools(
+  mcpServer: McpServer,
+  config: KlavisProxyConfig,
+): Promise<void> {
+  const { klavisClient, browserosId, enabledServers, registry, cache } = config
+
+  try {
+    const client = await cache.getOrCreate(
+      browserosId,
+      enabledServers,
+      klavisClient,
+    )
+
+    const result = await client.listTools()
+    const browserToolNames = new Set(registry.names())
+    let registeredCount = 0
+
+    for (const tool of result.tools) {
+      if (browserToolNames.has(tool.name)) {
+        logger.warn('Klavis tool name collides with browser tool, skipping', {
+          toolName: tool.name,
+        })
+        continue
+      }
+
+      const toolName = tool.name
+
+      const handler = async (
+        args: Record<string, unknown>,
+      ): Promise<CallToolResult> => {
+        const startTime = performance.now()
+
+        try {
+          logger.info(`Klavis proxy ${toolName} request`, {
+            args: JSON.stringify(args).slice(0, 200),
+          })
+
+          let activeClient: typeof client
+          try {
+            activeClient = await cache.getOrCreate(
+              browserosId,
+              enabledServers,
+              klavisClient,
+            )
+          } catch (reconnectError) {
+            const errorText =
+              reconnectError instanceof Error
+                ? reconnectError.message
+                : String(reconnectError)
+            logger.error('Failed to reconnect Klavis MCP client', {
+              toolName,
+              error: errorText,
+            })
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Klavis connection error: ${errorText}`,
+                },
+              ],
+              isError: true,
+            }
+          }
+
+          const callResult = await activeClient.callTool({
+            name: toolName,
+            arguments: args,
+          })
+
+          const isError = callResult.isError === true
+
+          metrics.log('tool_executed', {
+            tool_name: toolName,
+            duration_ms: Math.round(performance.now() - startTime),
+            success: !isError,
+            source: 'klavis',
+          })
+
+          return {
+            content: callResult.content as CallToolResult['content'],
+            isError,
+          }
+        } catch (error) {
+          const errorText =
+            error instanceof Error ? error.message : String(error)
+
+          metrics.log('tool_executed', {
+            tool_name: toolName,
+            duration_ms: Math.round(performance.now() - startTime),
+            success: false,
+            error_message: errorText,
+            source: 'klavis',
+          })
+
+          await cache.invalidate(browserosId).catch(() => {})
+
+          return {
+            content: [{ type: 'text' as const, text: errorText }],
+            isError: true,
+          }
+        }
+      }
+
+      mcpServer.registerTool(
+        tool.name,
+        {
+          description: tool.description,
+          inputSchema: tool.inputSchema as unknown as Record<string, never>,
+        },
+        handler,
+      )
+      registeredCount++
+    }
+
+    logger.info(
+      `Registered ${registeredCount} Klavis proxy tools from Strata`,
+      {
+        browserosId: browserosId.slice(0, 12),
+        totalAvailable: result.tools.length,
+        skipped: result.tools.length - registeredCount,
+      },
+    )
+  } catch (error) {
+    logger.error('Failed to register Klavis tools, browser tools unaffected', {
+      error: error instanceof Error ? error.message : String(error),
+      browserosId: browserosId.slice(0, 12),
+    })
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.61",
+      "version": "0.0.63",
       "bin": {
         "browseros-server": "./src/index.ts",
       },


### PR DESCRIPTION
## Summary
my browser agent repo i have 2 MCP, one which i created myself which has all browser mcp tools, and second i have klavis mcp, which is used to check all like gmail, slack etc, klavis exposes all third party tools directly, so if you check tool loop agent or single agent, i am passng klavis mcp urls directly, i need to expose klavis mcp tools within browser mcp as well, so that this can be unified, current agent has thode 2 MCP, i am thinking can we unify in one, lets thonk and try to work

**Note**: This is a partial implementation. The pipeline failed with: .agent/plan.md is missing required sections

## Changes
```
apps/server/src/api/routes/mcp.ts                  |  21 ++-
 apps/server/src/api/server.ts                      |   1 +
 .../src/api/services/mcp/klavis-mcp-cache.ts       |  85 ++++++++++++
 apps/server/src/api/services/mcp/mcp-server.ts     |  32 ++++-
 .../server/src/api/services/mcp/register-klavis.ts | 145 +++++++++++++++++++++
 5 files changed, 282 insertions(+), 2 deletions(-)
```

## Agent Metadata
- Total cost: $15.3591
- Stages:
  - ok setup ($0.0000, 57.1s)
  - ok plan ($6.3499, 2584.5s)

---
*Generated by coding-agent v3*