### PR TITLE
fix: use pageIds instead of tabIds in tab group tests

### DIFF
--- a/apps/server/tests/tools/tab-groups.test.ts
+++ b/apps/server/tests/tools/tab-groups.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
-import { close_page, list_pages, new_page } from '../../src/tools/navigation'
+import { close_page, new_page } from '../../src/tools/navigation'
 import {
   close_tab_group,
   group_tabs,
@@ -40,22 +40,11 @@ describe('tab group tools', () => {
         textOf(tab2Result).match(/Page ID:\s*(\d+)/)?.[1],
       )
 
-      // Get tab IDs from list_pages
-      const pagesResult = await execute(list_pages, {})
-      const pagesText = textOf(pagesResult)
-
-      // Extract tab IDs for our pages
-      const tabIds: number[] = []
-      for (const pageId of [tab1PageId, tab2PageId]) {
-        const pageRegex = new RegExp(`${pageId}\\.\\s+.*?\\(tab\\s+(\\d+)\\)`)
-        const match = pagesText.match(pageRegex)
-        if (match) tabIds.push(Number(match[1]))
-      }
-      assert.ok(tabIds.length === 2, `Expected 2 tab IDs, got ${tabIds.length}`)
+      const pageIds = [tab1PageId, tab2PageId]
 
       // Group tabs
       const groupResult = await execute(group_tabs, {
-        tabIds,
+        pageIds,
         title: 'Test Group',
       })
       assert.ok(!groupResult.isError, textOf(groupResult))
@@ -80,7 +69,7 @@ describe('tab group tools', () => {
       assert.ok(textOf(listResult).includes('Renamed Group'))
 
       // Ungroup
-      const ungroupResult = await execute(ungroup_tabs, { tabIds })
+      const ungroupResult = await execute(ungroup_tabs, { pageIds })
       assert.ok(!ungroupResult.isError, textOf(ungroupResult))
       assert.ok(textOf(ungroupResult).includes('Ungrouped'))
 
@@ -95,18 +84,12 @@ describe('tab group tools', () => {
       const tabResult = await execute(new_page, { url: 'about:blank' })
       const tabPageId = Number(textOf(tabResult).match(/Page ID:\s*(\d+)/)?.[1])
 
-      // Get tab ID
-      const pagesResult = await execute(list_pages, {})
-      const pageRegex = new RegExp(`${tabPageId}\\.\\s+.*?\\(tab\\s+(\\d+)\\)`)
-      const tabMatch = textOf(pagesResult).match(pageRegex)
-      assert.ok(tabMatch, 'Could not find tab ID')
-      const tabId = Number(tabMatch?.[1])
-
       // Group
       const groupResult = await execute(group_tabs, {
-        tabIds: [tabId],
+        pageIds: [tabPageId],
         title: 'Disposable',
       })
+      assert.ok(!groupResult.isError, textOf(groupResult))
       const groupId = textOf(groupResult).match(/Group ID:\s*(\S+)/)?.[1]
 
       // Close group (also closes the tab)


### PR DESCRIPTION
## Summary
- Tab group tests were passing raw Chrome `tabIds` to `group_tabs` and `ungroup_tabs` tools, but the Zod schemas expect `pageIds` (MCP-layer page IDs)
- The `tabIds` field was silently stripped during validation, leaving `pageIds` undefined and causing both tests to fail
- Removed unnecessary `list_pages` calls that were only used to extract Chrome tab IDs

## Design
The tools already translate pageIds → tabIds internally via `Browser.resolvePageIdsToTabIds()`. The tests just needed to pass the page IDs they already had from `new_page` results instead of going through a roundabout extraction of Chrome tab IDs.

## Test plan
- [ ] Run `bun run test:tools` and verify the 2 previously failing tab group tests now pass
- [ ] Verify all 168 tests pass (166 + 2 fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)