### PR TITLE
fix: pass user data dir to WXT when using dev:watch --new

### DIFF
--- a/apps/agent/web-ext.config.ts
+++ b/apps/agent/web-ext.config.ts
@@ -40,7 +40,7 @@ export default defineWebExtConfig({
       '/Applications/BrowserOS.app/Contents/MacOS/BrowserOS',
   },
   chromiumArgs,
-  chromiumProfile: '/tmp/browseros-dev',
+  chromiumProfile: env.BROWSEROS_USER_DATA_DIR || '/tmp/browseros-dev',
   keepProfileChanges: true,
   startUrls: ['chrome://newtab'],
 })

--- a/tools/dev/cmd/watch.go
+++ b/tools/dev/cmd/watch.go
@@ -74,6 +74,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	env := proc.BuildEnv(p, "development")
+	env = append(env, fmt.Sprintf("BROWSEROS_USER_DATA_DIR=%s", userDataDir))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary

- When `dev:watch --new` creates a fresh temp profile directory, the WXT agent config was ignoring it because `chromiumProfile` was hardcoded to `/tmp/browseros-dev`
- Pass `BROWSEROS_USER_DATA_DIR` env var from the Go dev tool to the agent process
- Read it in `web-ext.config.ts` with fallback to the default path

## Test plan

- [ ] Run `bun run dev:watch --new` and verify the browser opens with the fresh temp profile (check the logged profile path matches the actual Chrome `--user-data-dir`)
- [ ] Run `bun run dev:watch` (without `--new`) and verify it still uses `/tmp/browseros-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)