### PR TITLE
feat: add inline chat experience to new tab page

### DIFF
--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -46,6 +46,7 @@ import {
   NEWTAB_WORKSPACE_OPENED_EVENT,
 } from '@/lib/constants/analyticsEvents'
 import { useMcpServers } from '@/lib/mcp/mcpServerStorage'
+import { openSidePanelWithSearch } from '@/lib/messaging/sidepanel/openSidepanelWithSearch'
 import { track } from '@/lib/metrics/track'
 import { cn } from '@/lib/utils'
 import { useWorkspace } from '@/lib/workspace/use-workspace'
@@ -306,7 +307,17 @@ export const NewTab = () => {
           tabs: selectedTabs,
         })
         const searchQuery = `${item.name}${item.description ? ` - ${item.description}` : ''}}`
-        startInlineChat(searchQuery, 'agent', action)
+        if (supports(Feature.NEWTAB_CHAT_SUPPORT)) {
+          startInlineChat(searchQuery, 'agent', action)
+        } else {
+          openSidePanelWithSearch('open', {
+            query: searchQuery,
+            mode: 'agent',
+            action,
+          })
+          reset()
+          setSelectedTabs([])
+        }
         break
       }
       case 'browseros': {
@@ -319,7 +330,17 @@ export const NewTab = () => {
           message: item.message,
           tabs: selectedTabs,
         })
-        startInlineChat(item.message, item.mode, action)
+        if (supports(Feature.NEWTAB_CHAT_SUPPORT)) {
+          startInlineChat(item.message, item.mode, action)
+        } else {
+          openSidePanelWithSearch('open', {
+            query: item.message,
+            mode: item.mode,
+            action,
+          })
+          reset()
+          setSelectedTabs([])
+        }
         break
       }
     }

--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/tooltip'
 import { McpServerIcon } from '@/entrypoints/app/connect-mcp/McpServerIcon'
 import { useGetUserMCPIntegrations } from '@/entrypoints/app/connect-mcp/useGetUserMCPIntegrations'
