### PR TITLE
fix: handle SIGQUIT in dev:watch to prevent runtime crash on macOS

### DIFF
--- a/tools/dev/cmd/watch.go
+++ b/tools/dev/cmd/watch.go
@@ -80,7 +80,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	sigCh := make(chan os.Signal, 2)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	var wg sync.WaitGroup
 	var procs []*proc.ManagedProc


### PR DESCRIPTION
## Summary
- Add `syscall.SIGQUIT` to the signal notify list in `dev:watch` command
- Prevents Go runtime crash (`semasleep on Darwin signal stack`) when pressing `Ctrl+\` on macOS ARM64
- SIGQUIT now triggers the same graceful shutdown path as SIGINT/SIGTERM

## Test plan
- [ ] Run `bun run dev:watch` and press `Ctrl+\` — should shut down gracefully instead of crashing
- [ ] Verify `Ctrl+C` still works for normal shutdown
- [ ] Verify double `Ctrl+C` still force-kills

🤖 Generated with [Claude Code](https://claude.com/claude-code)