### PR TITLE
fix: per-request MCP server+transport for SDK 1.26.0 security fix

### DIFF
--- a/apps/server/src/agent/tool-loop/service.ts
+++ b/apps/server/src/agent/tool-loop/service.ts
@@ -122,9 +122,12 @@ export class ChatV2Service {
       })
     }
 
-    // For scheduled tasks, use the hidden window's browser context so the model
-    // knows the correct pageId and windowId to operate in.
-    const messageContext = session.browserContext ?? request.browserContext
+    // Scheduled tasks use the session's browser context (hidden window with
+    // correct pageId/windowId). Normal messages use the request's browser
+    // context so that freshly selected tabs are always included.
+    const messageContext = request.isScheduledTask
+      ? (session.browserContext ?? request.browserContext)
+      : request.browserContext
     const userContent = formatUserMessage(request.message, messageContext)
     session.agent.appendUserMessage(userContent)
 

--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -22,18 +22,19 @@ interface McpRouteDeps {
 
 export function createMcpRoutes(deps: McpRouteDeps) {
   const mcpServer = createMcpServer(deps)
+  const transport = new StreamableHTTPTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  })
 
   return new Hono<Env>().all('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
     metrics.log('mcp.request', { scopeId })
 
     try {
-      const transport = new StreamableHTTPTransport({
-        sessionIdGenerator: undefined,
-        enableJsonResponse: true,
-      })
-
-      await mcpServer.connect(transport)
+      if (!mcpServer.isConnected()) {
+        await mcpServer.connect(transport)
+      }
 
       return transport.handleRequest(c)
     } catch (error) {

--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -21,21 +21,20 @@ interface McpRouteDeps {
 }
 
 export function createMcpRoutes(deps: McpRouteDeps) {
-  const mcpServer = createMcpServer(deps)
-  const transport = new StreamableHTTPTransport({
-    sessionIdGenerator: undefined,
-    enableJsonResponse: true,
-  })
-
   return new Hono<Env>().all('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
     metrics.log('mcp.request', { scopeId })
 
-    try {
-      if (!mcpServer.isConnected()) {
-        await mcpServer.connect(transport)
-      }
+    // Per-request server + transport: no shared state, no race conditions,
+    // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
+    const mcpServer = createMcpServer(deps)
+    const transport = new StreamableHTTPTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    })
 
+    try {
+      await mcpServer.connect(transport)
       return transport.handleRequest(c)
     } catch (error) {
       Sentry.captureException(error)


### PR DESCRIPTION
## Summary

- Create fresh `McpServer` + `StreamableHTTPTransport` per request instead of sharing a singleton
- Fixes "Already connected to a transport" error introduced in MCP SDK 1.26.0
- Addresses security advisory [GHSA-345p-7cg4-v4c7](https://github.com/modelcontextprotocol/typescript-sdk/security/advisories/GHSA-345p-7cg4-v4c7) (CVSS 7.1) — singleton server/transport could leak cross-client response data via message ID collisions

## Why

MCP SDK 1.26.0 added a guard in `Protocol.connect()` that throws if the server is already connected. The old code created a per-request transport but reused a singleton `McpServer`, which:
1. Broke after SDK 1.26.0 (second request throws)
2. Was a security vulnerability even before — concurrent requests could get responses routed to the wrong client

## Trade-offs

- **Overhead**: Creates `McpServer` + registers 47 tools per request (sync map inserts, sub-millisecond). Negligible vs actual tool execution (100ms-10s).
- **No race conditions**: Each request is fully isolated
- **No ID collisions**: No shared transport state between requests