+import { useChatSessionContext } from '@/entrypoints/sidepanel/layout/ChatSessionContext'
 import { Feature } from '@/lib/browseros/capabilities'
 import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import {
@@ -35,6 +36,7 @@ import {
 import {
   NEWTAB_AI_TRIGGERED_EVENT,
   NEWTAB_APPS_OPENED_EVENT,
+  NEWTAB_CHAT_RESET_EVENT,
   NEWTAB_OPENED_EVENT,
   NEWTAB_SEARCH_EXECUTED_EVENT,
   NEWTAB_TAB_REMOVED_EVENT,
@@ -43,7 +45,6 @@ import {
   NEWTAB_WORKSPACE_OPENED_EVENT,
 } from '@/lib/constants/analyticsEvents'
 import { useMcpServers } from '@/lib/mcp/mcpServerStorage'
-import { openSidePanelWithSearch } from '@/lib/messaging/sidepanel/openSidepanelWithSearch'
 import { track } from '@/lib/metrics/track'
 import { cn } from '@/lib/utils'
 import { useWorkspace } from '@/lib/workspace/use-workspace'
@@ -54,6 +55,7 @@ import {
   useSuggestions,
 } from './lib/suggestions/useSuggestions'
 import { NewTabBranding } from './NewTabBranding'
+import { NewTabChat } from './NewTabChat'
 import { NewTabTip } from './NewTabTip'
 import { ScheduleResults } from './ScheduleResults'
 import { SearchSuggestions } from './SearchSuggestions'
@@ -79,6 +81,7 @@ export const NewTab = () => {
   const tabsDropdownRef = useRef<HTMLDivElement>(null)
   const [selectedTabs, setSelectedTabs] = useState<chrome.tabs.Tab[]>([])
   const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false)
+  const [chatActive, setChatActive] = useState(false)
   const [mentionState, setMentionState] = useState<MentionState>({
     isOpen: false,
     filterText: '',
@@ -88,6 +91,10 @@ export const NewTab = () => {
   const { supports } = useCapabilities()
   const { servers: mcpServers } = useMcpServers()
   const { data: userMCPIntegrations } = useGetUserMCPIntegrations()
+
+  // Chat session for inline chat
+  const { messages, sendMessage, setMode, resetConversation } =
+    useChatSessionContext()
 
   const connectedManagedServers = mcpServers.filter((s) => {
     if (s.type !== 'managed' || !s.managedServerName) return false
@@ -262,6 +269,21 @@ export const NewTab = () => {
     runSelectedAction(selectedItem)
   }
 
+  // Start inline chat with the given message and action
+  const startInlineChat = (
+    message: string,
+    mode: 'chat' | 'agent',
+    action?: ReturnType<
+      typeof createBrowserOSAction | typeof createAITabAction
+    >,
+  ) => {
+    setMode(mode)
+    setChatActive(true)
+    sendMessage({ text: message, action })
+    reset()
+    setSelectedTabs([])
+  }
+
   const runSelectedAction = (item: SuggestionItem | undefined) => {
     if (!item) return
 
@@ -284,11 +306,7 @@ export const NewTab = () => {
           tabs: selectedTabs,
         })
         const searchQuery = `${item.name}${item.description ? ` - ${item.description}` : ''}}`
-        openSidePanelWithSearch('open', {
-          query: searchQuery,
-          mode: 'agent',
-          action,
-        })
+        startInlineChat(searchQuery, 'agent', action)
         break
       }
       case 'browseros': {
@@ -301,31 +319,33 @@ export const NewTab = () => {
           message: item.message,
           tabs: selectedTabs,
         })
-        openSidePanelWithSearch('open', {
-          query: item.message,
-          mode: item.mode,
-          action,
-        })
+        startInlineChat(item.message, item.mode, action)
         break
       }
     }
-    reset()
-    setSelectedTabs([])
+  }
+
+  const handleBackToSearch = () => {
+    track(NEWTAB_CHAT_RESET_EVENT, { message_count: messages.length })
+    resetConversation()
+    setChatActive(false)
   }
 
   const isSuggestionsVisible =
     !mentionState.isOpen &&
-    // User is typing text into the input
     ((isOpen && inputValue.length) ||
-      // There are sections to display
       (sections.length > 0 && inputValue.length) ||
-      // User has selected some active tabs
       (isOpen && selectedTabs.length))
 
   useEffect(() => {
     setMounted(true)
     track(NEWTAB_OPENED_EVENT)
   }, [])
+
+  // Show chat view when active
+  if (chatActive) {
+    return <NewTabChat onBackToSearch={handleBackToSearch} />
+  }
 
   return (
     <div className="pt-[max(25vh,16px)]">

--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -92,7 +92,6 @@ export const NewTab = () => {
   const { servers: mcpServers } = useMcpServers()
   const { data: userMCPIntegrations } = useGetUserMCPIntegrations()
 
-  // Chat session for inline chat
   const { messages, sendMessage, setMode, resetConversation } =
     useChatSessionContext()
 
@@ -269,7 +268,6 @@ export const NewTab = () => {
     runSelectedAction(selectedItem)
   }
 
-  // Start inline chat with the given message and action
   const startInlineChat = (
     message: string,
     mode: 'chat' | 'agent',
@@ -342,7 +340,6 @@ export const NewTab = () => {
     track(NEWTAB_OPENED_EVENT)
   }, [])
 
-  // Show chat view when active
   if (chatActive) {
     return <NewTabChat onBackToSearch={handleBackToSearch} />
   }

--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -37,6 +37,7 @@ import {
   NEWTAB_AI_TRIGGERED_EVENT,
   NEWTAB_APPS_OPENED_EVENT,
   NEWTAB_CHAT_RESET_EVENT,
+  NEWTAB_CHAT_STARTED_EVENT,
   NEWTAB_OPENED_EVENT,
   NEWTAB_SEARCH_EXECUTED_EVENT,
   NEWTAB_TAB_REMOVED_EVENT,
@@ -275,6 +276,7 @@ export const NewTab = () => {
       typeof createBrowserOSAction | typeof createAITabAction
     >,
   ) => {
+    track(NEWTAB_CHAT_STARTED_EVENT, { mode, tabs_count: selectedTabs.length })
     setMode(mode)
     setChatActive(true)
     sendMessage({ text: message, action })

--- a/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
@@ -9,7 +9,7 @@ import { useChatSessionContext } from '@/entrypoints/sidepanel/layout/ChatSessio
 import { createBrowserOSAction } from '@/lib/chat-actions/types'
 import {
   NEWTAB_CHAT_MODE_CHANGED_EVENT,
-  NEWTAB_CHAT_STARTED_EVENT,
+  NEWTAB_CHAT_RESET_EVENT,
   NEWTAB_CHAT_STOPPED_EVENT,
   NEWTAB_CHAT_SUGGESTION_CLICKED_EVENT,
   NEWTAB_TAB_REMOVED_EVENT,
@@ -106,12 +106,6 @@ export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (messages.length === 0) {
-      track(NEWTAB_CHAT_STARTED_EVENT, {
-        mode,
-        tabs_count: attachedTabs.length,
-      })
-    }
     executeMessage()
   }
 
@@ -121,6 +115,7 @@ export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
   }
 
   const handleNewConversation = () => {
+    track(NEWTAB_CHAT_RESET_EVENT, { message_count: messages.length })
     resetConversation()
   }
 

--- a/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
@@ -1,0 +1,187 @@
+import { Loader2 } from 'lucide-react'
+import { type FC, useEffect, useRef, useState } from 'react'
+import { ChatEmptyState } from '@/entrypoints/sidepanel/index/ChatEmptyState'
+import { ChatError } from '@/entrypoints/sidepanel/index/ChatError'
+import { ChatFooter } from '@/entrypoints/sidepanel/index/ChatFooter'
+import { ChatMessages } from '@/entrypoints/sidepanel/index/ChatMessages'
+import type { ChatMode } from '@/entrypoints/sidepanel/index/chatTypes'
+import { useChatSessionContext } from '@/entrypoints/sidepanel/layout/ChatSessionContext'
+import { createBrowserOSAction } from '@/lib/chat-actions/types'
+import {
+  NEWTAB_CHAT_MODE_CHANGED_EVENT,
+  NEWTAB_CHAT_STARTED_EVENT,
+  NEWTAB_CHAT_STOPPED_EVENT,
+  NEWTAB_CHAT_SUGGESTION_CLICKED_EVENT,
+  NEWTAB_TAB_REMOVED_EVENT,
+  NEWTAB_TAB_TOGGLED_EVENT,
+} from '@/lib/constants/analyticsEvents'
+import { track } from '@/lib/metrics/track'
+import { NewTabChatHeader } from './NewTabChatHeader'
+
+interface NewTabChatProps {
+  onBackToSearch: () => void
+}
+
+export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
+  const {
+    mode,
+    setMode,
+    messages,
+    sendMessage,
+    status,
+    stop,
+    agentUrlError,
+    chatError,
+    getActionForMessage,
+    liked,
+    onClickLike,
+    disliked,
+    onClickDislike,
+    isRestoringConversation,
+    providers,
+    selectedProvider,
+    handleSelectProvider,
+    resetConversation,
+  } = useChatSessionContext()
+
+  const [input, setInput] = useState('')
+  const [attachedTabs, setAttachedTabs] = useState<chrome.tabs.Tab[]>([])
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll only when messages change
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const handleModeChange = (newMode: ChatMode) => {
+    track(NEWTAB_CHAT_MODE_CHANGED_EVENT, { from: mode, to: newMode })
+    setMode(newMode)
+  }
+
+  const handleStop = () => {
+    track(NEWTAB_CHAT_STOPPED_EVENT)
+    stop()
+  }
+
+  const toggleTabSelection = (tab: chrome.tabs.Tab) => {
+    setAttachedTabs((prev) => {
+      const isSelected = prev.some((t) => t.id === tab.id)
+      track(NEWTAB_TAB_TOGGLED_EVENT, {
+        action: isSelected ? 'removed' : 'added',
+      })
+      if (isSelected) {
+        return prev.filter((t) => t.id !== tab.id)
+      }
+      return [...prev, tab]
+    })
+  }
+
+  const removeTab = (tabId?: number) => {
+    track(NEWTAB_TAB_REMOVED_EVENT)
+    setAttachedTabs((prev) => prev.filter((t) => t.id !== tabId))
+  }
+
+  const executeMessage = (customMessageText?: string) => {
+    const messageText = customMessageText ? customMessageText : input.trim()
+    if (!messageText) return
+
+    if (attachedTabs.length) {
+      const action = createBrowserOSAction({
+        mode,
+        message: messageText,
+        tabs: attachedTabs,
+      })
+      sendMessage({ text: messageText, action })
+    } else {
+      sendMessage({ text: messageText })
+    }
+    setInput('')
+    setAttachedTabs([])
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (messages.length === 0) {
+      track(NEWTAB_CHAT_STARTED_EVENT, {
+        mode,
+        tabs_count: attachedTabs.length,
+      })
+    }
+    executeMessage()
+  }
+
+  const handleSuggestionClick = (suggestion: string) => {
+    track(NEWTAB_CHAT_SUGGESTION_CLICKED_EVENT, { mode })
+    executeMessage(suggestion)
+  }
+
+  const handleNewConversation = () => {
+    resetConversation()
+  }
+
+  if (!selectedProvider) return null
+
+  return (
+    <div className="flex h-[calc(100vh-2rem)] flex-col">
+      <NewTabChatHeader
+        selectedProvider={selectedProvider}
+        providers={providers}
+        onSelectProvider={handleSelectProvider}
+        onNewConversation={handleNewConversation}
+        onBackToSearch={onBackToSearch}
+        hasMessages={messages.length > 0}
+      />
+
+      <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col space-y-4 overflow-y-auto px-4 pt-4">
+        {isRestoringConversation ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : messages.length === 0 ? (
+          <ChatEmptyState
+            mode={mode}
+            mounted={mounted}
+            onSuggestionClick={handleSuggestionClick}
+          />
+        ) : (
+          <ChatMessages
+            messages={messages}
+            status={status}
+            messagesEndRef={messagesEndRef}
+            getActionForMessage={getActionForMessage}
+            liked={liked}
+            onClickLike={onClickLike}
+            disliked={disliked}
+            onClickDislike={onClickDislike}
+            showJtbdPopup={false}
+            showDontShowAgain={false}
+            onTakeSurvey={() => {}}
+            onDismissJtbdPopup={() => {}}
+          />
+        )}
+        {agentUrlError && <ChatError error={agentUrlError} />}
+        {chatError && <ChatError error={chatError} />}
+      </main>
+
+      <div className="mx-auto w-full max-w-3xl px-4">
+        <ChatFooter
+          mode={mode}
+          onModeChange={handleModeChange}
+          input={input}
+          onInputChange={setInput}
+          onSubmit={handleSubmit}
+          status={status}
+          onStop={handleStop}
+          attachedTabs={attachedTabs}
+          onToggleTab={toggleTabSelection}
+          onRemoveTab={removeTab}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/newtab/index/NewTabChatHeader.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTabChatHeader.tsx
@@ -1,0 +1,78 @@
+import { ArrowLeft, Plus } from 'lucide-react'
+import type { FC } from 'react'
+import { ChatProviderSelector } from '@/components/chat/ChatProviderSelector'
+import type { Provider } from '@/components/chat/chatComponentTypes'
+import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
+import type { ProviderType } from '@/lib/llm-providers/types'
+
+interface NewTabChatHeaderProps {
+  selectedProvider: Provider
+  providers: Provider[]
+  onSelectProvider: (provider: Provider) => void
+  onNewConversation: () => void
+  onBackToSearch: () => void
+  hasMessages: boolean
+}
+
+export const NewTabChatHeader: FC<NewTabChatHeaderProps> = ({
+  selectedProvider,
+  providers,
+  onSelectProvider,
+  onNewConversation,
+  onBackToSearch,
+  hasMessages,
+}) => {
+  return (
+    <header className="flex items-center justify-between border-border/40 border-b bg-background/80 px-4 py-2.5 backdrop-blur-md">
+      <div className="flex items-center gap-2">
+        {/* Back to search */}
+        <button
+          type="button"
+          onClick={onBackToSearch}
+          className="cursor-pointer rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          title="Back to search"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
+
+        {/* Provider selector */}
+        <ChatProviderSelector
+          providers={providers}
+          selectedProvider={selectedProvider}
+          onSelectProvider={onSelectProvider}
+        >
+          <button
+            type="button"
+            className="group relative inline-flex cursor-pointer items-center gap-2 rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground data-[state=open]:bg-accent"
+            title="Change AI Provider"
+          >
+            {selectedProvider.type === 'browseros' ? (
+              <BrowserOSIcon size={18} />
+            ) : (
+              <ProviderIcon
+                type={selectedProvider.type as ProviderType}
+                size={18}
+              />
+            )}
+            <span className="font-semibold text-base">
+              {selectedProvider.name}
+            </span>
+          </button>
+        </ChatProviderSelector>
+      </div>
+
+      <div className="flex items-center gap-1">
+        {hasMessages && (
+          <button
+            type="button"
+            onClick={onNewConversation}
+            className="cursor-pointer rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+            title="New conversation"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    </header>
+  )
+}

--- a/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
+++ b/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
@@ -5,7 +5,7 @@ import { NewTabFocusGrid } from './NewTabFocusGrid'
 
 export const NewTabLayout: FC = () => {
   return (
-    <ChatSessionProvider>
+    <ChatSessionProvider origin="newtab">
       <NewTabFocusGrid />
       <Outlet />
     </ChatSessionProvider>

--- a/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
+++ b/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
@@ -1,12 +1,13 @@
 import type { FC } from 'react'
 import { Outlet } from 'react-router'
+import { ChatSessionProvider } from '@/entrypoints/sidepanel/layout/ChatSessionContext'
 import { NewTabFocusGrid } from './NewTabFocusGrid'
 
 export const NewTabLayout: FC = () => {
   return (
-    <>
+    <ChatSessionProvider>
       <NewTabFocusGrid />
       <Outlet />
-    </>
+    </ChatSessionProvider>
   )
 }

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -64,7 +64,15 @@ export const getResponseAndQueryFromMessageId = (
   }
 }
 
-export const useChatSession = () => {
+export type ChatOrigin = 'sidepanel' | 'newtab'
+
+export interface ChatSessionOptions {
+  origin?: ChatOrigin
+}
+
+const NEWTAB_SYSTEM_PROMPT = `IMPORTANT: The user is chatting from the New Tab page. When performing browser actions, ALWAYS open content in a NEW TAB rather than navigating the current tab. The user's new tab page should remain accessible.`
+
+export const useChatSession = (options?: ChatSessionOptions) => {
   const {
     selectedLlmProviderRef,
     enabledMcpServersRef,
@@ -294,7 +302,12 @@ export const useChatSession = () => {
             region: provider?.region,
             sessionToken: provider?.sessionToken,
             browserContext,
-            userSystemPrompt: personalizationRef.current,
+            userSystemPrompt:
+              options?.origin === 'newtab'
+                ? [personalizationRef.current, NEWTAB_SYSTEM_PROMPT]
+                    .filter(Boolean)
+                    .join('\n\n')
+                : personalizationRef.current,
             userWorkingDir: workingDirRef.current,
             supportsImages: provider?.supportsImages,
             previousConversation,

--- a/apps/agent/entrypoints/sidepanel/layout/ChatSessionContext.tsx
+++ b/apps/agent/entrypoints/sidepanel/layout/ChatSessionContext.tsx
@@ -1,14 +1,17 @@
 import { createContext, type FC, type ReactNode, useContext } from 'react'
-import { useChatSession } from '../index/useChatSession'
+import {
+  type ChatSessionOptions,
+  useChatSession,
+} from '../index/useChatSession'
 
 type ChatSessionContextValue = ReturnType<typeof useChatSession>
 
 const ChatSessionContext = createContext<ChatSessionContextValue | null>(null)
 
-export const ChatSessionProvider: FC<{ children: ReactNode }> = ({
-  children,
-}) => {
-  const session = useChatSession()
+export const ChatSessionProvider: FC<
+  { children: ReactNode } & ChatSessionOptions
+> = ({ children, ...options }) => {
+  const session = useChatSession(options)
   return (
     <ChatSessionContext.Provider value={session}>
       {children}

--- a/apps/agent/lib/browseros/capabilities.ts
+++ b/apps/agent/lib/browseros/capabilities.ts
@@ -37,6 +37,8 @@ export enum Feature {
   PREVIOUS_CONVERSATION_ARRAY = 'PREVIOUS_CONVERSATION_ARRAY',
   // Soul page: agent personality viewer and editor
   SOUL_SUPPORT = 'SOUL_SUPPORT',
+  // Inline chat in the new tab page
+  NEWTAB_CHAT_SUPPORT = 'NEWTAB_CHAT_SUPPORT',
 }
 
 /**
@@ -60,6 +62,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.WORKFLOW_SUPPORT]: { minServerVersion: '0.0.41' },
   [Feature.PREVIOUS_CONVERSATION_ARRAY]: { minServerVersion: '0.0.64' },
   [Feature.SOUL_SUPPORT]: { minServerVersion: '0.0.67' },
+  [Feature.NEWTAB_CHAT_SUPPORT]: { minBrowserOSVersion: '0.40.0.0' },
 }
 
 function parseVersion(version: string): number[] {

--- a/apps/agent/lib/constants/analyticsEvents.ts
+++ b/apps/agent/lib/constants/analyticsEvents.ts
@@ -99,6 +99,22 @@ export const NEWTAB_APPS_OPENED_EVENT = 'newtab.apps.opened'
 export const NEWTAB_TIP_DISMISSED_EVENT = 'newtab.tip.dismissed'
 
 /** @public */
+export const NEWTAB_CHAT_STARTED_EVENT = 'newtab.chat.started'
+
+/** @public */
+export const NEWTAB_CHAT_STOPPED_EVENT = 'newtab.chat.stopped'
+
+/** @public */
+export const NEWTAB_CHAT_RESET_EVENT = 'newtab.chat.reset'
+
+/** @public */
+export const NEWTAB_CHAT_SUGGESTION_CLICKED_EVENT =
+  'newtab.chat.suggestion_clicked'
+
+/** @public */
+export const NEWTAB_CHAT_MODE_CHANGED_EVENT = 'newtab.chat.mode_changed'
+
+/** @public */
 export const WORKFLOW_DELETED_EVENT = 'settings.workflow.deleted'
 
 /** @public */


### PR DESCRIPTION
## Summary
- When users select an AI suggestion from the new tab search bar, the page now transitions inline to a full-page chat instead of opening the sidepanel
- Reuses existing sidepanel chat components (`ChatMessages`, `ChatFooter`, `ChatEmptyState`, `ChatError`) — no code duplication
- Adds a simplified `NewTabChatHeader` with provider selector, back-to-search, and new conversation controls
- Adds newtab-specific analytics events (`newtab.chat.started`, `newtab.chat.stopped`, `newtab.chat.reset`, etc.)

## Design
The NewTab component gains a `chatActive` state that toggles between the search view and a full-page chat view. When the user selects a BrowserOS or AI Tab suggestion, `startInlineChat()` sets the mode, activates the chat, and sends the first message — all inline without opening the sidepanel. The chat session is provided via `ChatSessionProvider` in `NewTabLayout`, reusing the existing `useChatSession` hook for streaming, tool calling, message persistence, provider selection, and all chat features. No backend changes needed.

## Files changed
- `NewTab.tsx` — added `chatActive` state, `startInlineChat()`, replaced `openSidePanelWithSearch()` calls
- `NewTabChat.tsx` — new full-page chat component (187 lines)
- `NewTabChatHeader.tsx` — new simplified chat header (78 lines)
- `NewTabLayout.tsx` — wrapped with `ChatSessionProvider`
- `analyticsEvents.ts` — added 5 newtab chat event constants

## Test plan
- [ ] Open a new tab, type an AI query, select a BrowserOS suggestion → should transition to full-page chat inline
- [ ] Verify streaming messages, tool calling, and stop button work in the newtab chat
- [ ] Click "back to search" arrow → should return to the search view and reset the conversation
- [ ] Click provider selector → should allow switching providers
- [ ] Click "+" (new conversation) → should reset the chat
- [ ] Verify Google search suggestions still navigate to Google (no regression)
- [ ] Verify existing sidepanel chat still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)