### PR TITLE
my browser agent repo i have 2 MCP, one which i created myself which has all bro

### DIFF
--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -7,10 +7,12 @@
 import { StreamableHTTPTransport } from '@hono/mcp'
 import { Hono } from 'hono'
 import type { Browser } from '../../browser/browser'
+import { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
 import type { ToolRegistry } from '../../tools/tool-registry'
+import { KlavisStrataPool } from '../services/mcp/klavis-strata-pool'
 import { createMcpServer } from '../services/mcp/mcp-server'
 import type { Env } from '../types'
 
@@ -18,14 +20,35 @@ interface McpRouteDeps {
   version: string
   registry: ToolRegistry
   browser: Browser
+  browserosId?: string
 }
 
 export function createMcpRoutes(deps: McpRouteDeps) {
   const mcpServer = createMcpServer(deps)
 
+  const browserToolNames = new Set(deps.registry.names())
+  const pool = deps.browserosId
+    ? new KlavisStrataPool(new KlavisClient(), mcpServer, browserToolNames)
+    : undefined
+
   return new Hono<Env>().all('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
     metrics.log('mcp.request', { scopeId })
+
+    if (pool && deps.browserosId) {
+      try {
+        const headerServers = c.req.header('X-Enabled-MCP-Servers')
+        const enabledServers = headerServers
+          ? headerServers.split(',').map((s) => s.trim()).filter(Boolean)
+          : undefined
+
+        await pool.ensureTools(deps.browserosId, enabledServers)
+      } catch (error) {
+        logger.error('Klavis tool registration failed (browser tools unaffected)', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
 
     try {
       const transport = new StreamableHTTPTransport({

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -87,6 +87,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         version,
         registry,
         browser,
+        browserosId,
       }),
     )
     .route(

--- a/apps/server/src/api/services/mcp/klavis-strata-pool.test.ts
+++ b/apps/server/src/api/services/mcp/klavis-strata-pool.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, it, mock } from 'bun:test'
+import assert from 'node:assert'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { KlavisClient, StrataCreateResponse, UserIntegration } from '../../../lib/clients/klavis/klavis-client'
+import { KlavisStrataPool } from './klavis-strata-pool'
+
+const originalFetch = globalThis.fetch
+
+function createMockMcpServer(): McpServer {
+  return new McpServer(
+    { name: 'test-server', version: '1.0.0' },
+    { capabilities: { logging: {} } },
+  )
+}
+
+function createMockKlavisClient(overrides: Partial<KlavisClient> = {}): KlavisClient {
+  return {
+    createStrata: mock(async (): Promise<StrataCreateResponse> => ({
+      strataServerUrl: 'https://strata.example.com/mcp',
+      strataId: 'strata-123',
+      addedServers: ['Gmail', 'Slack'],
+    })),
+    getUserIntegrations: mock(async (): Promise<UserIntegration[]> => [
+      { name: 'Gmail', isAuthenticated: true },
+      { name: 'Slack', isAuthenticated: true },
+      { name: 'Notion', isAuthenticated: false },
+    ]),
+    submitApiKey: mock(async () => {}),
+    removeServer: mock(async () => {}),
+    ...overrides,
+  } as unknown as KlavisClient
+}
+
+function mockFetchForStrata(toolNames: string[] = ['discover_server_categories_or_actions', 'execute_action']) {
+  const tools = toolNames.map((name) => ({
+    name,
+    description: `Klavis tool: ${name}`,
+    inputSchema: { type: 'object', properties: {} },
+  }))
+
+  globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : {}
+
+    if (body.method === 'tools/list') {
+      return Response.json({ jsonrpc: '2.0', id: 1, result: { tools } })
+    }
+
+    if (body.method === 'tools/call') {
+      return Response.json({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          content: [{ type: 'text', text: `executed ${body.params?.name}` }],
+          isError: false,
+        },
+      })
+    }
+
+    return Response.json({ jsonrpc: '2.0', id: 1, result: {} })
+  }) as typeof fetch
+}
+
+/**
+ * Creates a mock fetch that returns different tool sets per Strata URL.
+ * The first createStrata call returns strata-gmail, the second returns strata-slack.
+ */
+function mockFetchForMultipleStrata() {
+  let strataCallCount = 0
+
+  const strataTools: Record<string, Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>> = {
+    'https://strata-gmail.example.com/mcp': [
+      { name: 'gmail_list_emails', description: 'List Gmail emails', inputSchema: { type: 'object', properties: {} } },
+      { name: 'shared_tool', description: 'Shared tool', inputSchema: { type: 'object', properties: {} } },
+    ],
+    'https://strata-slack.example.com/mcp': [
+      { name: 'slack_send_message', description: 'Send Slack message', inputSchema: { type: 'object', properties: {} } },
+      { name: 'shared_tool', description: 'Shared tool', inputSchema: { type: 'object', properties: {} } },
+    ],
+  }
+
+  const strataUrls = Object.keys(strataTools)
+
+  return {
+    klavisClient: createMockKlavisClient({
+      createStrata: mock(async (): Promise<StrataCreateResponse> => {
+        const url = strataUrls[strataCallCount % strataUrls.length]
+        strataCallCount++
+        return {
+          strataServerUrl: url,
+          strataId: `strata-${strataCallCount}`,
+          addedServers: [],
+        }
+      }),
+    }),
+    setupFetch: () => {
+      globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+        const body = init?.body ? JSON.parse(init.body as string) : {}
+        const tools = strataTools[urlStr] || []
+
+        if (body.method === 'tools/list') {
+          return Response.json({ jsonrpc: '2.0', id: 1, result: { tools } })
+        }
+
+        if (body.method === 'tools/call') {
+          return Response.json({
+            jsonrpc: '2.0',
+            id: 1,
+            result: {
+              content: [{ type: 'text', text: `executed ${body.params?.name}` }],
+              isError: false,
+            },
+          })
+        }
+
+        return Response.json({ jsonrpc: '2.0', id: 1, result: {} })
+      }) as typeof fetch
+    },
+  }
+}
+
+describe('KlavisStrataPool', () => {
+  let mcpServer: McpServer
+  let klavisClient: KlavisClient
+  let pool: KlavisStrataPool
+
+  beforeEach(() => {
+    mcpServer = createMockMcpServer()
+    klavisClient = createMockKlavisClient()
+    pool = new KlavisStrataPool(klavisClient, mcpServer, new Set<string>())
+    mockFetchForStrata()
+  })
+
+  afterEach(() => {
+    pool.dispose()
+    globalThis.fetch = originalFetch
+  })
+
+  it('ensureTools creates pool entry and registers tools', async () => {
+    await pool.ensureTools('user-123', ['Gmail', 'Slack'])
+
+    assert.strictEqual(
+      (klavisClient.createStrata as ReturnType<typeof mock>).mock.calls.length,
+      1,
+    )
+  })
+
+  it('ensureTools is idempotent (no-op when entry exists)', async () => {
+    await pool.ensureTools('user-123', ['Gmail'])
+    await pool.ensureTools('user-123', ['Gmail'])
+
+    // createStrata should only be called once
+    assert.strictEqual(
+      (klavisClient.createStrata as ReturnType<typeof mock>).mock.calls.length,
+      1,
+    )
+  })
+
+  it('ensureTools with different servers creates separate entries and deduplicates shared tools', async () => {
+    const { klavisClient: multiClient, setupFetch } = mockFetchForMultipleStrata()
+    setupFetch()
+    const multiPool = new KlavisStrataPool(multiClient, mcpServer, new Set<string>())
+
+    // First entry: gmail_list_emails + shared_tool
+    await multiPool.ensureTools('user-123', ['Gmail'])
+    // Second entry: slack_send_message + shared_tool (shared_tool should be skipped)
+    await multiPool.ensureTools('user-123', ['Slack'])
+
+    // Both entries created successfully (no "already registered" error)
+    assert.strictEqual(
+      (multiClient.createStrata as ReturnType<typeof mock>).mock.calls.length,
+      2,
+    )
+
+    // shared_tool is proxied via the first entry; slack_send_message via the second
+    const gmailResult = await multiPool.executeToolCall('gmail_list_emails', {})
+    assert.strictEqual(gmailResult.isError, false)
+
+    const slackResult = await multiPool.executeToolCall('slack_send_message', {})
+    assert.strictEqual(slackResult.isError, false)
+
+    // shared_tool should still work (registered by first entry)
+    const sharedResult = await multiPool.executeToolCall('shared_tool', {})
+    assert.strictEqual(sharedResult.isError, false)
+
+    multiPool.dispose()
+  })
+
+  it('ensureTools with no servers uses getUserIntegrations for auto-discovery', async () => {
+    await pool.ensureTools('user-123')
+
+    assert.strictEqual(
+      (klavisClient.getUserIntegrations as ReturnType<typeof mock>).mock.calls.length,
+      1,
+    )
+
+    // Should only include authenticated integrations (Gmail, Slack), not Notion
+    const createStrataCall = (klavisClient.createStrata as ReturnType<typeof mock>).mock.calls[0]
+    assert.deepStrictEqual(createStrataCall, ['user-123', ['Gmail', 'Slack']])
+  })
+
+  it('ensureTools handles empty server list gracefully', async () => {
+    const emptyClient = createMockKlavisClient({
+      getUserIntegrations: mock(async () => []),
+    })
+    const emptyPool = new KlavisStrataPool(emptyClient, mcpServer, new Set<string>())
+
+    await emptyPool.ensureTools('user-123')
+
+    assert.strictEqual(
+      (emptyClient.createStrata as ReturnType<typeof mock>).mock.calls.length,
+      0,
+    )
+
+    emptyPool.dispose()
+  })
+
+  it('executeToolCall forwards to Strata endpoint', async () => {
+    await pool.ensureTools('user-123', ['Gmail'])
+
+    const result = await pool.executeToolCall('discover_server_categories_or_actions', { query: 'test' })
+
+    assert.ok(result.content.length > 0)
+    assert.strictEqual(result.isError, false)
+  })
+
+  it('executeToolCall returns error for unknown tool', async () => {
+    const result = await pool.executeToolCall('nonexistent_tool', {})
+
+    assert.strictEqual(result.isError, true)
+    assert.ok(result.content[0].type === 'text')
+    assert.ok((result.content[0] as { type: 'text'; text: string }).text.includes('Unknown Klavis tool'))
+  })
+
+  it('handles Klavis client failure gracefully (does not throw)', async () => {
+    const failingClient = createMockKlavisClient({
+      createStrata: mock(async () => {
+        throw new Error('Klavis unavailable')
+      }),
+    })
+    const failPool = new KlavisStrataPool(failingClient, mcpServer, new Set<string>())
+
+    // Should not throw
+    await failPool.ensureTools('user-123', ['Gmail'])
+
+    failPool.dispose()
+  })
+
+  it('handles fetch failure for tools/list gracefully', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('Network error')
+    }) as unknown as typeof fetch
+
+    // Should not throw
+    await pool.ensureTools('user-123', ['Gmail'])
+  })
+
+  it('dispose cleans up all entries and registered tools', async () => {
+    const { klavisClient: multiClient, setupFetch } = mockFetchForMultipleStrata()
+    setupFetch()
+    const multiPool = new KlavisStrataPool(multiClient, mcpServer, new Set<string>())
+
+    await multiPool.ensureTools('user-123', ['Gmail'])
+    await multiPool.ensureTools('user-123', ['Slack'])
+
+    // Should not throw - even with shared tools, each entry only removes its own
+    multiPool.dispose()
+  })
+
+  it('in-flight dedup prevents concurrent creations for same key', async () => {
+    await Promise.all([
+      pool.ensureTools('user-123', ['Gmail']),
+      pool.ensureTools('user-123', ['Gmail']),
+    ])
+
+    // createStrata should only be called once despite concurrent calls
+    assert.strictEqual(
+      (klavisClient.createStrata as ReturnType<typeof mock>).mock.calls.length,
+      1,
+    )
+  })
+
+  it('collision detection prefixes Klavis tools that clash with browser tools', async () => {
+    const browserPool = new KlavisStrataPool(
+      klavisClient,
+      mcpServer,
+      new Set(['discover_server_categories_or_actions']),
+    )
+
+    mockFetchForStrata(['discover_server_categories_or_actions'])
+
+    await browserPool.ensureTools('user-123', ['Gmail'])
+
+    // The tool should have been registered (with prefix) - no error
+    browserPool.dispose()
+  })
+})

