### PR TITLE
fix: filter empty-parts messages to prevent follow-up conversation crash

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -379,15 +379,14 @@ export const useChatSession = () => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: only need to run when messages change
   useEffect(() => {
     messagesRef.current = messages
-    if (messages.length > 0) {
-      // Local storage: save on every change (including during streaming)
-      // Remote: only save when not streaming to avoid partial message saves
+    const messagesToSave = messages.filter((m) => m.parts?.length > 0)
+    if (messagesToSave.length > 0) {
       if (isLoggedIn) {
         if (status !== 'streaming') {
-          saveRemoteConversation(conversationIdRef.current, messages)
+          saveRemoteConversation(conversationIdRef.current, messagesToSave)
         }
       } else {
-        saveLocalConversation(conversationIdRef.current, messages)
+        saveLocalConversation(conversationIdRef.current, messagesToSave)
       }
     }
   }, [messages, isLoggedIn, status])

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -304,6 +304,15 @@ export const useChatSession = () => {
     }),
   })
 
+  // Remove messages with empty parts (e.g. interrupted assistant responses)
+  // to prevent AI SDK validation errors on subsequent sends
+  useEffect(() => {
+    if (status === 'streaming') return
+    if (messages.some((m) => !m.parts?.length)) {
+      setMessages(messages.filter((m) => m.parts?.length > 0))
+    }
+  }, [messages, status, setMessages])
+
   useNotifyActiveTab({
     messages,
     status,

--- a/apps/agent/lib/conversations/formatConversationHistory.ts
+++ b/apps/agent/lib/conversations/formatConversationHistory.ts
@@ -17,6 +17,7 @@ export function formatConversationHistory(
 
   return recentMessages
     .map((msg) => {
+      if (!msg.parts?.length) return null
       const role: 'user' | 'assistant' =
         msg.role === 'user' ? 'user' : 'assistant'
       const textContent = msg.parts


### PR DESCRIPTION
## Summary
- Fixes crash when sending follow-up messages in the chat after an assistant response was interrupted or errored before producing content
- The AI SDK's `useChat` leaves a `UIMessage` with `parts: []` in state; on the next send, validation rejects it with "Message must contain at least one part"
- Adds a `useEffect` in `useChatSession` that removes empty-parts messages when not streaming
- Adds a safety guard in `formatConversationHistory` for messages with missing/empty parts

## Test plan
- [ ] Start a conversation in the sidepanel
- [ ] Interrupt an assistant response before any text is generated (e.g., rapid stop or network error)
- [ ] Send a follow-up message — should succeed without "Type validation failed" error
- [ ] Verify normal multi-turn conversations still work correctly
- [ ] Verify conversation restore (local + remote) works with conversations that may contain empty-parts messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)