### PR TITLE
feat(agent): update kimi launch provider branding

### DIFF
--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -81,7 +81,7 @@ export const ProviderCard: FC<ProviderCardProps> = ({
         </div>
         {isBuiltIn && provider.type === 'browseros' && kimiLaunch && (
           <span className="mb-1 inline-block rounded-full border border-orange-300/60 bg-orange-100/70 px-3 py-0.5 font-semibold text-orange-700 text-xs dark:border-orange-400/40 dark:bg-orange-500/15 dark:text-orange-300">
-            Powered by Kimi K2.5 from Moonshot AI
+            In partnership with Moonshot AI
           </span>
         )}
         <p className="truncate text-muted-foreground text-sm">

--- a/apps/agent/lib/llm-providers/storage.ts
+++ b/apps/agent/lib/llm-providers/storage.ts
@@ -2,11 +2,14 @@ import { storage } from '@wxt-dev/storage'
 import { sessionStorage } from '@/lib/auth/sessionStorage'
 import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
 import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
+import { isKimiLaunchEnabled } from '@/lib/feature-flags/kimi-launch'
 import type { LlmProviderConfig, LlmProvidersBackup } from './types'
 import { uploadLlmProvidersToGraphql } from './uploadLlmProvidersToGraphql'
 
 /** Default provider ID constant */
 export const DEFAULT_PROVIDER_ID = 'browseros'
+const DEFAULT_PROVIDER_NAME = 'BrowserOS'
+const KIMI_LAUNCH_PROVIDER_NAME = 'Kimi K2.5'
 
 /** Storage key for LLM providers array */
 export const providersStorage = storage.defineItem<LlmProviderConfig[]>(
@@ -68,8 +71,17 @@ export function setupLlmProvidersSyncToBackend(): () => void {
 
 /** Load providers from storage */
 export async function loadProviders(): Promise<LlmProviderConfig[]> {
-  const providers = await providersStorage.getValue()
-  return providers || []
+  const providers = (await providersStorage.getValue()) || []
+  const normalizedProviders = normalizeProvidersForLaunch(providers)
+
+  // Keep storage consistent so every consumer sees the same provider name.
+  if (
+    normalizedProviders.some((provider, index) => provider !== providers[index])
+  ) {
+    await providersStorage.setValue(normalizedProviders)
+  }
+
+  return normalizedProviders
 }
 
 /** Creates the default BrowserOS provider configuration */
@@ -78,7 +90,7 @@ export function createDefaultBrowserOSProvider(): LlmProviderConfig {
   return {
     id: DEFAULT_PROVIDER_ID,
     type: 'browseros',
-    name: 'BrowserOS',
+    name: getBuiltInProviderName(),
     baseUrl: 'https://api.browseros.com/v1',
     modelId: 'browseros-auto',
     supportsImages: true,
@@ -92,6 +104,32 @@ export function createDefaultBrowserOSProvider(): LlmProviderConfig {
 /** Creates the default providers configuration. Only call when storage is empty. */
 export function createDefaultProvidersConfig(): LlmProviderConfig[] {
   return [createDefaultBrowserOSProvider()]
+}
+
+function getBuiltInProviderName(): string {
+  return isKimiLaunchEnabled()
+    ? KIMI_LAUNCH_PROVIDER_NAME
+    : DEFAULT_PROVIDER_NAME
+}
+
+function normalizeProvidersForLaunch(
+  providers: LlmProviderConfig[],
+): LlmProviderConfig[] {
+  const builtInProviderName = getBuiltInProviderName()
+
+  return providers.map((provider) => {
+    if (
+      provider.id === DEFAULT_PROVIDER_ID &&
+      provider.type === 'browseros' &&
+      provider.name !== builtInProviderName
+    ) {
+      return {
+        ...provider,
+        name: builtInProviderName,
+      }
+    }
+    return provider
+  })
 }
 
 /** Storage key for the default provider ID */


### PR DESCRIPTION
## Summary
- rename built-in BrowserOS provider to `Kimi K2.5` when `VITE_PUBLIC_KIMI_LAUNCH=true`
- normalize existing stored built-in provider names during load so UI remains consistent
- update the orange badge copy to `In partnership with Moonshot AI`

## Validation
- bunx biome check apps/agent/lib/llm-providers/storage.ts apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
- bun run --filter @browseros/agent typecheck *(fails due to existing unrelated error in `entrypoints/app/create-graph/GraphChat.tsx` missing `showDontShowAgain` prop)*