--- a/apps/server/src/api/services/mcp/klavis-strata-pool.ts
+++ b/apps/server/src/api/services/mcp/klavis-strata-pool.ts
@@ -1,0 +1,254 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
+import { logger } from '../../../lib/logger'
+import {
+  registerKlavisTools,
+  type KlavisToolDescriptor,
+  type KlavisToolCallResult,
+} from './klavis-tool-proxy'
+
+const POOL_TTL_MS = 30 * 60 * 1000 // 30 minutes
+const EVICTION_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
+
+interface PoolEntry {
+  strataUrl: string
+  tools: KlavisToolDescriptor[]
+  registeredTools: RegisteredTool[]
+  registeredNames: string[]
+  expiresAt: number
+}
+
+export class KlavisStrataPool {
+  private entries = new Map<string, PoolEntry>()
+  private toolToKey = new Map<string, string>()
+  private registeredKlavisNames = new Set<string>()
+  private pending = new Map<string, Promise<void>>()
+  private evictionTimer: ReturnType<typeof setInterval>
+
+  constructor(
+    private klavisClient: KlavisClient,
+    private mcpServer: McpServer,
+    private browserToolNames: Set<string>,
+  ) {
+    this.evictionTimer = setInterval(() => this.evictExpired(), EVICTION_INTERVAL_MS)
+  }
+
+  async ensureTools(
+    browserosId: string,
+    enabledServers?: string[],
+  ): Promise<void> {
+    const cacheKey = this.computeCacheKey(browserosId, enabledServers)
+
+    const existing = this.entries.get(cacheKey)
+    if (existing && existing.expiresAt > Date.now()) {
+      return
+    }
+
+    const pendingPromise = this.pending.get(cacheKey)
+    if (pendingPromise) {
+      await pendingPromise
+      return
+    }
+
+    const creation = this.createEntry(browserosId, enabledServers, cacheKey)
+    this.pending.set(cacheKey, creation)
+
+    try {
+      await creation
+    } finally {
+      this.pending.delete(cacheKey)
+    }
+  }
+
+  async executeToolCall(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<KlavisToolCallResult> {
+    const key = this.toolToKey.get(toolName)
+    if (!key) {
+      return {
+        content: [{ type: 'text' as const, text: `Unknown Klavis tool: ${toolName}` }],
+        isError: true,
+      }
+    }
+
+    const entry = this.entries.get(key)
+    if (!entry) {
+      return {
+        content: [{ type: 'text' as const, text: `Klavis pool entry not found for tool: ${toolName}` }],
+        isError: true,
+      }
+    }
+
+    try {
+      const response = await fetch(entry.strataUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: toolName, arguments: args },
+        }),
+      })
+
+      const json = await response.json() as {
+        result?: { content?: KlavisToolCallResult['content']; isError?: boolean }
+        error?: { message?: string }
+      }
+
+      if (json.error) {
+        return {
+          content: [{ type: 'text' as const, text: json.error.message || 'Klavis tool call failed' }],
+          isError: true,
+        }
+      }
+
+      return {
+        content: json.result?.content || [{ type: 'text' as const, text: 'No content returned' }],
+        isError: json.result?.isError,
+      }
+    } catch (error) {
+      const errorText = error instanceof Error ? error.message : String(error)
+      logger.error(`Klavis tool call failed: ${toolName}`, { error: errorText })
+
+      return {
+        content: [{ type: 'text' as const, text: errorText }],
+        isError: true,
+      }
+    }
+  }
+
+  dispose(): void {
+    clearInterval(this.evictionTimer)
+    for (const [key, entry] of this.entries) {
+      this.removeEntry(key, entry)
+    }
+    this.entries.clear()
+    this.toolToKey.clear()
+    this.registeredKlavisNames.clear()
+    this.pending.clear()
+  }
+
+  private computeCacheKey(
+    browserosId: string,
+    enabledServers?: string[],
+  ): string {
+    if (!enabledServers) {
+      return `${browserosId}:__auto__`
+    }
+    return `${browserosId}:${[...enabledServers].sort().join(',')}`
+  }
+
+  private async createEntry(
+    browserosId: string,
+    enabledServers: string[] | undefined,
+    cacheKey: string,
+  ): Promise<void> {
+    try {
+      let servers = enabledServers
+
+      if (!servers) {
+        const integrations = await this.klavisClient.getUserIntegrations(browserosId)
+        servers = integrations
+          .filter((i) => i.isAuthenticated)
+          .map((i) => i.name)
+      }
+
+      if (servers.length === 0) {
+        logger.info('No Klavis servers to register (empty server list)')
+        return
+      }
+
+      const strata = await this.klavisClient.createStrata(browserosId, servers)
+      const strataUrl = strata.strataServerUrl
+
+      const response = await fetch(strataUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+          params: {},
+        }),
+      })
+
+      const json = await response.json() as {
+        result?: { tools?: KlavisToolDescriptor[] }
+      }
+
+      const tools: KlavisToolDescriptor[] = json.result?.tools || []
+
+      if (tools.length === 0) {
+        logger.info('No Klavis tools discovered from Strata')
+        return
+      }
+
+      // Evict existing entry for this key if present
+      const oldEntry = this.entries.get(cacheKey)
+      if (oldEntry) {
+        this.removeEntry(cacheKey, oldEntry)
+      }
+
+      const { registeredTools, registeredNames } = registerKlavisTools(this.mcpServer, tools, {
+        browserToolNames: this.browserToolNames,
+        registeredKlavisNames: this.registeredKlavisNames,
+        executeToolCall: (toolName, args) => this.executeToolCall(toolName, args),
+      })
+
+      const entry: PoolEntry = {
+        strataUrl,
+        tools,
+        registeredTools,
+        registeredNames,
+        expiresAt: Date.now() + POOL_TTL_MS,
+      }
+
+      this.entries.set(cacheKey, entry)
+
+      for (const tool of tools) {
+        this.toolToKey.set(tool.name, cacheKey)
+      }
+
+      logger.info(`Klavis Strata pool entry created`, {
+        cacheKey,
+        toolCount: tools.length,
+      })
+    } catch (error) {
+      const errorText = error instanceof Error ? error.message : String(error)
+      logger.error('Failed to create Klavis Strata pool entry', {
+        cacheKey,
+        error: errorText,
+      })
+    }
+  }
+
+  private removeEntry(key: string, entry: PoolEntry): void {
+    for (const registered of entry.registeredTools) {
+      try {
+        registered.remove()
+      } catch {
+        // Tool may already have been removed
+      }
+    }
+    for (const name of entry.registeredNames) {
+      this.registeredKlavisNames.delete(name)
+    }
+    for (const tool of entry.tools) {
+      this.toolToKey.delete(tool.name)
+    }
+    this.entries.delete(key)
+  }
+
+  private evictExpired(): void {
+    const now = Date.now()
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        logger.info('Evicting expired Klavis Strata pool entry', { cacheKey: key })
+        this.removeEntry(key, entry)
+      }
+    }
+  }
+}

