### PR TITLE
fix: suppress biome lint warnings

### DIFF
--- a/apps/server/src/agent/tool-loop/compaction.ts
+++ b/apps/server/src/agent/tool-loop/compaction.ts
@@ -446,6 +446,7 @@ export function slidingWindow(
 // Main compaction orchestrator
 // ---------------------------------------------------------------------------
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: multi-step compaction logic with split-turn handling
 async function compactMessages(
   model: LanguageModel,
   messages: ModelMessage[],

--- a/apps/server/src/tools/filesystem/grep.ts
+++ b/apps/server/src/tools/filesystem/grep.ts
@@ -118,6 +118,7 @@ export function createGrepTool(cwd: string) {
         .describe(`Maximum matches to return (default: ${DEFAULT_GREP_LIMIT})`),
     }),
     execute: (params) =>
+      // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: grep tool has many output mode and filtering branches
       executeWithMetrics(TOOL_NAME, async () => {
         const searchPath = resolve(cwd, params.path || '.')
         const limit = params.limit || DEFAULT_GREP_LIMIT

--- a/apps/server/tests/tools/filesystem/bash.test.ts
+++ b/apps/server/tests/tools/filesystem/bash.test.ts
@@ -15,6 +15,7 @@ beforeEach(async () => {
   )
   await mkdir(tmpDir, { recursive: true })
   const tool = createBashTool(tmpDir)
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
 })
 
@@ -84,6 +85,7 @@ describe('filesystem_bash', () => {
     await mkdir(join(tmpDir, 'subdir'))
     const subTool = createBashTool(join(tmpDir, 'subdir'))
     const subExec = (params: Record<string, unknown>) =>
+      // biome-ignore lint/suspicious/noExplicitAny: test helper
       (subTool as any).execute(params)
 
     const result = await subExec({ command: 'pwd' })

--- a/apps/server/tests/tools/filesystem/edit.test.ts
+++ b/apps/server/tests/tools/filesystem/edit.test.ts
@@ -15,6 +15,7 @@ beforeEach(async () => {
   )
   await mkdir(tmpDir, { recursive: true })
   const tool = createEditTool(tmpDir)
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
 })
 

--- a/apps/server/tests/tools/filesystem/find.test.ts
+++ b/apps/server/tests/tools/filesystem/find.test.ts
@@ -15,6 +15,7 @@ beforeEach(async () => {
   )
   await mkdir(tmpDir, { recursive: true })
   const tool = createFindTool(tmpDir)
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
 })
 

--- a/apps/server/tests/tools/filesystem/grep.test.ts
+++ b/apps/server/tests/tools/filesystem/grep.test.ts
@@ -15,6 +15,7 @@ beforeEach(async () => {
   )
   await mkdir(tmpDir, { recursive: true })
   const tool = createGrepTool(tmpDir)
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
 })
 

--- a/apps/server/tests/tools/filesystem/ls.test.ts
+++ b/apps/server/tests/tools/filesystem/ls.test.ts
@@ -15,6 +15,7 @@ beforeEach(async () => {
   )
   await mkdir(tmpDir, { recursive: true })
   const tool = createLsTool(tmpDir)
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
 })
 

--- a/apps/server/tests/tools/filesystem/read.test.ts
+++ b/apps/server/tests/tools/filesystem/read.test.ts
@@ -15,6 +15,7 @@ beforeEach(async () => {
   )
   await mkdir(tmpDir, { recursive: true })
   const tool = createReadTool(tmpDir)
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
 })
 

--- a/apps/server/tests/tools/filesystem/write.test.ts
+++ b/apps/server/tests/tools/filesystem/write.test.ts
@@ -15,6 +15,7 @@ beforeEach(async () => {
   )
   await mkdir(tmpDir, { recursive: true })
   const tool = createWriteTool(tmpDir)
+  // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
 })
 


### PR DESCRIPTION
## Summary
- Add `biome-ignore` directives to suppress 10 lint warnings across 9 files
- `noExcessiveCognitiveComplexity` suppressed on `compaction.ts` (score 31/30) and `grep.ts` (score 73/30) — refactoring these complex functions is out of scope
- `noExplicitAny` suppressed on 7 filesystem test files where `(tool as any).execute()` is used as a test helper pattern

## Test plan
- [x] `bun run lint` — 0 warnings (was 10)
- [x] `bun run typecheck` — passes for server, shared, controller-ext packages
- Note: `@browseros/agent` typecheck OOMs due to Node.js heap limits (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)