### PR TITLE
fix: use fresh browser context for selected tabs on each message

### DIFF
--- a/apps/server/src/agent/tool-loop/service.ts
+++ b/apps/server/src/agent/tool-loop/service.ts
@@ -122,9 +122,12 @@ export class ChatV2Service {
       })
     }
 
-    // For scheduled tasks, use the hidden window's browser context so the model
-    // knows the correct pageId and windowId to operate in.
-    const messageContext = session.browserContext ?? request.browserContext
+    // Scheduled tasks use the session's browser context (hidden window with
+    // correct pageId/windowId). Normal messages use the request's browser
+    // context so that freshly selected tabs are always included.
+    const messageContext = request.isScheduledTask
+      ? (session.browserContext ?? request.browserContext)
+      : request.browserContext
     const userContent = formatUserMessage(request.message, messageContext)
     session.agent.appendUserMessage(userContent)
 


### PR DESCRIPTION
## Summary
- On subsequent messages in a conversation, selected tabs from the request were ignored because `session.browserContext` (from the first message) always took precedence via `??`
- Now normal messages always use `request.browserContext` so freshly selected tabs are included
- Scheduled tasks still use the stored session context to preserve the hidden window's pageId/windowId

## Problem
User selects tabs A, B → sends message 1. Then selects tabs C, D, E → sends message 2. The agent only saw tabs A, B on both messages because `session.browserContext ?? request.browserContext` always preferred the cached session context.

## Test plan
- [ ] Send message 1 with 2 tabs selected, verify agent sees both tabs in context
- [ ] Send message 2 in same conversation with 3 different tabs selected, verify agent sees the new 3 tabs (not the old 2)
- [ ] Test a scheduled task still uses the hidden window context correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)