### PR TITLE
fix: gate Soul page behind server version 0.0.67

### DIFF
--- a/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -33,7 +33,12 @@ const settingsNavItems: NavItem[] = [
     icon: Palette,
     feature: Feature.CUSTOMIZATION_SUPPORT,
   },
-  { name: 'Agent Soul', to: '/settings/soul', icon: Sparkles },
+  {
+    name: 'Agent Soul',
+    to: '/settings/soul',
+    icon: Sparkles,
+    feature: Feature.SOUL_SUPPORT,
+  },
   { name: 'Explore Features', to: '/onboarding/features', icon: Compass },
   { name: 'Revisit Onboarding', to: '/onboarding', icon: RotateCcw },
 ]

--- a/apps/agent/lib/browseros/capabilities.ts
+++ b/apps/agent/lib/browseros/capabilities.ts
@@ -35,6 +35,8 @@ export enum Feature {
   WORKFLOW_SUPPORT = 'WORKFLOW_SUPPORT',
   // previousConversation as structured array (older servers only accept string)
   PREVIOUS_CONVERSATION_ARRAY = 'PREVIOUS_CONVERSATION_ARRAY',
+  // Soul page: agent personality viewer and editor
+  SOUL_SUPPORT = 'SOUL_SUPPORT',
 }
 
 /**
@@ -57,6 +59,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.PROXY_SUPPORT]: { minBrowserOSVersion: '0.39.0.1' },
   [Feature.WORKFLOW_SUPPORT]: { minServerVersion: '0.0.41' },
   [Feature.PREVIOUS_CONVERSATION_ARRAY]: { minServerVersion: '0.0.64' },
+  [Feature.SOUL_SUPPORT]: { minServerVersion: '0.0.67' },
 }
 
 function parseVersion(version: string): number[] {


### PR DESCRIPTION
## Summary
- Add `SOUL_SUPPORT` feature flag gated by `minServerVersion: '0.0.67'`
- Hide "Agent Soul" nav item in settings sidebar for older servers lacking the `/soul` endpoint
- Follows existing feature gating pattern used by Workflows, MCP, Customization, etc.

## Design
Uses the established `Feature` enum + `FEATURE_CONFIG` + `useCapabilities` hook pattern. Added one enum value, one config entry, and one `feature` property on the sidebar nav item. No new abstractions needed.

## Test plan
- [ ] Verify Soul nav item appears when server version >= 0.0.67
- [ ] Verify Soul nav item is hidden when server version < 0.0.67
- [ ] Verify all features still enabled in dev mode (`import.meta.env.DEV`)
- [ ] Verify other gated features are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)