--- a/apps/server/src/api/services/mcp/klavis-tool-proxy.test.ts
+++ b/apps/server/src/api/services/mcp/klavis-tool-proxy.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, it, mock } from 'bun:test'
+import assert from 'node:assert'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerKlavisTools, type KlavisToolDescriptor, type KlavisToolProxyDeps } from './klavis-tool-proxy'
+
+function createMockMcpServer(): McpServer {
+  return new McpServer(
+    { name: 'test-server', version: '1.0.0' },
+    { capabilities: { logging: {} } },
+  )
+}
+
+describe('registerKlavisTools', () => {
+  let mcpServer: McpServer
+
+  beforeEach(() => {
+    mcpServer = createMockMcpServer()
+  })
+
+  it('registers tools on the MCP server', () => {
+    const tools: KlavisToolDescriptor[] = [
+      {
+        name: 'discover_server_categories_or_actions',
+        description: 'Discover available server actions',
+        inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+      },
+      {
+        name: 'execute_action',
+        description: 'Execute an action',
+        inputSchema: { type: 'object', properties: { action: { type: 'string' } } },
+      },
+    ]
+
+    const executeToolCall = mock(async () => ({
+      content: [{ type: 'text' as const, text: 'ok' }],
+    }))
+
+    const deps: KlavisToolProxyDeps = {
+      browserToolNames: new Set<string>(),
+      registeredKlavisNames: new Set<string>(),
+      executeToolCall,
+    }
+
+    const result = registerKlavisTools(mcpServer, tools, deps)
+
+    assert.strictEqual(result.registeredTools.length, 2)
+    assert.strictEqual(result.registeredNames.length, 2)
+    assert.ok(result.registeredNames.includes('discover_server_categories_or_actions'))
+    assert.ok(result.registeredNames.includes('execute_action'))
+  })
+
+  it('prefixes tool name with klavis_ on collision with browser tools', () => {
+    const tools: KlavisToolDescriptor[] = [
+      {
+        name: 'browser_navigate',
+        description: 'Navigate (collision)',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ]
+
+    const executeToolCall = mock(async () => ({
+      content: [{ type: 'text' as const, text: 'ok' }],
+    }))
+
+    const deps: KlavisToolProxyDeps = {
+      browserToolNames: new Set(['browser_navigate']),
+      registeredKlavisNames: new Set<string>(),
+      executeToolCall,
+    }
+
+    const result = registerKlavisTools(mcpServer, tools, deps)
+
+    assert.strictEqual(result.registeredTools.length, 1)
+    assert.deepStrictEqual(result.registeredNames, ['klavis_browser_navigate'])
+  })
+
+  it('returns empty array for empty tool list', () => {
+    const deps: KlavisToolProxyDeps = {
+      browserToolNames: new Set<string>(),
+      registeredKlavisNames: new Set<string>(),
+      executeToolCall: mock(async () => ({
+        content: [{ type: 'text' as const, text: '' }],
+      })),
+    }
+
+    const result = registerKlavisTools(mcpServer, [], deps)
+    assert.strictEqual(result.registeredTools.length, 0)
+    assert.strictEqual(result.registeredNames.length, 0)
+  })
+
+  it('calls executeToolCall with original name even when prefixed', () => {
+    const tools: KlavisToolDescriptor[] = [
+      {
+        name: 'browser_click',
+        description: 'Click (collision)',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ]
+
+    const executeToolCall = mock(async (toolName: string, _args: Record<string, unknown>) => ({
+      content: [{ type: 'text' as const, text: `called ${toolName}` }],
+    }))
+
+    const deps: KlavisToolProxyDeps = {
+      browserToolNames: new Set(['browser_click']),
+      registeredKlavisNames: new Set<string>(),
+      executeToolCall,
+    }
+
+    const result = registerKlavisTools(mcpServer, tools, deps)
+
+    // Registered under prefixed name
+    assert.deepStrictEqual(result.registeredNames, ['klavis_browser_click'])
+    // executeToolCall not called yet (only when handler is invoked)
+    assert.strictEqual(executeToolCall.mock.calls.length, 0)
+  })
+
+  it('handler returns isError true on executeToolCall failure', () => {
+    const tools: KlavisToolDescriptor[] = [
+      {
+        name: 'test_tool',
+        description: 'Test tool',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ]
+
+    const executeToolCall = mock(async () => {
+      throw new Error('Connection refused')
+    })
+
+    const deps: KlavisToolProxyDeps = {
+      browserToolNames: new Set<string>(),
+      registeredKlavisNames: new Set<string>(),
+      executeToolCall,
+    }
+
+    const result = registerKlavisTools(mcpServer, tools, deps)
+    assert.strictEqual(result.registeredTools.length, 1)
+  })
+
+  it('registered tools can be removed', () => {
+    const tools: KlavisToolDescriptor[] = [
+      {
+        name: 'removable_tool',
+        description: 'Will be removed',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ]
+
+    const deps: KlavisToolProxyDeps = {
+      browserToolNames: new Set<string>(),
+      registeredKlavisNames: new Set<string>(),
+      executeToolCall: mock(async () => ({
+        content: [{ type: 'text' as const, text: 'ok' }],
+      })),
+    }
+
+    const result = registerKlavisTools(mcpServer, tools, deps)
+    assert.strictEqual(result.registeredTools.length, 1)
+
+    // Should not throw
+    result.registeredTools[0].remove()
+  })
+
+  it('skips tools already registered by another pool entry', () => {
+    const tools: KlavisToolDescriptor[] = [
+      {
+        name: 'shared_tool',
+        description: 'Shared across entries',
+        inputSchema: { type: 'object', properties: {} },
+      },
+      {
+        name: 'unique_tool',
+        description: 'Only in this entry',
+        inputSchema: { type: 'object', properties: {} },
+      },
+    ]
+
+    const deps: KlavisToolProxyDeps = {
+      browserToolNames: new Set<string>(),
+      registeredKlavisNames: new Set(['shared_tool']),
+      executeToolCall: mock(async () => ({
+        content: [{ type: 'text' as const, text: 'ok' }],
+      })),
+    }
+
+    const result = registerKlavisTools(mcpServer, tools, deps)
+
+    // Only unique_tool should be registered; shared_tool skipped
+    assert.strictEqual(result.registeredTools.length, 1)
+    assert.deepStrictEqual(result.registeredNames, ['unique_tool'])
+  })
+
+  it('adds registered names to the registeredKlavisNames set', () => {
+    const tools: KlavisToolDescriptor[] = [
+      { name: 'tool_a', description: 'A', inputSchema: { type: 'object', properties: {} } },
+      { name: 'tool_b', description: 'B', inputSchema: { type: 'object', properties: {} } },
+    ]
+
+    const registeredKlavisNames = new Set<string>()
+
+    const deps: KlavisToolProxyDeps = {
+      browserToolNames: new Set<string>(),
+      registeredKlavisNames,
+      executeToolCall: mock(async () => ({
+        content: [{ type: 'text' as const, text: 'ok' }],
+      })),
+    }
+
+    registerKlavisTools(mcpServer, tools, deps)
+
+    assert.ok(registeredKlavisNames.has('tool_a'))
+    assert.ok(registeredKlavisNames.has('tool_b'))
+  })
+})

--- a/apps/server/src/api/services/mcp/klavis-tool-proxy.ts
+++ b/apps/server/src/api/services/mcp/klavis-tool-proxy.ts
@@ -1,0 +1,129 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { logger } from '../../../lib/logger'
+import { metrics } from '../../../lib/metrics'
+
+export interface KlavisToolDescriptor {
+  name: string
+  description?: string
+  inputSchema?: Record<string, unknown>
+}
+
+export interface KlavisToolCallResult {
+  content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>
+  isError?: boolean
+}
+
+export interface KlavisToolProxyDeps {
+  browserToolNames: Set<string>
+  registeredKlavisNames: Set<string>
+  executeToolCall: (
+    toolName: string,
+    args: Record<string, unknown>,
+  ) => Promise<KlavisToolCallResult>
+}
+
+function resolveToolName(
+  name: string,
+  browserToolNames: Set<string>,
+  registeredKlavisNames: Set<string>,
+): { resolvedName: string; skip: boolean } {
+  if (registeredKlavisNames.has(name)) {
+    logger.debug(`Klavis tool "${name}" already registered by another pool entry, skipping`)
+    return { resolvedName: name, skip: true }
+  }
+  if (browserToolNames.has(name)) {
+    const prefixed = `klavis_${name}`
+    if (registeredKlavisNames.has(prefixed)) {
+      logger.debug(`Klavis tool "${name}" (as "${prefixed}") already registered by another pool entry, skipping`)
+      return { resolvedName: prefixed, skip: true }
+    }
+    logger.warn(`Klavis tool name collision: "${name}" already registered as browser tool, using "${prefixed}"`)
+    return { resolvedName: prefixed, skip: false }
+  }
+  return { resolvedName: name, skip: false }
+}
+
+export interface RegisterKlavisToolsResult {
+  registeredTools: RegisteredTool[]
+  registeredNames: string[]
+}
+
+export function registerKlavisTools(
+  mcpServer: McpServer,
+  tools: KlavisToolDescriptor[],
+  deps: KlavisToolProxyDeps,
+): RegisterKlavisToolsResult {
+  const registeredTools: RegisteredTool[] = []
+  const registeredNames: string[] = []
+
+  for (const tool of tools) {
+    const originalName = tool.name
+    const { resolvedName, skip } = resolveToolName(
+      originalName,
+      deps.browserToolNames,
+      deps.registeredKlavisNames,
+    )
+
+    if (skip) {
+      continue
+    }
+
+    const handler = async (
+      args: Record<string, unknown>,
+      extra: { signal: AbortSignal },
+    ) => {
+      const startTime = performance.now()
+
+      try {
+        const result = await deps.executeToolCall(originalName, args)
+
+        metrics.log('tool_executed', {
+          tool_name: resolvedName,
+          duration_ms: Math.round(performance.now() - startTime),
+          success: !result.isError,
+          source: 'klavis',
+        })
+
+        return {
+          content: result.content,
+          isError: result.isError,
+        }
+      } catch (error) {
+        const errorText = error instanceof Error ? error.message : String(error)
+
+        metrics.log('tool_executed', {
+          tool_name: resolvedName,
+          duration_ms: Math.round(performance.now() - startTime),
+          success: false,
+          error_message: errorText,
+          source: 'klavis',
+        })
+
+        return {
+          content: [{ type: 'text' as const, text: errorText }],
+          isError: true,
+        }
+      }
+    }
+
+    const registered = mcpServer.registerTool(
+      resolvedName,
+      {
+        description: tool.description,
+        inputSchema: tool.inputSchema as unknown as Record<string, never>,
+      },
+      handler,
+    )
+
+    registeredTools.push(registered)
+    registeredNames.push(resolvedName)
+    deps.registeredKlavisNames.add(resolvedName)
+  }
+
+  logger.info(
+    `Registered ${registeredTools.length} Klavis proxy tools: ${registeredNames.join(', ')}`,
+  )
+
+  return { registeredTools, registeredNames }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.61",
+      "version": "0.0.63",
       "bin": {
         "browseros-server": "./src/index.ts",
       },


### PR DESCRIPTION
## Summary
my browser agent repo i have 2 MCP, one which i created myself which has all browser mcp tools, and second i have klavis mcp, which is used to check all like gmail, slack etc, klavis exposes all third party tools directly, so if you check tool loop agent or single agent, i am passng klavis mcp urls directly, i need to expose klavis mcp tools within browser mcp as well, so that this can be unified, current agent has thode 2 MCP, i am thinking can we unify in one, lets thonk and try to work

## Changes
```
apps/server/src/api/routes/mcp.ts                  |  23 ++
 apps/server/src/api/server.ts                      |   1 +
 .../api/services/mcp/klavis-strata-pool.test.ts    | 297 +++++++++++++++++++++
 .../src/api/services/mcp/klavis-strata-pool.ts     | 254 ++++++++++++++++++
 .../src/api/services/mcp/klavis-tool-proxy.test.ts | 215 +++++++++++++++
 .../src/api/services/mcp/klavis-tool-proxy.ts      | 129 +++++++++
 6 files changed, 919 insertions(+)
```

## Agent Metadata
- Total cost: $19.9787
- Stages:
  - ok setup ($0.0000, 61.1s)
  - ok plan ($4.6157, 851.2s)
  - ok implement ($9.0131, 2346.1s)

---
*Generated by coding-agent v3*