### PR TITLE
fix: resolve active page IDs from MCP response

### DIFF
--- a/apps/cli/integration_test.go
+++ b/apps/cli/integration_test.go
@@ -215,11 +215,30 @@ func TestPageLifecycle(t *testing.T) {
 
 func TestActivePage(t *testing.T) {
 	data := runJSON(t, "active")
-	// Should return structured content with pageId
-	raw, _ := json.Marshal(data)
-	rawStr := string(raw)
-	if !strings.Contains(rawStr, "pageId") && !strings.Contains(rawStr, "page") {
-		t.Errorf("expected active page response to contain pageId, got: %s", rawStr)
+	page, ok := data["page"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected active page response to contain page object, got: %v", data)
+	}
+	if _, ok := page["pageId"].(float64); !ok {
+		t.Fatalf("expected active page response to contain numeric pageId, got: %v", page)
+	}
+}
+
+func TestSnapUsesActivePage(t *testing.T) {
+	activeData := runJSON(t, "active")
+	page, ok := activeData["page"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected active page response to contain page object, got: %v", activeData)
+	}
+	if _, ok := page["pageId"].(float64); !ok {
+		t.Fatalf("expected active page response to contain numeric pageId, got: %v", page)
+	}
+	r := run(t, "--json", "snap")
+	if r.ExitCode != 0 {
+		t.Fatalf("snap exited %d: %s%s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+	if len(strings.TrimSpace(r.Stdout)) < 10 {
+		t.Fatalf("snapshot output too short: %s", r.Stdout)
 	}
 }
 

--- a/apps/cli/integration_test.go
+++ b/apps/cli/integration_test.go
@@ -224,7 +224,7 @@ func TestActivePage(t *testing.T) {
 	}
 }
 
-func TestSnapUsesActivePage(t *testing.T) {
+func TestSnapWithoutExplicitPage(t *testing.T) {
 	activeData := runJSON(t, "active")
 	page, ok := activeData["page"].(map[string]any)
 	if !ok {

--- a/apps/cli/mcp/client.go
+++ b/apps/cli/mcp/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"time"
 
@@ -155,6 +156,9 @@ func intValue(v any) (int, bool) {
 	case int64:
 		return int(n), true
 	case float64:
+		if math.Trunc(n) != n {
+			return 0, false
+		}
 		return int(n), true
 	case json.Number:
 		i, err := n.Int64()

--- a/apps/cli/mcp/client.go
+++ b/apps/cli/mcp/client.go
@@ -121,15 +121,50 @@ func (c *Client) ResolvePageID(explicit *int) (int, error) {
 		return 0, fmt.Errorf("no active page: %w", err)
 	}
 
-	if sc := result.StructuredContent; sc != nil {
-		if v, ok := sc["pageId"]; ok {
-			if f, ok := v.(float64); ok {
-				return int(f), nil
-			}
-		}
+	if pageID, ok := extractPageID(result.StructuredContent); ok {
+		return pageID, nil
 	}
 
 	return 0, fmt.Errorf("could not determine active page ID from response")
+}
+
+func extractPageID(sc map[string]any) (int, bool) {
+	if sc == nil {
+		return 0, false
+	}
+	if pageID, ok := intValue(sc["pageId"]); ok {
+		return pageID, true
+	}
+	page, ok := sc["page"].(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	pageID, ok := intValue(page["pageId"])
+	if !ok {
+		return 0, false
+	}
+	return pageID, true
+}
+
+func intValue(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case json.Number:
+		i, err := n.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(i), true
+	default:
+		return 0, false
+	}
 }
 
 // Health checks the /health endpoint (REST, not MCP).

--- a/apps/cli/mcp/client_test.go
+++ b/apps/cli/mcp/client_test.go
@@ -1,6 +1,9 @@
 package mcp
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestExtractPageID(t *testing.T) {
 	tests := []struct {
@@ -43,6 +46,26 @@ func TestExtractPageID(t *testing.T) {
 				"page": map[string]any{
 					"tabId": float64(9),
 				},
+			},
+			ok: false,
+		},
+		{
+			name: "nil structured content",
+			data: nil,
+			ok:   false,
+		},
+		{
+			name: "json number page id",
+			data: map[string]any{
+				"pageId": json.Number("13"),
+			},
+			want: 13,
+			ok:   true,
+		},
+		{
+			name: "non whole float page id",
+			data: map[string]any{
+				"pageId": 3.5,
 			},
 			ok: false,
 		},

--- a/apps/cli/mcp/client_test.go
+++ b/apps/cli/mcp/client_test.go
@@ -1,0 +1,62 @@
+package mcp
+
+import "testing"
+
+func TestExtractPageID(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		want int
+		ok   bool
+	}{
+		{
+			name: "nested page object",
+			data: map[string]any{
+				"page": map[string]any{
+					"pageId": float64(7),
+				},
+			},
+			want: 7,
+			ok:   true,
+		},
+		{
+			name: "top level page id",
+			data: map[string]any{
+				"pageId": float64(3),
+			},
+			want: 3,
+			ok:   true,
+		},
+		{
+			name: "nested int page id",
+			data: map[string]any{
+				"page": map[string]any{
+					"pageId": 11,
+				},
+			},
+			want: 11,
+			ok:   true,
+		},
+		{
+			name: "missing page id",
+			data: map[string]any{
+				"page": map[string]any{
+					"tabId": float64(9),
+				},
+			},
+			ok: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := extractPageID(tt.data)
+			if ok != tt.ok {
+				t.Fatalf("extractPageID() ok = %v, want %v", ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("extractPageID() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- make browseros-cli page-targeting commands resolve the active page from the MCP get_active_page response
- accept both nested `page.pageId` and top-level `pageId` structured content for compatibility
- add unit and integration coverage for implicit active-page resolution

## Design
This keeps the fix in the Go CLI, where the contract mismatch exists today. The server continues returning its current nested structured content, and the CLI resolver adapts to that response shape instead of assuming a flattened payload.

## Test plan
- `go test ./...` in `apps/cli`
- `go vet ./...` in `apps/cli`
- `go test -tags integration -v ./...` in `apps/cli`
- `go build -o browseros-cli . && ./browseros-cli --server http://127.0.0.1:9105 active && ./browseros-cli --server http://127.0.0.1:9105 snap` in `apps/cli`