### PR TITLE
fix: resolve Klavis MCP auth for newly added servers

### DIFF
--- a/apps/agent/components/elements/AppSelector.tsx
+++ b/apps/agent/components/elements/AppSelector.tsx
@@ -58,7 +58,7 @@ export const AppSelector: FC<AppSelectorProps> = ({
   const connectedServers = createdServers.filter((s) => {
     if (s.type !== 'managed' || !s.managedServerName) return false
     const integration = userMCPIntegrations?.integrations?.find(
-      (i) => i.name === s.managedServerName,
+      (i) => i.name.toLowerCase() === s.managedServerName?.toLowerCase(),
     )
     return integration?.is_authenticated === true
   })
@@ -67,7 +67,7 @@ export const AppSelector: FC<AppSelectorProps> = ({
     if (s.type !== 'managed' || !s.managedServerName) return false
     if (isIntegrationsLoading) return false
     const integration = userMCPIntegrations?.integrations?.find(
-      (i) => i.name === s.managedServerName,
+      (i) => i.name.toLowerCase() === s.managedServerName?.toLowerCase(),
     )
     return !integration?.is_authenticated
   })
@@ -123,6 +123,12 @@ export const AppSelector: FC<AppSelectorProps> = ({
   const handleAddServer = async (name: string, description: string) => {
     try {
       const response = await addManagedServerMutation({ serverName: name })
+
+      if (!response.apiKeyUrl && !response.oauthUrl) {
+        toast.error(`Failed to add app: ${name}`)
+        return
+      }
+
       addServer({
         id: Date.now().toString(),
         displayName: name,
@@ -134,10 +140,6 @@ export const AppSelector: FC<AppSelectorProps> = ({
 
       if (response.apiKeyUrl) {
         setApiKeyServer({ name, apiKeyUrl: response.apiKeyUrl })
-        return
-      }
-      if (!response.oauthUrl) {
-        toast.error(`Failed to add app: ${name}`)
         return
       }
       window.open(response.oauthUrl, '_blank')?.focus()

--- a/apps/agent/entrypoints/app/connect-mcp/ConnectMCP.tsx
+++ b/apps/agent/entrypoints/app/connect-mcp/ConnectMCP.tsx
@@ -195,7 +195,7 @@ export const ConnectMCP: FC = () => {
     for (const server of createdServers) {
       if (server.type !== 'managed' || !server.managedServerName) continue
       const integration = userMCPIntegrations?.integrations?.find(
-        (i) => i.name === server.managedServerName,
+        (i) => i.name.toLowerCase() === server.managedServerName?.toLowerCase(),
       )
       if (!integration?.is_authenticated) {
         unauthenticatedServers.push({
@@ -283,7 +283,9 @@ export const ConnectMCP: FC = () => {
                   (isUserMCPIntegrationsLoading ? (
                     <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
                   ) : userMCPIntegrations?.integrations?.find(
-                      (i) => i.name === server.managedServerName,
+                      (i) =>
+                        i.name.toLowerCase() ===
+                        server.managedServerName?.toLowerCase(),
                     )?.is_authenticated ? (
                     <span className="flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-1 font-medium text-green-600 text-xs">
                       <Check className="h-3 w-3" />

--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -92,7 +92,7 @@ export const NewTab = () => {
   const connectedManagedServers = mcpServers.filter((s) => {
     if (s.type !== 'managed' || !s.managedServerName) return false
     return userMCPIntegrations?.integrations?.find(
-      (i) => i.name === s.managedServerName,
+      (i) => i.name.toLowerCase() === s.managedServerName?.toLowerCase(),
     )?.is_authenticated
   })
 

--- a/apps/agent/entrypoints/sidepanel/index/ChatFooter.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatFooter.tsx
@@ -50,7 +50,7 @@ export const ChatFooter: FC<ChatFooterProps> = ({
   const connectedManagedServers = mcpServers.filter((s) => {
     if (s.type !== 'managed' || !s.managedServerName) return false
     return userMCPIntegrations?.integrations?.find(
-      (i) => i.name === s.managedServerName,
+      (i) => i.name.toLowerCase() === s.managedServerName?.toLowerCase(),
     )?.is_authenticated
   })
 

--- a/apps/server/src/api/routes/klavis.ts
+++ b/apps/server/src/api/routes/klavis.ts
@@ -90,10 +90,17 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
 
       try {
         const integrations = await klavisClient.getUserIntegrations(browserosId)
-        const normalizedIntegrations = integrations.map((integration) => ({
-          name: integration.name,
-          is_authenticated: integration.isAuthenticated,
-        }))
+        const normalizedIntegrations = integrations.map((integration) => {
+          const canonical = OAUTH_MCP_SERVERS.find(
+            (s) =>
+              normalizeServerKey(s.name) ===
+              normalizeServerKey(integration.name),
+          )
+          return {
+            name: canonical?.name ?? integration.name,
+            is_authenticated: integration.isAuthenticated,
+          }
+        })
         logger.info('Fetched user integrations', {
           browserosId: browserosId.slice(0, 12),
           count: normalizedIntegrations.length,

--- a/apps/server/src/lib/clients/klavis/klavis-client.ts
+++ b/apps/server/src/lib/clients/klavis/klavis-client.ts
@@ -112,7 +112,7 @@ export class KlavisClient {
     integration: KlavisIntegrationItem,
   ): UserIntegration | null {
     if (typeof integration === 'string') {
-      return { name: integration, isAuthenticated: true }
+      return { name: integration, isAuthenticated: false }
     }
     const name = integration.name
     if (!name || typeof name !== 'string') {


### PR DESCRIPTION
## Summary
- Fix `normalizeIntegration` defaulting string integrations to `isAuthenticated: true` — now defaults to `false` so unauthenticated servers show the auth prompt
- Add case-insensitive integration name matching across all 4 frontend components (ConnectMCP, AppSelector, ChatFooter, NewTab)
- Normalize Klavis integration names to canonical `OAUTH_MCP_SERVERS` names server-side before returning to frontend
- Fix `AppSelector.handleAddServer` adding servers to storage before validating auth URL

## Design
Targeted fix at the data/matching layer. The Klavis Strata MCP tools and agent auth prompt work correctly once the user is properly authenticated — the bug was that new servers (Exa, Stripe, etc.) weren't surfacing the authentication prompt due to incorrect status normalization and case-sensitive name matching.

## Test plan
- [ ] Add a new API-key server (e.g., Exa) — verify it shows "Needs authentication" in ConnectMCP settings
- [ ] Verify clicking "Authenticate" opens the API key dialog
- [ ] After entering API key, verify server shows as "Authenticated"
- [ ] In chat footer, verify the server icon appears only after authentication
- [ ] Test with an OAuth server (e.g., Gmail) to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)