### PR TITLE
fix: prevent sending multiple messages when chat is running

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/ChatInput.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatInput.tsx
@@ -147,10 +147,16 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       [closeMention, openMentionAtCursor, toggleMentionAtCursor],
     )
 
+    const isBusy = status !== 'ready' && status !== 'error'
+
     const handleSubmit = (e: FormEvent) => {
       if (mentionStateRef.current.isOpen) {
         e.preventDefault()
         closeMention()
+        return
+      }
+      if (isBusy) {
+        e.preventDefault()
         return
       }
       onSubmitProp(e)
@@ -229,7 +235,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         !e.nativeEvent.isComposing
       ) {
         e.preventDefault()
-        if (input.trim()) {
+        if (input.trim() && !isBusy) {
           e.currentTarget.form?.requestSubmit()
         }
       }
@@ -280,7 +286,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
           }
           rows={1}
         />
-        {status === 'streaming' ? (
+        {isBusy ? (
           <button
             type="button"
             onClick={onStop}


### PR DESCRIPTION
This pull request improves the user experience and reliability of the `ChatInput` component by preventing user input and submission actions when the chat is in a busy state (such as loading or streaming). The changes ensure that users cannot submit new messages or trigger certain actions while the system is not ready, reducing the risk of errors or unintended behavior.

**Input handling improvements:**

* Added an `isBusy` flag to determine when the chat is not ready for new input, based on the `status` prop.
* Prevented form submission in the `handleSubmit` function if the chat is busy, ensuring that messages cannot be sent when the system is not ready.
* Updated the Enter key handler to prevent message submission if the chat is busy, even if the input is non-empty.

**UI feedback improvements:**

* Updated the rendering logic to show the busy state UI (e.g., a stop button) whenever the chat is busy, not just when streaming.