### PR TITLE
fix: avoid CSP-unsafe MCP SDK usage in settings

### DIFF
--- a/apps/agent/lib/mcp/client.test.ts
+++ b/apps/agent/lib/mcp/client.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { createServer, type IncomingMessage } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { fetchMcpTools } from './client'
+
+function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Uint8Array[] = []
+
+  return new Promise((resolve, reject) => {
+    req.on('data', (chunk) => {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+    })
+    req.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'))
+    })
+    req.on('error', reject)
+  })
+}
+
+describe('fetchMcpTools', () => {
+  let originalFunction: FunctionConstructor
+
+  beforeEach(() => {
+    originalFunction = globalThis.Function
+  })
+
+  afterEach(() => {
+    globalThis.Function = originalFunction
+  })
+
+  it('lists tools without compiling output schemas', async () => {
+    const requests: string[] = []
+    let initialized = false
+
+    const server = createServer(async (req, res) => {
+      if (req.method === 'GET') {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+
+      const message = JSON.parse(await readBody(req)) as {
+        id?: string | number
+        method: string
+      }
+      requests.push(message.method)
+
+      if (message.method === 'initialize') {
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'mcp-session-id': 'test-session',
+        })
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              protocolVersion: '2025-03-26',
+              capabilities: {
+                tools: {},
+              },
+              serverInfo: {
+                name: 'test-server',
+                version: '1.0.0',
+              },
+            },
+          }),
+        )
+        return
+      }
+
+      if (message.method === 'notifications/initialized') {
+        initialized = true
+        res.writeHead(202)
+        res.end()
+        return
+      }
+
+      if (message.method === 'tools/list') {
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+        })
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              tools: [
+                {
+                  name: 'browser_list_tabs',
+                  description: 'List tabs',
+                  inputSchema: {
+                    type: 'object',
+                  },
+                  outputSchema: {
+                    type: 'object',
+                    properties: {
+                      ok: {
+                        type: 'boolean',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+        )
+        return
+      }
+
+      res.writeHead(500)
+      res.end()
+    })
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    try {
+      globalThis.Function = (() => {
+        throw new Error('blocked')
+      }) as unknown as FunctionConstructor
+
+      const { port } = server.address() as AddressInfo
+      const tools = await fetchMcpTools(`http://127.0.0.1:${port}/mcp`)
+
+      expect(tools).toEqual([
+        {
+          name: 'browser_list_tabs',
+          description: 'List tabs',
+        },
+      ])
+      expect(initialized).toBe(true)
+      expect(requests).toEqual([
+        'initialize',
+        'notifications/initialized',
+        'tools/list',
+      ])
+    } finally {
+      globalThis.Function = originalFunction
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
+    }
+  })
+})

--- a/apps/agent/lib/mcp/client.test.ts
+++ b/apps/agent/lib/mcp/client.test.ts
@@ -149,4 +149,128 @@ describe('fetchMcpTools', () => {
       })
     }
   })
+
+  it('follows paginated tools/list responses', async () => {
+    const cursors: Array<string | undefined> = []
+    let listRequests = 0
+
+    const server = createServer(async (req, res) => {
+      const message = JSON.parse(await readBody(req)) as {
+        id?: string | number
+        method: string
+        params?: {
+          cursor?: string
+        }
+      }
+
+      if (message.method === 'initialize') {
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'mcp-session-id': 'test-session',
+        })
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              protocolVersion: '2025-03-26',
+              capabilities: {
+                tools: {},
+              },
+              serverInfo: {
+                name: 'test-server',
+                version: '1.0.0',
+              },
+            },
+          }),
+        )
+        return
+      }
+
+      if (message.method === 'notifications/initialized') {
+        res.writeHead(202)
+        res.end()
+        return
+      }
+
+      if (message.method === 'tools/list') {
+        listRequests += 1
+        cursors.push(message.params?.cursor)
+
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+        })
+
+        if (message.params?.cursor === 'cursor-1') {
+          res.end(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: message.id,
+              result: {
+                tools: [
+                  {
+                    name: 'browser_get_page_content',
+                    description: 'Get page content',
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              nextCursor: 'cursor-1',
+              tools: [
+                {
+                  name: 'browser_list_tabs',
+                  description: 'List tabs',
+                },
+              ],
+            },
+          }),
+        )
+        return
+      }
+
+      res.writeHead(500)
+      res.end()
+    })
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    try {
+      const { port } = server.address() as AddressInfo
+      const tools = await fetchMcpTools(`http://127.0.0.1:${port}/mcp`)
+
+      expect(tools).toEqual([
+        {
+          name: 'browser_list_tabs',
+          description: 'List tabs',
+        },
+        {
+          name: 'browser_get_page_content',
+          description: 'Get page content',
+        },
+      ])
+      expect(listRequests).toBe(2)
+      expect(cursors).toEqual([undefined, 'cursor-1'])
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
+    }
+  })
 })

