### PR TITLE
fix: resolve dev runner port conflicts

### DIFF
--- a/tools/dev/cmd/cleanup.go
+++ b/tools/dev/cmd/cleanup.go
@@ -31,10 +31,9 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 	doTemps := !cleanupPorts || cleanupTemps
 
 	if doPorts {
-		proc.LogMsg(proc.TagInfo, "Killing processes on ports 9005, 9105, 9305...")
-		proc.KillPort(9005)
-		proc.KillPort(9105)
-		proc.KillPort(9305)
+		ports := proc.DefaultLocalPorts()
+		proc.LogMsgf(proc.TagInfo, "Killing processes on ports %d, %d, %d...", ports.CDP, ports.Server, ports.Extension)
+		proc.KillPorts(ports)
 		proc.LogMsg(proc.TagInfo, "Ports cleared")
 	}
 

--- a/tools/dev/cmd/test.go
+++ b/tools/dev/cmd/test.go
@@ -43,12 +43,10 @@ func runTest(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	p := proc.Ports{CDP: 9005, Server: 9105, Extension: 9305}
+	p := proc.DefaultLocalPorts()
 
 	proc.LogMsg(proc.TagInfo, "Killing processes on test ports...")
-	proc.KillPort(p.CDP)
-	proc.KillPort(p.Server)
-	proc.KillPort(p.Extension)
+	proc.KillPorts(p)
 	proc.LogMsg(proc.TagInfo, "Ports cleared")
 
 	if n := proc.CleanupTempDirs("browseros-test-"); n > 0 {

--- a/tools/dev/cmd/watch.go
+++ b/tools/dev/cmd/watch.go
@@ -41,11 +41,12 @@ func runWatch(cmd *cobra.Command, args []string) error {
 
 	defaultPorts := proc.DefaultLocalPorts()
 	p := defaultPorts
+	var reservations *proc.PortReservations
 	userDataDir := "/tmp/browseros-dev"
 
 	if watchNew {
 		proc.LogMsg(proc.TagInfo, "Selecting random available ports...")
-		p, err = proc.ResolveWatchPorts(true)
+		p, reservations, err = proc.ResolveWatchPorts(true)
 		if err != nil {
 			return err
 		}
@@ -61,7 +62,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 		proc.KillPorts(defaultPorts)
 		proc.LogMsg(proc.TagInfo, "Ports cleared")
 
-		p, err = proc.ResolveWatchPorts(false)
+		p, reservations, err = proc.ResolveWatchPorts(false)
 		if err != nil {
 			return err
 		}
@@ -71,6 +72,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 				p.CDP, p.Server, p.Extension)
 		}
 	}
+	defer reservations.ReleaseAll()
 
 	fmt.Println()
 	mode := "watch"
@@ -121,6 +123,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 		}
 		proc.LogMsg(proc.TagBuild, "agent built")
 