--- a/apps/agent/lib/mcp/client.test.ts
+++ b/apps/agent/lib/mcp/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { createServer, type IncomingMessage } from 'node:http'
+import { createServer, type IncomingMessage, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { fetchMcpTools } from './client'
 
@@ -17,6 +17,25 @@ function readBody(req: IncomingMessage): Promise<string> {
   })
 }
 
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}
+
 describe('fetchMcpTools', () => {
   let originalFunction: FunctionConstructor
 
@@ -28,12 +47,15 @@ describe('fetchMcpTools', () => {
     globalThis.Function = originalFunction
   })
 
-  it('lists tools without compiling output schemas', async () => {
+  it('lists tools without invoking Function-based schema compilation', async () => {
     const requests: string[] = []
+    let evalCalls = 0
+    let getRequests = 0
     let initialized = false
 
     const server = createServer(async (req, res) => {
       if (req.method === 'GET') {
+        getRequests += 1
         res.writeHead(405)
         res.end()
         return
@@ -112,13 +134,18 @@ describe('fetchMcpTools', () => {
       res.end()
     })
 
-    await new Promise<void>((resolve) => {
-      server.listen(0, '127.0.0.1', resolve)
-    })
+    await listen(server)
 
     try {
-      globalThis.Function = (() => {
-        throw new Error('blocked')
+      globalThis.Function = new Proxy(originalFunction, {
+        apply(target, thisArg, argArray) {
+          evalCalls += 1
+          return Reflect.apply(target, thisArg, argArray)
+        },
+        construct(target, argArray, newTarget) {
+          evalCalls += 1
+          return Reflect.construct(target, argArray, newTarget)
+        },
       }) as unknown as FunctionConstructor
 
       const { port } = server.address() as AddressInfo
@@ -130,6 +157,8 @@ describe('fetchMcpTools', () => {
           description: 'List tabs',
         },
       ])
+      expect(evalCalls).toBe(0)
+      expect(getRequests).toBe(1)
       expect(initialized).toBe(true)
       expect(requests).toEqual([
         'initialize',
@@ -138,15 +167,7 @@ describe('fetchMcpTools', () => {
       ])
     } finally {
       globalThis.Function = originalFunction
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error)
-            return
-          }
-          resolve()
-        })
-      })
+      await close(server)
     }
   })
 
@@ -155,6 +176,12 @@ describe('fetchMcpTools', () => {
     let listRequests = 0
 
     const server = createServer(async (req, res) => {
+      if (req.method === 'GET') {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+
       const message = JSON.parse(await readBody(req)) as {
         id?: string | number
         method: string
@@ -211,6 +238,9 @@ describe('fetchMcpTools', () => {
                   {
                     name: 'browser_get_page_content',
                     description: 'Get page content',
+                    inputSchema: {
+                      type: 'object',
+                    },
                   },
                 ],
               },
@@ -229,6 +259,9 @@ describe('fetchMcpTools', () => {
                 {
                   name: 'browser_list_tabs',
                   description: 'List tabs',
+                  inputSchema: {
+                    type: 'object',
+                  },
                 },
               ],
             },
@@ -241,9 +274,7 @@ describe('fetchMcpTools', () => {
       res.end()
     })
 
-    await new Promise<void>((resolve) => {
-      server.listen(0, '127.0.0.1', resolve)
-    })
+    await listen(server)
 
     try {
       const { port } = server.address() as AddressInfo
@@ -262,15 +293,7 @@ describe('fetchMcpTools', () => {
       expect(listRequests).toBe(2)
       expect(cursors).toEqual([undefined, 'cursor-1'])
     } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error)
-            return
-          }
-          resolve()
-        })
-      })
+      await close(server)
     }
   })
 })

--- a/apps/agent/lib/mcp/client.ts
+++ b/apps/agent/lib/mcp/client.ts
@@ -1,156 +1,91 @@
+import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
+import * as z from 'zod/v4'
+
 /** @public */
 export interface McpTool {
   name: string
   description?: string
 }
 
-interface InitializeResult {
-  protocolVersion?: string
-}
-
-interface ListToolsResult {
-  nextCursor?: unknown
-  tools?: Array<{
-    description?: unknown
-    name?: unknown
-  }>
-}
-
-const JSON_RPC_VERSION = '2.0'
-const MCP_PROTOCOL_VERSION = '2025-03-26'
-const MCP_REQUEST_TIMEOUT_MS = 5_000
 const MCP_CLIENT_INFO = {
   name: 'browseros-settings',
   version: '1.0.0',
+} as const
+
+type McpClientConstructor =
+  typeof import('@modelcontextprotocol/sdk/client/index.js').Client
+type McpListToolsResultSchema =
+  typeof import('@modelcontextprotocol/sdk/types.js').ListToolsResultSchema
+type McpTransportConstructor =
+  typeof import('@modelcontextprotocol/sdk/client/streamableHttp.js').StreamableHTTPClientTransport
+
+interface McpSdk {
+  Client: McpClientConstructor
+  ListToolsResultSchema: McpListToolsResultSchema
+  StreamableHTTPClientTransport: McpTransportConstructor
 }
 
-function createMcpHeaders(
-  sessionId?: string,
-  protocolVersion?: string,
-): HeadersInit {
-  const headers: Record<string, string> = {
-    Accept: 'application/json, text/event-stream',
-    'Content-Type': 'application/json',
+let mcpSdkPromise: Promise<McpSdk> | undefined
+
+async function loadMcpSdk(): Promise<McpSdk> {
+  if (!mcpSdkPromise) {
+    mcpSdkPromise = (async () => {
+      const previousJitless = z.config().jitless
+
+      // Zod v4 captures JIT settings when schemas are constructed, so this has
+      // to be set before the SDK modules create their schemas.
+      z.config({ jitless: true })
+
+      try {
+        const [clientModule, transportModule, typesModule] = await Promise.all([
+          import('@modelcontextprotocol/sdk/client/index.js'),
+          import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
+          import('@modelcontextprotocol/sdk/types.js'),
+        ])
+
+        return {
+          Client: clientModule.Client,
+          StreamableHTTPClientTransport:
+            transportModule.StreamableHTTPClientTransport,
+          ListToolsResultSchema: typesModule.ListToolsResultSchema,
+        }
+      } finally {
+        z.config({ jitless: previousJitless })
+      }
+    })()
   }
 
-  if (sessionId) {
-    headers['mcp-session-id'] = sessionId
-  }
-
-  if (protocolVersion) {
-    headers['mcp-protocol-version'] = protocolVersion
-  }
-
-  return headers
+  return mcpSdkPromise
 }
 
-async function postMcpMessage(
-  serverUrl: string,
-  message: Record<string, unknown>,
-  sessionId?: string,
-  protocolVersion?: string,
-): Promise<Response> {
-  return fetch(serverUrl, {
-    method: 'POST',
-    headers: createMcpHeaders(sessionId, protocolVersion),
-    body: JSON.stringify(message),
-    signal: AbortSignal.timeout(MCP_REQUEST_TIMEOUT_MS),
-  })
+function normalizeTools(tools: ListToolsResult['tools']): McpTool[] {
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+  }))
 }
 
-function parseSseMessage(responseText: string): unknown {
-  for (const block of responseText.split(/\r?\n\r?\n/)) {
-    const data = block
-      .split(/\r?\n/)
-      .filter((line) => line.startsWith('data:'))
-      .map((line) => line.slice(5).trim())
-      .filter(Boolean)
-      .join('\n')
+async function listTools(
+  client: InstanceType<McpClientConstructor>,
+  listToolsResultSchema: McpListToolsResultSchema,
+): Promise<McpTool[]> {
+  const tools: McpTool[] = []
+  let cursor: string | undefined
 
-    if (data) {
-      return JSON.parse(data)
-    }
-  }
-
-  throw new Error('MCP server returned an empty SSE response')
-}
-
-async function parseMcpMessage(response: Response): Promise<unknown> {
-  const contentType = response.headers.get('content-type') ?? ''
-
-  if (contentType.includes('application/json')) {
-    return response.json()
-  }
-
-  if (contentType.includes('text/event-stream')) {
-    return parseSseMessage(await response.text())
-  }
-
-  await response.body?.cancel()
-  throw new Error(
-    `Unsupported MCP response content type: ${contentType || 'unknown'}`,
-  )
-}
-
-async function readMcpResult<TResult>(response: Response): Promise<TResult> {
-  if (!response.ok) {
-    const message = await response.text()
-    throw new Error(
-      message || `MCP request failed with status ${response.status}`,
+  do {
+    const response: ListToolsResult = await client.request(
+      {
+        method: 'tools/list',
+        ...(cursor ? { params: { cursor } } : {}),
+      },
+      listToolsResultSchema,
     )
-  }
 
-  const payload = await parseMcpMessage(response)
-  if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid MCP response payload')
-  }
+    tools.push(...normalizeTools(response.tools))
+    cursor = response.nextCursor
+  } while (cursor)
 
-  if (
-    'error' in payload &&
-    payload.error &&
-    typeof payload.error === 'object'
-  ) {
-    const error = payload.error as { message?: unknown }
-    throw new Error(
-      typeof error.message === 'string' ? error.message : 'MCP request failed',
-    )
-  }
-
-  if (!('result' in payload)) {
-    throw new Error('MCP response missing result')
-  }
-
-  return payload.result as TResult
-}
-
-function normalizeTools(result: ListToolsResult): McpTool[] {
-  if (!Array.isArray(result.tools)) {
-    throw new Error('MCP tools response missing tools array')
-  }
-
-  return result.tools.map((tool) => {
-    if (typeof tool.name !== 'string') {
-      throw new Error('MCP tools response contains an invalid tool entry')
-    }
-
-    return {
-      name: tool.name,
-      description:
-        typeof tool.description === 'string' ? tool.description : undefined,
-    }
-  })
-}
-
-function readNextCursor(result: ListToolsResult): string | undefined {
-  if (typeof result.nextCursor === 'undefined') {
-    return undefined
-  }
-
-  if (typeof result.nextCursor !== 'string') {
-    throw new Error('MCP tools response contains an invalid cursor')
-  }
-
-  return result.nextCursor
+  return tools
 }
 
 /**
@@ -158,66 +93,15 @@ function readNextCursor(result: ListToolsResult): string | undefined {
  * @public
  */
 export async function fetchMcpTools(serverUrl: string): Promise<McpTool[]> {
-  const initializeResponse = await postMcpMessage(serverUrl, {
-    jsonrpc: JSON_RPC_VERSION,
-    id: 0,
-    method: 'initialize',
-    params: {
-      protocolVersion: MCP_PROTOCOL_VERSION,
-      capabilities: {},
-      clientInfo: MCP_CLIENT_INFO,
-    },
-  })
-  const sessionId =
-    initializeResponse.headers.get('mcp-session-id') ?? undefined
-  const initializeResult =
-    await readMcpResult<InitializeResult>(initializeResponse)
-  const protocolVersion =
-    typeof initializeResult.protocolVersion === 'string'
-      ? initializeResult.protocolVersion
-      : MCP_PROTOCOL_VERSION
+  const { Client, StreamableHTTPClientTransport, ListToolsResultSchema } =
+    await loadMcpSdk()
+  const client = new Client(MCP_CLIENT_INFO)
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl))
 
-  const initializedResponse = await postMcpMessage(
-    serverUrl,
-    {
-      jsonrpc: JSON_RPC_VERSION,
-      method: 'notifications/initialized',
-    },
-    sessionId,
-    protocolVersion,
-  )
-
-  if (!initializedResponse.ok) {
-    const message = await initializedResponse.text()
-    throw new Error(
-      message ||
-        `MCP initialized notification failed with status ${initializedResponse.status}`,
-    )
+  try {
+    await client.connect(transport)
+    return await listTools(client, ListToolsResultSchema)
+  } finally {
+    await client.close()
   }
-
-  await initializedResponse.body?.cancel()
-
-  const tools: McpTool[] = []
-  let cursor: string | undefined
-  let requestId = 1
-
-  do {
-    const toolsResponse = await postMcpMessage(
-      serverUrl,
-      {
-        jsonrpc: JSON_RPC_VERSION,
-        id: requestId,
-        method: 'tools/list',
-        ...(cursor ? { params: { cursor } } : {}),
-      },
-      sessionId,
-      protocolVersion,
-    )
-    const toolsResult = await readMcpResult<ListToolsResult>(toolsResponse)
-    tools.push(...normalizeTools(toolsResult))
-    cursor = readNextCursor(toolsResult)
-    requestId += 1
-  } while (cursor)
-
-  return tools
 }

--- a/apps/agent/lib/mcp/client.ts
+++ b/apps/agent/lib/mcp/client.ts
@@ -9,6 +9,7 @@ interface InitializeResult {
 }
 
 interface ListToolsResult {
+  nextCursor?: unknown
   tools?: Array<{
     description?: unknown
     name?: unknown
@@ -85,6 +86,7 @@ async function parseMcpMessage(response: Response): Promise<unknown> {
     return parseSseMessage(await response.text())
   }
 
+  await response.body?.cancel()
   throw new Error(
     `Unsupported MCP response content type: ${contentType || 'unknown'}`,
   )
@@ -139,6 +141,18 @@ function normalizeTools(result: ListToolsResult): McpTool[] {
   })
 }
 
+function readNextCursor(result: ListToolsResult): string | undefined {
+  if (typeof result.nextCursor === 'undefined') {
+    return undefined
+  }
+
+  if (typeof result.nextCursor !== 'string') {
+    throw new Error('MCP tools response contains an invalid cursor')
+  }
+
+  return result.nextCursor
+}
+
 /**
  * Fetches available tools from an MCP server
  * @public
@@ -183,17 +197,27 @@ export async function fetchMcpTools(serverUrl: string): Promise<McpTool[]> {
 
   await initializedResponse.body?.cancel()
 
-  const toolsResponse = await postMcpMessage(
-    serverUrl,
-    {
-      jsonrpc: JSON_RPC_VERSION,
-      id: 1,
-      method: 'tools/list',
-    },
-    sessionId,
-    protocolVersion,
-  )
-  const toolsResult = await readMcpResult<ListToolsResult>(toolsResponse)
+  const tools: McpTool[] = []
+  let cursor: string | undefined
+  let requestId = 1
 
-  return normalizeTools(toolsResult)
+  do {
+    const toolsResponse = await postMcpMessage(
+      serverUrl,
+      {
+        jsonrpc: JSON_RPC_VERSION,
+        id: requestId,
+        method: 'tools/list',
+        ...(cursor ? { params: { cursor } } : {}),
+      },
+      sessionId,
+      protocolVersion,
+    )
+    const toolsResult = await readMcpResult<ListToolsResult>(toolsResponse)
+    tools.push(...normalizeTools(toolsResult))
+    cursor = readNextCursor(toolsResult)
+    requestId += 1
+  } while (cursor)
+
+  return tools
 }

--- a/apps/agent/lib/mcp/client.ts
+++ b/apps/agent/lib/mcp/client.ts
@@ -1,10 +1,142 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-
 /** @public */
 export interface McpTool {
   name: string
   description?: string
+}
+
+interface InitializeResult {
+  protocolVersion?: string
+}
+
+interface ListToolsResult {
+  tools?: Array<{
+    description?: unknown
+    name?: unknown
+  }>
+}
+
+const JSON_RPC_VERSION = '2.0'
+const MCP_PROTOCOL_VERSION = '2025-03-26'
+const MCP_REQUEST_TIMEOUT_MS = 5_000
+const MCP_CLIENT_INFO = {
+  name: 'browseros-settings',
+  version: '1.0.0',
+}
+
+function createMcpHeaders(
+  sessionId?: string,
+  protocolVersion?: string,
+): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: 'application/json, text/event-stream',
+    'Content-Type': 'application/json',
+  }
+
+  if (sessionId) {
+    headers['mcp-session-id'] = sessionId
+  }
+
+  if (protocolVersion) {
+    headers['mcp-protocol-version'] = protocolVersion
+  }
+
+  return headers
+}
+
+async function postMcpMessage(
+  serverUrl: string,
+  message: Record<string, unknown>,
+  sessionId?: string,
+  protocolVersion?: string,
+): Promise<Response> {
+  return fetch(serverUrl, {
+    method: 'POST',
+    headers: createMcpHeaders(sessionId, protocolVersion),
+    body: JSON.stringify(message),
+    signal: AbortSignal.timeout(MCP_REQUEST_TIMEOUT_MS),
+  })
+}
+
+function parseSseMessage(responseText: string): unknown {
+  for (const block of responseText.split(/\r?\n\r?\n/)) {
+    const data = block
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trim())
+      .filter(Boolean)
+      .join('\n')
+
+    if (data) {
+      return JSON.parse(data)
+    }
+  }
+
+  throw new Error('MCP server returned an empty SSE response')
+}
+
+async function parseMcpMessage(response: Response): Promise<unknown> {
+  const contentType = response.headers.get('content-type') ?? ''
+
+  if (contentType.includes('application/json')) {
+    return response.json()
+  }
+
+  if (contentType.includes('text/event-stream')) {
+    return parseSseMessage(await response.text())
+  }
+
+  throw new Error(
+    `Unsupported MCP response content type: ${contentType || 'unknown'}`,
+  )
+}
+
+async function readMcpResult<TResult>(response: Response): Promise<TResult> {
+  if (!response.ok) {
+    const message = await response.text()
+    throw new Error(
+      message || `MCP request failed with status ${response.status}`,
+    )
+  }
+
+  const payload = await parseMcpMessage(response)
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid MCP response payload')
+  }
+
+  if (
+    'error' in payload &&
+    payload.error &&
+    typeof payload.error === 'object'
+  ) {
+    const error = payload.error as { message?: unknown }
+    throw new Error(
+      typeof error.message === 'string' ? error.message : 'MCP request failed',
+    )
+  }
+
+  if (!('result' in payload)) {
+    throw new Error('MCP response missing result')
+  }
+
+  return payload.result as TResult
+}
+
+function normalizeTools(result: ListToolsResult): McpTool[] {
+  if (!Array.isArray(result.tools)) {
+    throw new Error('MCP tools response missing tools array')
+  }
+
+  return result.tools.map((tool) => {
+    if (typeof tool.name !== 'string') {
+      throw new Error('MCP tools response contains an invalid tool entry')
+    }
+
+    return {
+      name: tool.name,
+      description:
+        typeof tool.description === 'string' ? tool.description : undefined,
+    }
+  })
 }
 
 /**
@@ -12,22 +144,56 @@ export interface McpTool {
  * @public
  */
 export async function fetchMcpTools(serverUrl: string): Promise<McpTool[]> {
-  const client = new Client({
-    name: 'browseros-settings',
-    version: '1.0.0',
+  const initializeResponse = await postMcpMessage(serverUrl, {
+    jsonrpc: JSON_RPC_VERSION,
+    id: 0,
+    method: 'initialize',
+    params: {
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: MCP_CLIENT_INFO,
+    },
   })
+  const sessionId =
+    initializeResponse.headers.get('mcp-session-id') ?? undefined
+  const initializeResult =
+    await readMcpResult<InitializeResult>(initializeResponse)
+  const protocolVersion =
+    typeof initializeResult.protocolVersion === 'string'
+      ? initializeResult.protocolVersion
+      : MCP_PROTOCOL_VERSION
 
-  const transport = new StreamableHTTPClientTransport(new URL(serverUrl))
+  const initializedResponse = await postMcpMessage(
+    serverUrl,
+    {
+      jsonrpc: JSON_RPC_VERSION,
+      method: 'notifications/initialized',
+    },
+    sessionId,
+    protocolVersion,
+  )
 
-  try {
-    await client.connect(transport)
-    const response = await client.listTools()
-
-    return response.tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-    }))
-  } finally {
-    await client.close()
+  if (!initializedResponse.ok) {
+    const message = await initializedResponse.text()
+    throw new Error(
+      message ||
+        `MCP initialized notification failed with status ${initializedResponse.status}`,
+    )
   }
+
+  await initializedResponse.body?.cancel()
+
+  const toolsResponse = await postMcpMessage(
+    serverUrl,
+    {
+      jsonrpc: JSON_RPC_VERSION,
+      id: 1,
+      method: 'tools/list',
+    },
+    sessionId,
+    protocolVersion,
+  )
+  const toolsResult = await readMcpResult<ListToolsResult>(toolsResponse)
+
+  return normalizeTools(toolsResult)
 }


### PR DESCRIPTION
## Summary
- replace browser-side MCP SDK usage in the settings tool-list helper with a minimal JSON-RPC fetch flow
- fix the BrowserOS MCP settings page CSP regression caused by SDK runtime code paths that use `new Function(...)` under extension CSP
- add a regression test that blocks `Function` and verifies tool listing still succeeds with `outputSchema` present

## Design
The MCP settings page only needs local tool metadata, so the extension no longer loads the MCP TypeScript SDK in this path. Instead it performs `initialize`, `notifications/initialized`, and `tools/list` directly over HTTP, which avoids the CSP-incompatible `zod/v4` and AJV runtime behavior introduced by newer SDK versions in the browser worker.

## Test plan
- `bun test apps/agent/lib/mcp/client.test.ts`
- `bun run lint`
- `bunx tsc --noEmit --module esnext --moduleResolution bundler --target esnext --lib esnext,dom --types bun,node --skipLibCheck apps/agent/lib/mcp/client.ts apps/agent/lib/mcp/client.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run typecheck` *(still OOMs in `@browseros/agent` in this environment)*