+		reservations.ReleaseCDP()
 		procs = append(procs, proc.StartManaged(ctx, &wg, proc.ProcConfig{
 			Tag:     proc.TagBrowser,
 			Dir:     root,
@@ -133,6 +136,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 			}),
 		}))
 	} else {
+		reservations.ReleaseCDP()
 		procs = append(procs, proc.StartManaged(ctx, &wg, proc.ProcConfig{
 			Tag:     proc.TagAgent,
 			Dir:     agentDir,
@@ -151,6 +155,8 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	}
 
 	// Start server
+	reservations.ReleaseServer()
+	reservations.ReleaseExtension()
 	procs = append(procs, proc.StartManaged(ctx, &wg, proc.ProcConfig{
 		Tag:     proc.TagServer,
 		Dir:     filepath.Join(root, "apps/server"),

--- a/tools/dev/cmd/watch.go
+++ b/tools/dev/cmd/watch.go
@@ -28,7 +28,7 @@ var (
 )
 
 func init() {
-	watchCmd.Flags().BoolVar(&watchNew, "new", false, "Find available ports and create a fresh user-data directory")
+	watchCmd.Flags().BoolVar(&watchNew, "new", false, "Use random available ports in 9000-9999 and create a fresh user-data directory")
 	watchCmd.Flags().BoolVar(&watchManual, "manual", false, "Build agent statically instead of WXT HMR mode")
 	rootCmd.AddCommand(watchCmd)
 }
@@ -39,14 +39,16 @@ func runWatch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	p := proc.Ports{CDP: 9005, Server: 9105, Extension: 9305}
+	defaultPorts := proc.DefaultLocalPorts()
+	p := defaultPorts
 	userDataDir := "/tmp/browseros-dev"
 
 	if watchNew {
-		proc.LogMsg(proc.TagInfo, "Finding available ports...")
-		p.CDP = proc.FindAvailablePort(p.CDP)
-		p.Server = proc.FindAvailablePort(p.Server)
-		p.Extension = proc.FindAvailablePort(p.Extension)
+		proc.LogMsg(proc.TagInfo, "Selecting random available ports...")
+		p, err = proc.ResolveWatchPorts(true)
+		if err != nil {
+			return err
+		}
 
 		dir, err := os.MkdirTemp("", "browseros-dev-")
 		if err != nil {
@@ -55,11 +57,19 @@ func runWatch(cmd *cobra.Command, args []string) error {
 		userDataDir = dir
 		proc.LogMsgf(proc.TagInfo, "Created fresh profile: %s", userDataDir)
 	} else {
-		proc.LogMsg(proc.TagInfo, "Killing processes on default ports...")
-		proc.KillPort(p.CDP)
-		proc.KillPort(p.Server)
-		proc.KillPort(p.Extension)
+		proc.LogMsg(proc.TagInfo, "Killing processes on preferred ports...")
+		proc.KillPorts(defaultPorts)
 		proc.LogMsg(proc.TagInfo, "Ports cleared")
+
+		p, err = proc.ResolveWatchPorts(false)
+		if err != nil {
+			return err
+		}
+		if p != defaultPorts {
+			proc.LogMsgf(proc.TagInfo,
+				"Preferred ports unavailable, using fallback ports: CDP=%d Server=%d Extension=%d",
+				p.CDP, p.Server, p.Extension)
+		}
 	}
 
 	fmt.Println()

--- a/tools/dev/proc/ports.go
+++ b/tools/dev/proc/ports.go
@@ -16,6 +16,12 @@ type Ports struct {
 	Extension int
 }
 
+type PortReservations struct {
+	CDP       net.Listener
+	Server    net.Listener
+	Extension net.Listener
+}
+
 const (
 	randomPortMin = 9000
 	randomPortMax = 9999
@@ -27,39 +33,52 @@ func DefaultLocalPorts() Ports {
 	return defaultLocalPorts
 }
 
-func ResolveWatchPorts(useRandom bool) (Ports, error) {
+func ResolveWatchPorts(useRandom bool) (Ports, *PortReservations, error) {
 	reserved := make(map[int]struct{}, 3)
+	reservations := &PortReservations{}
 	if useRandom {
 		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-		cdp, err := selectRandomPort(rng, reserved)
+		cdp, cdpListener, err := selectRandomPort(rng, reserved)
 		if err != nil {
-			return Ports{}, err
+			reservations.ReleaseAll()
+			return Ports{}, nil, err
 		}
-		server, err := selectRandomPort(rng, reserved)
+		reservations.CDP = cdpListener
+		server, serverListener, err := selectRandomPort(rng, reserved)
 		if err != nil {
-			return Ports{}, err
+			reservations.ReleaseAll()
+			return Ports{}, nil, err
 		}
-		extension, err := selectRandomPort(rng, reserved)
+		reservations.Server = serverListener
+		extension, extensionListener, err := selectRandomPort(rng, reserved)
 		if err != nil {
-			return Ports{}, err
+			reservations.ReleaseAll()
+			return Ports{}, nil, err
 		}
-		return Ports{CDP: cdp, Server: server, Extension: extension}, nil
+		reservations.Extension = extensionListener
+		return Ports{CDP: cdp, Server: server, Extension: extension}, reservations, nil
 	}
 
 	defaultPorts := DefaultLocalPorts()
-	cdp, err := selectPreferredPort(defaultPorts.CDP, reserved)
+	cdp, cdpListener, err := selectPreferredPort(defaultPorts.CDP, reserved)
 	if err != nil {
-		return Ports{}, err
+		reservations.ReleaseAll()
+		return Ports{}, nil, err
 	}
-	server, err := selectPreferredPort(defaultPorts.Server, reserved)
+	reservations.CDP = cdpListener
+	server, serverListener, err := selectPreferredPort(defaultPorts.Server, reserved)
 	if err != nil {
-		return Ports{}, err
+		reservations.ReleaseAll()
+		return Ports{}, nil, err
 	}
-	extension, err := selectPreferredPort(defaultPorts.Extension, reserved)
+	reservations.Server = serverListener
+	extension, extensionListener, err := selectPreferredPort(defaultPorts.Extension, reserved)
 	if err != nil {
-		return Ports{}, err
+		reservations.ReleaseAll()
+		return Ports{}, nil, err
 	}
-	return Ports{CDP: cdp, Server: server, Extension: extension}, nil
+	reservations.Extension = extensionListener
+	return Ports{CDP: cdp, Server: server, Extension: extension}, reservations, nil
 }
 
 func IsPortAvailable(port int) bool {
@@ -75,6 +94,39 @@ func KillPorts(p Ports) {
 	KillPort(p.CDP)
 	KillPort(p.Server)
 	KillPort(p.Extension)
+}
+
+func (r *PortReservations) ReleaseCDP() {
+	if r == nil || r.CDP == nil {
+		return
+	}
+	r.CDP.Close()
+	r.CDP = nil
+}
+
+func (r *PortReservations) ReleaseServer() {
+	if r == nil || r.Server == nil {
+		return
+	}
+	r.Server.Close()
+	r.Server = nil
+}
+
+func (r *PortReservations) ReleaseExtension() {
+	if r == nil || r.Extension == nil {
+		return
+	}
+	r.Extension.Close()
+	r.Extension = nil
+}
+
+func (r *PortReservations) ReleaseAll() {
+	if r == nil {
+		return
+	}
+	r.ReleaseCDP()
+	r.ReleaseServer()
+	r.ReleaseExtension()
 }
 
 func KillPort(port int) {
@@ -151,9 +203,9 @@ func isMonorepoRoot(dir string) bool {
 	return err == nil
 }
 
-func selectPreferredPort(preferred int, reserved map[int]struct{}) (int, error) {
-	if reservePort(preferred, reserved) {
-		return preferred, nil
+func selectPreferredPort(preferred int, reserved map[int]struct{}) (int, net.Listener, error) {
+	if listener, ok := reservePort(preferred, reserved); ok {
+		return preferred, listener, nil
 	}
 
 	start := preferred + 1
@@ -162,19 +214,19 @@ func selectPreferredPort(preferred int, reserved map[int]struct{}) (int, error) 
 	}
 
 	for port := start; port <= randomPortMax; port++ {
-		if reservePort(port, reserved) {
-			return port, nil
+		if listener, ok := reservePort(port, reserved); ok {
+			return port, listener, nil
 		}
 	}
 	for port := randomPortMin; port < start; port++ {
-		if reservePort(port, reserved) {
-			return port, nil
+		if listener, ok := reservePort(port, reserved); ok {
+			return port, listener, nil
 		}
 	}
-	return 0, fmt.Errorf("no available port found in range %d-%d", randomPortMin, randomPortMax)
+	return 0, nil, fmt.Errorf("no available port found in range %d-%d", randomPortMin, randomPortMax)
 }
 
-func selectRandomPort(rng *rand.Rand, reserved map[int]struct{}) (int, error) {
+func selectRandomPort(rng *rand.Rand, reserved map[int]struct{}) (int, net.Listener, error) {
 	candidates := make([]int, 0, randomPortMax-randomPortMin+1)
 	for port := randomPortMin; port <= randomPortMax; port++ {
 		candidates = append(candidates, port)
@@ -183,20 +235,21 @@ func selectRandomPort(rng *rand.Rand, reserved map[int]struct{}) (int, error) {
 		candidates[i], candidates[j] = candidates[j], candidates[i]
 	})
 	for _, port := range candidates {
-		if reservePort(port, reserved) {
-			return port, nil
+		if listener, ok := reservePort(port, reserved); ok {
+			return port, listener, nil
 		}
 	}
-	return 0, fmt.Errorf("no available port found in range %d-%d", randomPortMin, randomPortMax)
+	return 0, nil, fmt.Errorf("no available port found in range %d-%d", randomPortMin, randomPortMax)
 }
 
-func reservePort(port int, reserved map[int]struct{}) bool {
+func reservePort(port int, reserved map[int]struct{}) (net.Listener, bool) {
 	if _, exists := reserved[port]; exists {
-		return false
+		return nil, false
 	}
-	if !IsPortAvailable(port) {
-		return false
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return nil, false
 	}
 	reserved[port] = struct{}{}
-	return true
+	return listener, true
 }

--- a/tools/dev/proc/ports.go
+++ b/tools/dev/proc/ports.go
@@ -2,10 +2,12 @@ package proc
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 )
 
 type Ports struct {
@@ -14,16 +16,65 @@ type Ports struct {
 	Extension int
 }
 
-func FindAvailablePort(start int) int {
-	for port := start; port < start+100; port++ {
-		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-		if err == nil {
-			ln.Close()
-			return port
+const (
+	randomPortMin = 9000
+	randomPortMax = 9999
+)
+
+var defaultLocalPorts = Ports{CDP: 9005, Server: 9105, Extension: 9305}
+
+func DefaultLocalPorts() Ports {
+	return defaultLocalPorts
+}
+
+func ResolveWatchPorts(useRandom bool) (Ports, error) {
+	reserved := make(map[int]struct{}, 3)
+	if useRandom {
+		rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+		cdp, err := selectRandomPort(rng, reserved)
+		if err != nil {
+			return Ports{}, err
 		}
+		server, err := selectRandomPort(rng, reserved)
+		if err != nil {
+			return Ports{}, err
+		}
+		extension, err := selectRandomPort(rng, reserved)
+		if err != nil {
+			return Ports{}, err
+		}
+		return Ports{CDP: cdp, Server: server, Extension: extension}, nil
 	}
-	LogMsg(TagInfo, WarnColor.Sprintf("Could not find available port near %d, using %d", start, start))
-	return start
+
+	defaultPorts := DefaultLocalPorts()
+	cdp, err := selectPreferredPort(defaultPorts.CDP, reserved)
+	if err != nil {
+		return Ports{}, err
+	}
+	server, err := selectPreferredPort(defaultPorts.Server, reserved)
+	if err != nil {
+		return Ports{}, err
+	}
+	extension, err := selectPreferredPort(defaultPorts.Extension, reserved)
+	if err != nil {
+		return Ports{}, err
+	}
+	return Ports{CDP: cdp, Server: server, Extension: extension}, nil
+}
+
+func IsPortAvailable(port int) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false
+	}
+	ln.Close()
+	return true
+}
+
+func KillPorts(p Ports) {
+	KillPort(p.CDP)
+	KillPort(p.Server)
+	KillPort(p.Extension)
 }
 
 func KillPort(port int) {
@@ -98,4 +149,54 @@ func isMonorepoRoot(dir string) bool {
 	}
 	_, err = os.Stat(filepath.Join(dir, "apps"))
 	return err == nil
+}
+
+func selectPreferredPort(preferred int, reserved map[int]struct{}) (int, error) {
+	if reservePort(preferred, reserved) {
+		return preferred, nil
+	}
+
+	start := preferred + 1
+	if preferred < randomPortMin || preferred > randomPortMax {
+		start = randomPortMin
+	}
+
+	for port := start; port <= randomPortMax; port++ {
+		if reservePort(port, reserved) {
+			return port, nil
+		}
+	}
+	for port := randomPortMin; port < start; port++ {
+		if reservePort(port, reserved) {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available port found in range %d-%d", randomPortMin, randomPortMax)
+}
+
+func selectRandomPort(rng *rand.Rand, reserved map[int]struct{}) (int, error) {
+	candidates := make([]int, 0, randomPortMax-randomPortMin+1)
+	for port := randomPortMin; port <= randomPortMax; port++ {
+		candidates = append(candidates, port)
+	}
+	rng.Shuffle(len(candidates), func(i, j int) {
+		candidates[i], candidates[j] = candidates[j], candidates[i]
+	})
+	for _, port := range candidates {
+		if reservePort(port, reserved) {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available port found in range %d-%d", randomPortMin, randomPortMax)
+}
+
+func reservePort(port int, reserved map[int]struct{}) bool {
+	if _, exists := reserved[port]; exists {
+		return false
+	}
+	if !IsPortAvailable(port) {
+		return false
+	}
+	reserved[port] = struct{}{}
+	return true
 }

--- a/tools/dev/proc/ports_test.go
+++ b/tools/dev/proc/ports_test.go
@@ -1,0 +1,113 @@
+package proc
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"testing"
+)
+
+func TestSelectPreferredPortUsesPreferredWhenAvailable(t *testing.T) {
+	reserved := map[int]struct{}{}
+	preferred := findFreePortInRange(t, randomPortMin)
+
+	port, err := selectPreferredPort(preferred, reserved)
+	if err != nil {
+		t.Fatalf("selectPreferredPort returned error: %v", err)
+	}
+	if port != preferred {
+		t.Fatalf("expected preferred port %d, got %d", preferred, port)
+	}
+	if _, ok := reserved[port]; !ok {
+		t.Fatalf("expected port %d to be reserved", port)
+	}
+}
+
+func TestSelectPreferredPortFallsBackWhenPreferredUnavailable(t *testing.T) {
+	preferred := findFreePortInRange(t, randomPortMin)
+	listener := listenOnPort(t, preferred)
+	defer listener.Close()
+
+	reserved := map[int]struct{}{}
+	port, err := selectPreferredPort(preferred, reserved)
+	if err != nil {
+		t.Fatalf("selectPreferredPort returned error: %v", err)
+	}
+	if port == preferred {
+		t.Fatalf("expected fallback port when preferred port %d is unavailable", preferred)
+	}
+	if port < randomPortMin || port > randomPortMax {
+		t.Fatalf("expected fallback port in range %d-%d, got %d", randomPortMin, randomPortMax, port)
+	}
+	if _, ok := reserved[port]; !ok {
+		t.Fatalf("expected fallback port %d to be reserved", port)
+	}
+}
+
+func TestSelectRandomPortUsesRangeAndUniqueness(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	reserved := map[int]struct{}{}
+
+	first, err := selectRandomPort(rng, reserved)
+	if err != nil {
+		t.Fatalf("selectRandomPort returned error: %v", err)
+	}
+	second, err := selectRandomPort(rng, reserved)
+	if err != nil {
+		t.Fatalf("selectRandomPort returned error: %v", err)
+	}
+	third, err := selectRandomPort(rng, reserved)
+	if err != nil {
+		t.Fatalf("selectRandomPort returned error: %v", err)
+	}
+
+	assertPortInRange(t, first)
+	assertPortInRange(t, second)
+	assertPortInRange(t, third)
+
+	if first == second || first == third || second == third {
+		t.Fatalf("expected unique ports, got %d, %d, %d", first, second, third)
+	}
+}
+
+func TestResolveWatchPortsRandomUsesUniquePortsInRange(t *testing.T) {
+	ports, err := ResolveWatchPorts(true)
+	if err != nil {
+		t.Fatalf("ResolveWatchPorts returned error: %v", err)
+	}
+
+	assertPortInRange(t, ports.CDP)
+	assertPortInRange(t, ports.Server)
+	assertPortInRange(t, ports.Extension)
+
+	if ports.CDP == ports.Server || ports.CDP == ports.Extension || ports.Server == ports.Extension {
+		t.Fatalf("expected unique ports, got %+v", ports)
+	}
+}
+
+func assertPortInRange(t *testing.T, port int) {
+	t.Helper()
+	if port < randomPortMin || port > randomPortMax {
+		t.Fatalf("expected port in range %d-%d, got %d", randomPortMin, randomPortMax, port)
+	}
+}
+
+func findFreePortInRange(t *testing.T, start int) int {
+	t.Helper()
+	for port := start; port <= randomPortMax; port++ {
+		if IsPortAvailable(port) {
+			return port
+		}
+	}
+	t.Fatalf("failed to find free port in range %d-%d", start, randomPortMax)
+	return 0
+}
+
+func listenOnPort(t *testing.T, port int) net.Listener {
+	t.Helper()
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("failed to listen on port %d: %v", port, err)
+	}
+	return listener
+}

--- a/tools/dev/proc/ports_test.go
+++ b/tools/dev/proc/ports_test.go
@@ -11,10 +11,11 @@ func TestSelectPreferredPortUsesPreferredWhenAvailable(t *testing.T) {
 	reserved := map[int]struct{}{}
 	preferred := findFreePortInRange(t, randomPortMin)
 
-	port, err := selectPreferredPort(preferred, reserved)
+	port, listener, err := selectPreferredPort(preferred, reserved)
 	if err != nil {
 		t.Fatalf("selectPreferredPort returned error: %v", err)
 	}
+	defer listener.Close()
 	if port != preferred {
 		t.Fatalf("expected preferred port %d, got %d", preferred, port)
 	}
@@ -29,10 +30,11 @@ func TestSelectPreferredPortFallsBackWhenPreferredUnavailable(t *testing.T) {
 	defer listener.Close()
 
 	reserved := map[int]struct{}{}
-	port, err := selectPreferredPort(preferred, reserved)
+	port, reservedListener, err := selectPreferredPort(preferred, reserved)
 	if err != nil {
 		t.Fatalf("selectPreferredPort returned error: %v", err)
 	}
+	defer reservedListener.Close()
 	if port == preferred {
 		t.Fatalf("expected fallback port when preferred port %d is unavailable", preferred)
 	}
@@ -48,18 +50,21 @@ func TestSelectRandomPortUsesRangeAndUniqueness(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 	reserved := map[int]struct{}{}
 
-	first, err := selectRandomPort(rng, reserved)
+	first, firstListener, err := selectRandomPort(rng, reserved)
 	if err != nil {
 		t.Fatalf("selectRandomPort returned error: %v", err)
 	}
-	second, err := selectRandomPort(rng, reserved)
+	defer firstListener.Close()
+	second, secondListener, err := selectRandomPort(rng, reserved)
 	if err != nil {
 		t.Fatalf("selectRandomPort returned error: %v", err)
 	}
-	third, err := selectRandomPort(rng, reserved)
+	defer secondListener.Close()
+	third, thirdListener, err := selectRandomPort(rng, reserved)
 	if err != nil {
 		t.Fatalf("selectRandomPort returned error: %v", err)
 	}
+	defer thirdListener.Close()
 
 	assertPortInRange(t, first)
 	assertPortInRange(t, second)
@@ -71,10 +76,11 @@ func TestSelectRandomPortUsesRangeAndUniqueness(t *testing.T) {
 }
 
 func TestResolveWatchPortsRandomUsesUniquePortsInRange(t *testing.T) {
-	ports, err := ResolveWatchPorts(true)
+	ports, reservations, err := ResolveWatchPorts(true)
 	if err != nil {
 		t.Fatalf("ResolveWatchPorts returned error: %v", err)
 	}
+	defer reservations.ReleaseAll()
 
 	assertPortInRange(t, ports.CDP)
 	assertPortInRange(t, ports.Server)
@@ -82,6 +88,41 @@ func TestResolveWatchPortsRandomUsesUniquePortsInRange(t *testing.T) {
 
 	if ports.CDP == ports.Server || ports.CDP == ports.Extension || ports.Server == ports.Extension {
 		t.Fatalf("expected unique ports, got %+v", ports)
+	}
+	if IsPortAvailable(ports.CDP) || IsPortAvailable(ports.Server) || IsPortAvailable(ports.Extension) {
+		t.Fatalf("expected reserved ports to stay bound until release, got %+v", ports)
+	}
+}
+
+func TestResolveWatchPortsDefaultFallsBackWhenPreferredUnavailable(t *testing.T) {
+	defaults := findUniqueFreePorts(t, 3)
+	originalDefaults := defaultLocalPorts
+	defaultLocalPorts = defaults
+	defer func() {
+		defaultLocalPorts = originalDefaults
+	}()
+
+	cdpListener := listenOnPort(t, defaults.CDP)
+	defer cdpListener.Close()
+	serverListener := listenOnPort(t, defaults.Server)
+	defer serverListener.Close()
+	extensionListener := listenOnPort(t, defaults.Extension)
+	defer extensionListener.Close()
+
+	ports, reservations, err := ResolveWatchPorts(false)
+	if err != nil {
+		t.Fatalf("ResolveWatchPorts returned error: %v", err)
+	}
+	defer reservations.ReleaseAll()
+
+	if ports == defaults {
+		t.Fatalf("expected fallback ports when defaults are occupied, got %+v", ports)
+	}
+	if ports.CDP == ports.Server || ports.CDP == ports.Extension || ports.Server == ports.Extension {
+		t.Fatalf("expected unique fallback ports, got %+v", ports)
+	}
+	if IsPortAvailable(ports.CDP) || IsPortAvailable(ports.Server) || IsPortAvailable(ports.Extension) {
+		t.Fatalf("expected fallback ports to stay bound until release, got %+v", ports)
 	}
 }
 
@@ -101,6 +142,24 @@ func findFreePortInRange(t *testing.T, start int) int {
 	}
 	t.Fatalf("failed to find free port in range %d-%d", start, randomPortMax)
 	return 0
+}
+
+func findUniqueFreePorts(t *testing.T, count int) Ports {
+	t.Helper()
+	found := Ports{}
+	values := make([]int, 0, count)
+	for port := randomPortMin; port <= randomPortMax && len(values) < count; port++ {
+		if IsPortAvailable(port) {
+			values = append(values, port)
+		}
+	}
+	if len(values) != count {
+		t.Fatalf("failed to find %d unique free ports", count)
+	}
+	found.CDP = values[0]
+	found.Server = values[1]
+	found.Extension = values[2]
+	return found
 }
 
 func listenOnPort(t *testing.T, port int) net.Listener {


### PR DESCRIPTION
## Summary
- Prevent `tools/dev/run.sh watch` from failing when preferred ports are occupied by resolving fallback ports before startup.
- Make `watch --new` always choose distinct random ports in `9000-9999`.
- Validate selected ports up front and keep the existing env and browser argument wiring intact.

## Design
Added a centralized port allocator in `tools/dev/proc` that resolves the full `{cdp, server, extension}` triplet together. Default watch keeps `9005/9105/9305` when those ports are free and falls back inside `9000-9999` when conflicts remain. `watch --new` now always picks random ports from the same range and reserves prior selections so roles cannot collide.

## Test Plan
- `go test ./...` (in `tools/dev`)
- `make -sC tools/dev`
- `./tools/dev/run.sh watch --help`
