### PR TITLE
feat: integrate models.dev registry for model defaults

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -49,6 +49,7 @@
     "@ai-sdk/provider": "^3.0.8",
     "@browseros-ai/agent-sdk": "workspace:*",
     "@browseros/cdp-protocol": "workspace:*",
+    "@browseros/models-dev": "workspace:*",
     "@browseros/shared": "workspace:*",
     "@google/gemini-cli-core": "^0.16.0",
     "@google/genai": "1.30.0",

--- a/apps/server/src/api/routes/models.ts
+++ b/apps/server/src/api/routes/models.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+  getAllProviders,
+  getProviderModels,
+} from '@browseros/models-dev/registry'
+import { Hono } from 'hono'
+
+export function createModelsRoutes() {
+  return new Hono()
+    .get('/', (c) => {
+      // Return provider summary with model counts
+      const providers = getAllProviders()
+      const summary = Object.fromEntries(
+        Object.entries(providers).map(([id, p]) => [
+          id,
+          {
+            id: p.id,
+            name: p.name,
+            modelCount: Object.keys(p.models).length,
+          },
+        ]),
+      )
+      return c.json(summary)
+    })
+    .get('/:provider', (c) => {
+      const provider = c.req.param('provider')
+      const info = getProviderModels(provider)
+      if (!info) return c.json({ error: 'Provider not found' }, 404)
+      return c.json(info)
+    })
+}

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -21,6 +21,7 @@ import { createGraphRoutes } from './routes/graph'
 import { createHealthRoute } from './routes/health'
 import { createKlavisRoutes } from './routes/klavis'
 import { createMcpRoutes } from './routes/mcp'
+import { createModelsRoutes } from './routes/models'
 import { createProviderRoutes } from './routes/provider'
 import { createSdkRoutes } from './routes/sdk'
 import { createShutdownRoute } from './routes/shutdown'
@@ -108,6 +109,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     .route('/status', createStatusRoute({ controller }))
     .route('/soul', createSoulRoutes())
     .route('/test-provider', createProviderRoutes())
+    .route('/models', createModelsRoutes())
     .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))
     .route(
       '/mcp',

--- a/apps/server/src/api/services/chat-v2-service.ts
+++ b/apps/server/src/api/services/chat-v2-service.ts
@@ -6,6 +6,7 @@
 
 import { mkdir } from 'node:fs/promises'
 import path from 'node:path'
+import { getModelDefaults } from '@browseros/models-dev/registry'
 import { createAgentUIStreamResponse, type UIMessage } from 'ai'
 import { AiSdkAgent } from '../../agent/tool-loop/ai-sdk-agent'
 import { formatUserMessage } from '../../agent/tool-loop/format-message'
@@ -40,6 +41,9 @@ export class ChatV2Service {
 
     const sessionExecutionDir = await this.resolveSessionDir(request)
 
+    // Auto-populate model defaults from registry when not client-specified
+    const modelDefaults = getModelDefaults(llmConfig.provider, llmConfig.model)
+
     const agentConfig: ResolvedAgentConfig = {
       conversationId: request.conversationId,
       provider: llmConfig.provider,
@@ -52,10 +56,14 @@ export class ChatV2Service {
       accessKeyId: llmConfig.accessKeyId,
       secretAccessKey: llmConfig.secretAccessKey,
       sessionToken: llmConfig.sessionToken,
-      contextWindowSize: request.contextWindowSize,
+      contextWindowSize:
+        request.contextWindowSize ?? modelDefaults?.limit.context,
       userSystemPrompt: request.userSystemPrompt,
       sessionExecutionDir,
-      supportsImages: request.supportsImages,
+      supportsImages:
+        request.supportsImages ??
+        modelDefaults?.modalities.input.includes('image') ??
+        true,
       chatMode: request.mode === 'chat',
       isScheduledTask: request.isScheduledTask,
     }

--- a/apps/server/src/api/services/chat-v2-service.ts
+++ b/apps/server/src/api/services/chat-v2-service.ts
@@ -41,8 +41,13 @@ export class ChatV2Service {
 
     const sessionExecutionDir = await this.resolveSessionDir(request)
 
-    // Auto-populate model defaults from registry when not client-specified
-    const modelDefaults = getModelDefaults(llmConfig.provider, llmConfig.model)
+    // Auto-populate model defaults from registry when not client-specified.
+    // For the browseros meta-provider, also try the upstream provider.
+    const modelDefaults =
+      getModelDefaults(llmConfig.provider, llmConfig.model) ??
+      (llmConfig.upstreamProvider
+        ? getModelDefaults(llmConfig.upstreamProvider, llmConfig.model)
+        : undefined)
 
     const agentConfig: ResolvedAgentConfig = {
       conversationId: request.conversationId,

--- a/apps/server/src/api/types.ts
+++ b/apps/server/src/api/types.ts
@@ -44,7 +44,7 @@ export const ChatRequestSchema = AgentLLMConfigSchema.extend({
   userSystemPrompt: z.string().optional(),
   isScheduledTask: z.boolean().optional().default(false),
   userWorkingDir: z.string().min(1).optional(),
-  supportsImages: z.boolean().optional().default(true),
+  supportsImages: z.boolean().optional(),
   mode: z.enum(['chat', 'agent']).optional().default('agent'),
   previousConversation: z
     .union([

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
         "@ai-sdk/provider": "^3.0.8",
         "@browseros-ai/agent-sdk": "workspace:*",
         "@browseros/cdp-protocol": "workspace:*",
+        "@browseros/models-dev": "workspace:*",
         "@browseros/shared": "workspace:*",
         "@google/gemini-cli-core": "^0.16.0",
         "@google/genai": "1.30.0",
@@ -217,6 +218,10 @@
     },
     "packages/cdp-protocol": {
       "name": "@browseros/cdp-protocol",
+      "version": "0.0.1",
+    },
+    "packages/models-dev": {
+      "name": "@browseros/models-dev",
       "version": "0.0.1",
     },
     "packages/shared": {
@@ -443,6 +448,8 @@
     "@browseros/agent": ["@browseros/agent@workspace:apps/agent"],
 
     "@browseros/cdp-protocol": ["@browseros/cdp-protocol@workspace:packages/cdp-protocol"],
+
+    "@browseros/models-dev": ["@browseros/models-dev@workspace:packages/models-dev"],
 
     "@browseros/server": ["@browseros/server@workspace:apps/server"],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "bunx biome check",
     "lint:fix": "bunx biome check --write --unsafe",
     "gen:cdp": "bun scripts/codegen/cdp-protocol.ts",
+    "generate:models": "bun packages/models-dev/scripts/generate.ts",
     "clean": "rimraf dist"
   },
   "repository": "browseros-ai/BrowserOS-server",

--- a/packages/models-dev/package.json
+++ b/packages/models-dev/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@browseros/models-dev",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "generate": "bun scripts/generate.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "exports": {
+    "./registry": {
+      "types": "./src/registry.ts",
+      "default": "./src/registry.ts"
+    },
+    "./types": {
+      "types": "./src/types.ts",
+      "default": "./src/types.ts"
+    }
+  }
+}

--- a/packages/models-dev/scripts/generate.ts
+++ b/packages/models-dev/scripts/generate.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Generates registry.json from a local models.dev clone.
+ *
+ * Usage:
+ *   bun packages/models-dev/scripts/generate.ts /path/to/models.dev/providers
+ */
+
+import path from 'node:path'
+import type {
+  ModelCost,
+  ModelInfo,
+  ModelRegistry,
+  ProviderInfo,
+} from '../src/types'
+
+// models.dev provider IDs → BrowserOS provider IDs
+const PROVIDER_MAP: Record<string, string> = {
+  anthropic: 'anthropic',
+  openai: 'openai',
+  google: 'google',
+  openrouter: 'openrouter',
+  'ollama-cloud': 'ollama',
+}
+
+const SOURCE_PROVIDERS = Object.keys(PROVIDER_MAP)
+
+interface RawModel {
+  id?: string
+  name: string
+  family?: string
+  reasoning: boolean
+  tool_call: boolean
+  structured_output?: boolean
+  attachment: boolean
+  modalities: { input: string[]; output: string[] }
+  limit: { context: number; input?: number; output: number }
+  cost?: RawCost
+  knowledge?: string
+  status?: string
+  release_date: string
+  [key: string]: unknown
+}
+
+interface RawCost {
+  input: number
+  output: number
+  reasoning?: number
+  cache_read?: number
+  cache_write?: number
+  [key: string]: unknown
+}
+
+interface RawProvider {
+  name: string
+  [key: string]: unknown
+}
+
+function extractCost(raw?: RawCost): ModelCost | undefined {
+  if (!raw) return undefined
+  const cost: ModelCost = { input: raw.input, output: raw.output }
+  if (raw.reasoning !== undefined) cost.reasoning = raw.reasoning
+  if (raw.cache_read !== undefined) cost.cache_read = raw.cache_read
+  if (raw.cache_write !== undefined) cost.cache_write = raw.cache_write
+  return cost
+}
+
+function extractModel(raw: RawModel, modelId: string): ModelInfo {
+  return {
+    id: modelId,
+    name: raw.name,
+    ...(raw.family && { family: raw.family }),
+    reasoning: raw.reasoning,
+    tool_call: raw.tool_call,
+    ...(raw.structured_output !== undefined && {
+      structured_output: raw.structured_output,
+    }),
+    attachment: raw.attachment,
+    modalities: raw.modalities,
+    limit: {
+      context: raw.limit.context,
+      ...(raw.limit.input !== undefined && { input: raw.limit.input }),
+      output: raw.limit.output,
+    },
+    ...(raw.cost && { cost: extractCost(raw.cost) }),
+    ...(raw.knowledge && { knowledge: raw.knowledge }),
+    ...(raw.status && { status: raw.status as ModelInfo['status'] }),
+    release_date: raw.release_date,
+  }
+}
+
+async function loadToml(filePath: string): Promise<Record<string, unknown>> {
+  return import(filePath, { with: { type: 'toml' } }).then((mod) => mod.default)
+}
+
+async function generateProvider(
+  providersDir: string,
+  sourceId: string,
+  targetId: string,
+): Promise<ProviderInfo> {
+  // Load provider metadata
+  const providerToml = (await loadToml(
+    path.join(providersDir, sourceId, 'provider.toml'),
+  )) as unknown as RawProvider
+
+  const provider: ProviderInfo = {
+    id: targetId,
+    name: providerToml.name,
+    models: {},
+  }
+
+  // Scan all model TOML files
+  const modelsDir = path.join(providersDir, sourceId, 'models')
+  for await (const modelPath of new Bun.Glob('**/*.toml').scan({
+    cwd: modelsDir,
+    absolute: true,
+    followSymlinks: true,
+  })) {
+    const modelId = path.relative(modelsDir, modelPath).slice(0, -5)
+    try {
+      const raw = (await loadToml(modelPath)) as unknown as RawModel
+      provider.models[modelId] = extractModel(raw, modelId)
+    } catch (err) {
+      console.warn(`Skipping ${sourceId}/${modelId}: ${err}`)
+    }
+  }
+
+  return provider
+}
+
+async function main() {
+  const providersDir = process.argv[2]
+  if (!providersDir) {
+    console.error(
+      'Usage: bun scripts/generate.ts <path-to-models.dev-providers>',
+    )
+    process.exit(1)
+  }
+
+  const absoluteDir = path.resolve(providersDir)
+  console.log(`Reading from: ${absoluteDir}`)
+
+  const registry: ModelRegistry = {}
+
+  for (const sourceId of SOURCE_PROVIDERS) {
+    const targetId = PROVIDER_MAP[sourceId]
+    try {
+      const provider = await generateProvider(absoluteDir, sourceId, targetId)
+      const modelCount = Object.keys(provider.models).length
+      console.log(`  ${sourceId} → ${targetId}: ${modelCount} models`)
+      registry[targetId] = provider
+    } catch (err) {
+      console.error(`Failed to process ${sourceId}: ${err}`)
+      process.exit(1)
+    }
+  }
+
+  // Write registry
+  const outputPath = path.join(
+    import.meta.dir,
+    '..',
+    'src',
+    'data',
+    'registry.json',
+  )
+  await Bun.write(outputPath, JSON.stringify(registry, null, 2))
+
+  const totalModels = Object.values(registry).reduce(
+    (sum, p) => sum + Object.keys(p.models).length,
+    0,
+  )
+  console.log(`\nGenerated ${outputPath}`)
+  console.log(
+    `  ${Object.keys(registry).length} providers, ${totalModels} models`,
+  )
+}
+
+main()

--- a/packages/models-dev/src/data/registry.json
+++ b/packages/models-dev/src/data/registry.json
@@ -1,0 +1,7074 @@
+{
+  "anthropic": {
+    "id": "anthropic",
+    "name": "Anthropic",
+    "models": {
+      "claude-3-5-haiku-20241022": {
+        "id": "claude-3-5-haiku-20241022",
+        "name": "Claude Haiku 3.5",
+        "family": "claude-haiku",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.8,
+          "output": 4,
+          "cache_read": 0.08,
+          "cache_write": 1
+        },
+        "knowledge": "2024-07-31",
+        "release_date": "2024-10-22"
+      },
+      "claude-haiku-4-5": {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "family": "claude-haiku",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        },
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15"
+      },
+      "claude-3-5-sonnet-20241022": {
+        "id": "claude-3-5-sonnet-20241022",
+        "name": "Claude Sonnet 3.5 v2",
+        "family": "claude-sonnet",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2024-04-30",
+        "release_date": "2024-10-22"
+      },
+      "claude-3-5-haiku-latest": {
+        "id": "claude-3-5-haiku-latest",
+        "name": "Claude Haiku 3.5 (latest)",
+        "family": "claude-haiku",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.8,
+          "output": 4,
+          "cache_read": 0.08,
+          "cache_write": 1
+        },
+        "knowledge": "2024-07-31",
+        "release_date": "2024-10-22"
+      },
+      "claude-opus-4-20250514": {
+        "id": "claude-opus-4-20250514",
+        "name": "Claude Opus 4",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-05-22"
+      },
+      "claude-3-sonnet-20240229": {
+        "id": "claude-3-sonnet-20240229",
+        "name": "Claude Sonnet 3",
+        "family": "claude-sonnet",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 4096
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 0.3
+        },
+        "knowledge": "2023-08-31",
+        "release_date": "2024-03-04"
+      },
+      "claude-sonnet-4-5": {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2025-07-31",
+        "release_date": "2025-09-29"
+      },
+      "claude-3-7-sonnet-latest": {
+        "id": "claude-3-7-sonnet-latest",
+        "name": "Claude Sonnet 3.7 (latest)",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2024-10-31",
+        "release_date": "2025-02-19"
+      },
+      "claude-opus-4-5": {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-11-24"
+      },
+      "claude-3-5-sonnet-20240620": {
+        "id": "claude-3-5-sonnet-20240620",
+        "name": "Claude Sonnet 3.5",
+        "family": "claude-sonnet",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2024-04-30",
+        "release_date": "2024-06-20"
+      },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "knowledge": "2025-05",
+        "release_date": "2026-02-05"
+      },
+      "claude-opus-4-5-20251101": {
+        "id": "claude-opus-4-5-20251101",
+        "name": "Claude Opus 4.5",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-11-01"
+      },
+      "claude-haiku-4-5-20251001": {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "family": "claude-haiku",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        },
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15"
+      },
+      "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2025-08",
+        "release_date": "2026-02-17"
+      },
+      "claude-3-haiku-20240307": {
+        "id": "claude-3-haiku-20240307",
+        "name": "Claude Haiku 3",
+        "family": "claude-haiku",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 4096
+        },
+        "cost": {
+          "input": 0.25,
+          "output": 1.25,
+          "cache_read": 0.03,
+          "cache_write": 0.3
+        },
+        "knowledge": "2023-08-31",
+        "release_date": "2024-03-13"
+      },
+      "claude-sonnet-4-5-20250929": {
+        "id": "claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4.5",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2025-07-31",
+        "release_date": "2025-09-29"
+      },
+      "claude-3-7-sonnet-20250219": {
+        "id": "claude-3-7-sonnet-20250219",
+        "name": "Claude Sonnet 3.7",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2024-10-31",
+        "release_date": "2025-02-19"
+      },
+      "claude-opus-4-1-20250805": {
+        "id": "claude-opus-4-1-20250805",
+        "name": "Claude Opus 4.1",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-08-05"
+      },
+      "claude-sonnet-4-20250514": {
+        "id": "claude-sonnet-4-20250514",
+        "name": "Claude Sonnet 4",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-05-22"
+      },
+      "claude-opus-4-0": {
+        "id": "claude-opus-4-0",
+        "name": "Claude Opus 4 (latest)",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-05-22"
+      },
+      "claude-opus-4-1": {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1 (latest)",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-08-05"
+      },
+      "claude-3-opus-20240229": {
+        "id": "claude-3-opus-20240229",
+        "name": "Claude Opus 3",
+        "family": "claude-opus",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 4096
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "knowledge": "2023-08-31",
+        "release_date": "2024-02-29"
+      },
+      "claude-sonnet-4-0": {
+        "id": "claude-sonnet-4-0",
+        "name": "Claude Sonnet 4 (latest)",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-05-22"
+      }
+    }
+  },
+  "openai": {
+    "id": "openai",
+    "name": "OpenAI",
+    "models": {
+      "gpt-5.2-codex": {
+        "id": "gpt-5.2-codex",
+        "name": "GPT-5.2 Codex",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11"
+      },
+      "gpt-5.2": {
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "family": "gpt",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11"
+      },
+      "gpt-5-nano": {
+        "id": "gpt-5-nano",
+        "name": "GPT-5 Nano",
+        "family": "gpt-nano",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.05,
+          "output": 0.4,
+          "cache_read": 0.005
+        },
+        "knowledge": "2024-05-30",
+        "release_date": "2025-08-07"
+      },
+      "gpt-4o-2024-11-20": {
+        "id": "gpt-4o-2024-11-20",
+        "name": "GPT-4o (2024-11-20)",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cache_read": 1.25
+        },
+        "knowledge": "2023-09",
+        "release_date": "2024-11-20"
+      },
+      "o3-pro": {
+        "id": "o3-pro",
+        "name": "o3-pro",
+        "family": "o-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 20,
+          "output": 80
+        },
+        "knowledge": "2024-05",
+        "release_date": "2025-06-10"
+      },
+      "gpt-5.1-chat-latest": {
+        "id": "gpt-5.1-chat-latest",
+        "name": "GPT-5.1 Chat",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "text-embedding-ada-002": {
+        "id": "text-embedding-ada-002",
+        "name": "text-embedding-ada-002",
+        "family": "text-embedding",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 1536
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0
+        },
+        "knowledge": "2022-12",
+        "release_date": "2022-12-15"
+      },
+      "o4-mini-deep-research": {
+        "id": "o4-mini-deep-research",
+        "name": "o4-mini-deep-research",
+        "family": "o-mini",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        },
+        "knowledge": "2024-05",
+        "release_date": "2024-06-26"
+      },
+      "codex-mini-latest": {
+        "id": "codex-mini-latest",
+        "name": "Codex Mini",
+        "family": "gpt-codex-mini",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 1.5,
+          "output": 6,
+          "cache_read": 0.375
+        },
+        "knowledge": "2024-04",
+        "release_date": "2025-05-16"
+      },
+      "o1-mini": {
+        "id": "o1-mini",
+        "name": "o1-mini",
+        "family": "o-mini",
+        "reasoning": true,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.55
+        },
+        "knowledge": "2023-09",
+        "release_date": "2024-09-12"
+      },
+      "text-embedding-3-large": {
+        "id": "text-embedding-3-large",
+        "name": "text-embedding-3-large",
+        "family": "text-embedding",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8191,
+          "output": 3072
+        },
+        "cost": {
+          "input": 0.13,
+          "output": 0
+        },
+        "knowledge": "2024-01",
+        "release_date": "2024-01-25"
+      },
+      "gpt-4o-2024-08-06": {
+        "id": "gpt-4o-2024-08-06",
+        "name": "GPT-4o (2024-08-06)",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cache_read": 1.25
+        },
+        "knowledge": "2023-09",
+        "release_date": "2024-08-06"
+      },
+      "gpt-4-turbo": {
+        "id": "gpt-4-turbo",
+        "name": "GPT-4 Turbo",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "cost": {
+          "input": 10,
+          "output": 30
+        },
+        "knowledge": "2023-12",
+        "release_date": "2023-11-06"
+      },
+      "gpt-5-codex": {
+        "id": "gpt-5-codex",
+        "name": "GPT-5-Codex",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-09-15"
+      },
+      "gpt-5.3-codex-spark": {
+        "id": "gpt-5.3-codex-spark",
+        "name": "GPT-5.3 Codex Spark",
+        "family": "gpt-codex-spark",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "input": 100000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-05"
+      },
+      "gpt-5-mini": {
+        "id": "gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "family": "gpt-mini",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.025
+        },
+        "knowledge": "2024-05-30",
+        "release_date": "2025-08-07"
+      },
+      "o3": {
+        "id": "o3",
+        "name": "o3",
+        "family": "o",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        },
+        "knowledge": "2024-05",
+        "release_date": "2025-04-16"
+      },
+      "gpt-4o-2024-05-13": {
+        "id": "gpt-4o-2024-05-13",
+        "name": "GPT-4o (2024-05-13)",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "cost": {
+          "input": 5,
+          "output": 15
+        },
+        "knowledge": "2023-09",
+        "release_date": "2024-05-13"
+      },
+      "gpt-4.1": {
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        },
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14"
+      },
+      "text-embedding-3-small": {
+        "id": "text-embedding-3-small",
+        "name": "text-embedding-3-small",
+        "family": "text-embedding",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8191,
+          "output": 1536
+        },
+        "cost": {
+          "input": 0.02,
+          "output": 0
+        },
+        "knowledge": "2024-01",
+        "release_date": "2024-01-25"
+      },
+      "o1-preview": {
+        "id": "o1-preview",
+        "name": "o1-preview",
+        "family": "o",
+        "reasoning": true,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 32768
+        },
+        "cost": {
+          "input": 15,
+          "output": 60,
+          "cache_read": 7.5
+        },
+        "knowledge": "2023-09",
+        "release_date": "2024-09-12"
+      },
+      "gpt-5": {
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "family": "gpt",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-08-07"
+      },
+      "o1-pro": {
+        "id": "o1-pro",
+        "name": "o1-pro",
+        "family": "o-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 150,
+          "output": 600
+        },
+        "knowledge": "2023-09",
+        "release_date": "2025-03-19"
+      },
+      "gpt-5.3-codex": {
+        "id": "gpt-5.3-codex",
+        "name": "GPT-5.3 Codex",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-05"
+      },
+      "gpt-5-pro": {
+        "id": "gpt-5-pro",
+        "name": "GPT-5 Pro",
+        "family": "gpt-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 272000
+        },
+        "cost": {
+          "input": 15,
+          "output": 120
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-10-06"
+      },
+      "o1": {
+        "id": "o1",
+        "name": "o1",
+        "family": "o",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 15,
+          "output": 60,
+          "cache_read": 7.5
+        },
+        "knowledge": "2023-09",
+        "release_date": "2024-12-05"
+      },
+      "o4-mini": {
+        "id": "o4-mini",
+        "name": "o4-mini",
+        "family": "o-mini",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.28
+        },
+        "knowledge": "2024-05",
+        "release_date": "2025-04-16"
+      },
+      "gpt-4": {
+        "id": "gpt-4",
+        "name": "GPT-4",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 8192
+        },
+        "cost": {
+          "input": 30,
+          "output": 60
+        },
+        "knowledge": "2023-11",
+        "release_date": "2023-11-06"
+      },
+      "gpt-5.1-codex-mini": {
+        "id": "gpt-5.1-codex-mini",
+        "name": "GPT-5.1 Codex mini",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.025
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "o3-deep-research": {
+        "id": "o3-deep-research",
+        "name": "o3-deep-research",
+        "family": "o",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 10,
+          "output": 40,
+          "cache_read": 2.5
+        },
+        "knowledge": "2024-05",
+        "release_date": "2024-06-26"
+      },
+      "gpt-4.1-mini": {
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "family": "gpt-mini",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.4,
+          "output": 1.6,
+          "cache_read": 0.1
+        },
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14"
+      },
+      "o3-mini": {
+        "id": "o3-mini",
+        "name": "o3-mini",
+        "family": "o-mini",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.55
+        },
+        "knowledge": "2024-05",
+        "release_date": "2024-12-20"
+      },
+      "gpt-4o-mini": {
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "family": "gpt-mini",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cache_read": 0.08
+        },
+        "knowledge": "2023-09",
+        "release_date": "2024-07-18"
+      },
+      "gpt-4.1-nano": {
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "family": "gpt-nano",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.03
+        },
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14"
+      },
+      "gpt-5.1-codex-max": {
+        "id": "gpt-5.1-codex-max",
+        "name": "GPT-5.1 Codex Max",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "gpt-5.2-chat-latest": {
+        "id": "gpt-5.2-chat-latest",
+        "name": "GPT-5.2 Chat",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11"
+      },
+      "gpt-5.1-codex": {
+        "id": "gpt-5.1-codex",
+        "name": "GPT-5.1 Codex",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "gpt-5.2-pro": {
+        "id": "gpt-5.2-pro",
+        "name": "GPT-5.2 Pro",
+        "family": "gpt-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 21,
+          "output": 168
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11"
+      },
+      "gpt-5.1": {
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "family": "gpt",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.13
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "gpt-5-chat-latest": {
+        "id": "gpt-5-chat-latest",
+        "name": "GPT-5 Chat (latest)",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "input": 272000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-08-07"
+      },
+      "gpt-4o": {
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 2.5,
+          "output": 10,
+          "cache_read": 1.25
+        },
+        "knowledge": "2023-09",
+        "release_date": "2024-05-13"
+      },
+      "gpt-3.5-turbo": {
+        "id": "gpt-3.5-turbo",
+        "name": "GPT-3.5-turbo",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 16385,
+          "output": 4096
+        },
+        "cost": {
+          "input": 0.5,
+          "output": 1.5,
+          "cache_read": 1.25
+        },
+        "knowledge": "2021-09-01",
+        "release_date": "2023-03-01"
+      }
+    }
+  },
+  "google": {
+    "id": "google",
+    "name": "Google",
+    "models": {
+      "gemini-3.1-pro-preview-customtools": {
+        "id": "gemini-3.1-pro-preview-customtools",
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2
+        },
+        "knowledge": "2025-01",
+        "release_date": "2026-02-19"
+      },
+      "gemini-flash-lite-latest": {
+        "id": "gemini-flash-lite-latest",
+        "name": "Gemini Flash-Lite Latest",
+        "family": "gemini-flash-lite",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-09-25"
+      },
+      "gemini-2.0-flash": {
+        "id": "gemini-2.0-flash",
+        "name": "Gemini 2.0 Flash",
+        "family": "gemini-flash",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "knowledge": "2024-06",
+        "release_date": "2024-12-11"
+      },
+      "gemini-2.5-pro": {
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.31
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-03-20"
+      },
+      "gemini-2.5-flash": {
+        "id": "gemini-2.5-flash",
+        "name": "Gemini 2.5 Flash",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.075
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-03-20"
+      },
+      "gemini-2.5-pro-preview-05-06": {
+        "id": "gemini-2.5-pro-preview-05-06",
+        "name": "Gemini 2.5 Pro Preview 05-06",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.31
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-05-06"
+      },
+      "gemini-embedding-001": {
+        "id": "gemini-embedding-001",
+        "name": "Gemini Embedding 001",
+        "family": "gemini",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 2048,
+          "output": 3072
+        },
+        "cost": {
+          "input": 0.15,
+          "output": 0
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-05-20"
+      },
+      "gemini-3-flash-preview": {
+        "id": "gemini-3-flash-preview",
+        "name": "Gemini 3 Flash Preview",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.5,
+          "output": 3,
+          "cache_read": 0.05
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-12-17"
+      },
+      "gemini-3-pro-preview": {
+        "id": "gemini-3-pro-preview",
+        "name": "Gemini 3 Pro Preview",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-11-18"
+      },
+      "gemini-3.1-pro-preview": {
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video", "audio", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2
+        },
+        "knowledge": "2025-01",
+        "release_date": "2026-02-19"
+      },
+      "gemini-1.5-flash-8b": {
+        "id": "gemini-1.5-flash-8b",
+        "name": "Gemini 1.5 Flash-8B",
+        "family": "gemini-flash",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.0375,
+          "output": 0.15,
+          "cache_read": 0.01
+        },
+        "knowledge": "2024-04",
+        "release_date": "2024-10-03"
+      },
+      "gemini-2.5-flash-preview-tts": {
+        "id": "gemini-2.5-flash-preview-tts",
+        "name": "Gemini 2.5 Flash Preview TTS",
+        "family": "gemini-flash",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["audio"]
+        },
+        "limit": {
+          "context": 8000,
+          "output": 16000
+        },
+        "cost": {
+          "input": 0.5,
+          "output": 10
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-05-01"
+      },
+      "gemini-2.5-flash-lite": {
+        "id": "gemini-2.5-flash-lite",
+        "name": "Gemini 2.5 Flash Lite",
+        "family": "gemini-flash-lite",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-06-17"
+      },
+      "gemini-2.5-flash-preview-04-17": {
+        "id": "gemini-2.5-flash-preview-04-17",
+        "name": "Gemini 2.5 Flash Preview 04-17",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cache_read": 0.0375
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-04-17"
+      },
+      "gemini-2.0-flash-lite": {
+        "id": "gemini-2.0-flash-lite",
+        "name": "Gemini 2.0 Flash Lite",
+        "family": "gemini-flash-lite",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.075,
+          "output": 0.3
+        },
+        "knowledge": "2024-06",
+        "release_date": "2024-12-11"
+      },
+      "gemini-2.5-pro-preview-tts": {
+        "id": "gemini-2.5-pro-preview-tts",
+        "name": "Gemini 2.5 Pro Preview TTS",
+        "family": "gemini-flash",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["audio"]
+        },
+        "limit": {
+          "context": 8000,
+          "output": 16000
+        },
+        "cost": {
+          "input": 1,
+          "output": 20
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-05-01"
+      },
+      "gemini-2.5-pro-preview-06-05": {
+        "id": "gemini-2.5-pro-preview-06-05",
+        "name": "Gemini 2.5 Pro Preview 06-05",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.31
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-06-05"
+      },
+      "gemini-2.5-flash-preview-05-20": {
+        "id": "gemini-2.5-flash-preview-05-20",
+        "name": "Gemini 2.5 Flash Preview 05-20",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cache_read": 0.0375
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-05-20"
+      },
+      "gemini-2.5-flash-image": {
+        "id": "gemini-2.5-flash-image",
+        "name": "Gemini 2.5 Flash Image",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text", "image"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 30,
+          "cache_read": 0.075
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-08-26"
+      },
+      "gemini-2.5-flash-preview-09-2025": {
+        "id": "gemini-2.5-flash-preview-09-2025",
+        "name": "Gemini 2.5 Flash Preview 09-25",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.075
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-09-25"
+      },
+      "gemini-2.5-flash-image-preview": {
+        "id": "gemini-2.5-flash-image-preview",
+        "name": "Gemini 2.5 Flash Image (Preview)",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text", "image"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 30,
+          "cache_read": 0.075
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-08-26"
+      },
+      "gemini-live-2.5-flash": {
+        "id": "gemini-live-2.5-flash",
+        "name": "Gemini Live 2.5 Flash",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video"],
+          "output": ["text", "audio"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 8000
+        },
+        "cost": {
+          "input": 0.5,
+          "output": 2
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-09-01"
+      },
+      "gemini-live-2.5-flash-preview-native-audio": {
+        "id": "gemini-live-2.5-flash-preview-native-audio",
+        "name": "Gemini Live 2.5 Flash Preview Native Audio",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "audio", "video"],
+          "output": ["text", "audio"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.5,
+          "output": 2
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-06-17"
+      },
+      "gemini-flash-latest": {
+        "id": "gemini-flash-latest",
+        "name": "Gemini Flash Latest",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.075
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-09-25"
+      },
+      "gemini-1.5-flash": {
+        "id": "gemini-1.5-flash",
+        "name": "Gemini 1.5 Flash",
+        "family": "gemini-flash",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.075,
+          "output": 0.3,
+          "cache_read": 0.01875
+        },
+        "knowledge": "2024-04",
+        "release_date": "2024-05-14"
+      },
+      "gemini-2.5-flash-lite-preview-09-2025": {
+        "id": "gemini-2.5-flash-lite-preview-09-2025",
+        "name": "Gemini 2.5 Flash Lite Preview 09-25",
+        "family": "gemini-flash-lite",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-09-25"
+      },
+      "gemini-2.5-flash-lite-preview-06-17": {
+        "id": "gemini-2.5-flash-lite-preview-06-17",
+        "name": "Gemini 2.5 Flash Lite Preview 06-17",
+        "family": "gemini-flash-lite",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-06-17"
+      },
+      "gemini-1.5-pro": {
+        "id": "gemini-1.5-pro",
+        "name": "Gemini 1.5 Pro",
+        "family": "gemini-pro",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 5,
+          "cache_read": 0.3125
+        },
+        "knowledge": "2024-04",
+        "release_date": "2024-02-15"
+      }
+    }
+  },
+  "openrouter": {
+    "id": "openrouter",
+    "name": "OpenRouter",
+    "models": {
+      "openai/gpt-5.2-codex": {
+        "id": "openai/gpt-5.2-codex",
+        "name": "GPT-5.2-Codex",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2026-01-14"
+      },
+      "openai/gpt-5.2": {
+        "id": "openai/gpt-5.2",
+        "name": "GPT-5.2",
+        "family": "gpt",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11"
+      },
+      "openai/gpt-oss-safeguard-20b": {
+        "id": "openai/gpt-oss-safeguard-20b",
+        "name": "GPT OSS Safeguard 20B",
+        "family": "gpt-oss",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.075,
+          "output": 0.3
+        },
+        "release_date": "2025-10-29"
+      },
+      "openai/gpt-5-nano": {
+        "id": "openai/gpt-5-nano",
+        "name": "GPT-5 Nano",
+        "family": "gpt-nano",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.05,
+          "output": 0.4
+        },
+        "knowledge": "2024-10-01",
+        "release_date": "2025-08-07"
+      },
+      "openai/gpt-5.1-chat": {
+        "id": "openai/gpt-5.1-chat",
+        "name": "GPT-5.1 Chat",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "openai/gpt-oss-120b": {
+        "id": "openai/gpt-oss-120b",
+        "name": "GPT OSS 120B",
+        "family": "gpt-oss",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.072,
+          "output": 0.28
+        },
+        "release_date": "2025-08-05"
+      },
+      "openai/gpt-5-image": {
+        "id": "openai/gpt-5-image",
+        "name": "GPT-5 Image",
+        "family": "gpt",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text", "image"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 10,
+          "cache_read": 1.25
+        },
+        "knowledge": "2024-10-01",
+        "release_date": "2025-10-14"
+      },
+      "openai/gpt-5-chat": {
+        "id": "openai/gpt-5-chat",
+        "name": "GPT-5 Chat (latest)",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-08-07"
+      },
+      "openai/gpt-5-codex": {
+        "id": "openai/gpt-5-codex",
+        "name": "GPT-5 Codex",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-10-01",
+        "release_date": "2025-09-15"
+      },
+      "openai/gpt-5-mini": {
+        "id": "openai/gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "family": "gpt-mini",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.25,
+          "output": 2
+        },
+        "knowledge": "2024-10-01",
+        "release_date": "2025-08-07"
+      },
+      "openai/gpt-oss-20b": {
+        "id": "openai/gpt-oss-20b",
+        "name": "GPT OSS 20B",
+        "family": "gpt-oss",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.05,
+          "output": 0.2
+        },
+        "release_date": "2025-08-05"
+      },
+      "openai/gpt-4.1": {
+        "id": "openai/gpt-4.1",
+        "name": "GPT-4.1",
+        "family": "gpt",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "cost": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        },
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14"
+      },
+      "openai/gpt-oss-120b:free": {
+        "id": "openai/gpt-oss-120b:free",
+        "name": "gpt-oss-120b (free)",
+        "family": "gpt-oss",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "release_date": "2025-08-05"
+      },
+      "openai/gpt-5": {
+        "id": "openai/gpt-5",
+        "name": "GPT-5",
+        "family": "gpt",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10
+        },
+        "knowledge": "2024-10-01",
+        "release_date": "2025-08-07"
+      },
+      "openai/gpt-5-pro": {
+        "id": "openai/gpt-5-pro",
+        "name": "GPT-5 Pro",
+        "family": "gpt-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 272000
+        },
+        "cost": {
+          "input": 15,
+          "output": 120
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-10-06"
+      },
+      "openai/gpt-oss-20b:free": {
+        "id": "openai/gpt-oss-20b:free",
+        "name": "gpt-oss-20b (free)",
+        "family": "gpt-oss",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "release_date": "2025-08-05"
+      },
+      "openai/o4-mini": {
+        "id": "openai/o4-mini",
+        "name": "o4 Mini",
+        "family": "o-mini",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.28
+        },
+        "knowledge": "2024-06",
+        "release_date": "2025-04-16"
+      },
+      "openai/gpt-5.1-codex-mini": {
+        "id": "openai/gpt-5.1-codex-mini",
+        "name": "GPT-5.1-Codex-Mini",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 100000
+        },
+        "cost": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.025
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "openai/gpt-4.1-mini": {
+        "id": "openai/gpt-4.1-mini",
+        "name": "GPT-4.1 Mini",
+        "family": "gpt-mini",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1047576,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.4,
+          "output": 1.6,
+          "cache_read": 0.1
+        },
+        "knowledge": "2024-04",
+        "release_date": "2025-04-14"
+      },
+      "openai/gpt-4o-mini": {
+        "id": "openai/gpt-4o-mini",
+        "name": "GPT-4o-mini",
+        "family": "gpt-mini",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cache_read": 0.08
+        },
+        "knowledge": "2024-10",
+        "release_date": "2024-07-18"
+      },
+      "openai/gpt-5.1-codex-max": {
+        "id": "openai/gpt-5.1-codex-max",
+        "name": "GPT-5.1-Codex-Max",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.1,
+          "output": 9,
+          "cache_read": 0.11
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "openai/gpt-oss-120b:exacto": {
+        "id": "openai/gpt-oss-120b:exacto",
+        "name": "GPT OSS 120B (exacto)",
+        "family": "gpt-oss",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.05,
+          "output": 0.24
+        },
+        "release_date": "2025-08-05"
+      },
+      "openai/gpt-5.2-chat": {
+        "id": "openai/gpt-5.2-chat",
+        "name": "GPT-5.2 Chat",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11"
+      },
+      "openai/gpt-5.1-codex": {
+        "id": "openai/gpt-5.1-codex",
+        "name": "GPT-5.1-Codex",
+        "family": "gpt-codex",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "openai/gpt-5.2-pro": {
+        "id": "openai/gpt-5.2-pro",
+        "name": "GPT-5.2 Pro",
+        "family": "gpt-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 21,
+          "output": 168
+        },
+        "knowledge": "2025-08-31",
+        "release_date": "2025-12-11"
+      },
+      "openai/gpt-5.1": {
+        "id": "openai/gpt-5.1",
+        "name": "GPT-5.1",
+        "family": "gpt",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 400000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        },
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13"
+      },
+      "meta-llama/llama-3.2-11b-vision-instruct": {
+        "id": "meta-llama/llama-3.2-11b-vision-instruct",
+        "name": "Llama 3.2 11B Vision Instruct",
+        "family": "llama",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2023-12",
+        "release_date": "2024-09-25"
+      },
+      "meta-llama/llama-3.1-405b-instruct:free": {
+        "id": "meta-llama/llama-3.1-405b-instruct:free",
+        "name": "Llama 3.1 405B Instruct (free)",
+        "family": "llama",
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-08",
+        "release_date": "2024-07-23"
+      },
+      "meta-llama/llama-3.2-3b-instruct:free": {
+        "id": "meta-llama/llama-3.2-3b-instruct:free",
+        "name": "Llama 3.2 3B Instruct (free)",
+        "family": "llama",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2023-12",
+        "release_date": "2024-09-25"
+      },
+      "meta-llama/llama-3.3-70b-instruct:free": {
+        "id": "meta-llama/llama-3.3-70b-instruct:free",
+        "name": "Llama 3.3 70B Instruct (free)",
+        "family": "llama",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-12",
+        "release_date": "2024-12-06"
+      },
+      "meta-llama/llama-4-scout:free": {
+        "id": "meta-llama/llama-4-scout:free",
+        "name": "Llama 4 Scout (free)",
+        "family": "llama",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 64000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-08",
+        "release_date": "2025-04-05"
+      },
+      "rekaai/reka-flash-3": {
+        "id": "rekaai/reka-flash-3",
+        "name": "Reka Flash 3",
+        "family": "reka",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-12"
+      },
+      "cognitivecomputations/dolphin-mistral-24b-venice-edition:free": {
+        "id": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
+        "name": "Uncensored (free)",
+        "family": "mistral",
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-07-09"
+      },
+      "cognitivecomputations/dolphin3.0-mistral-24b": {
+        "id": "cognitivecomputations/dolphin3.0-mistral-24b",
+        "name": "Dolphin3.0 Mistral 24B",
+        "family": "mistral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-02-13"
+      },
+      "cognitivecomputations/dolphin3.0-r1-mistral-24b": {
+        "id": "cognitivecomputations/dolphin3.0-r1-mistral-24b",
+        "name": "Dolphin3.0 R1 Mistral 24B",
+        "family": "mistral",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-02-13"
+      },
+      "nousresearch/deephermes-3-llama-3-8b-preview": {
+        "id": "nousresearch/deephermes-3-llama-3-8b-preview",
+        "name": "DeepHermes 3 Llama 3 8B Preview",
+        "family": "llama",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-04",
+        "release_date": "2025-02-28"
+      },
+      "nousresearch/hermes-4-405b": {
+        "id": "nousresearch/hermes-4-405b",
+        "name": "Hermes 4 405B",
+        "family": "hermes",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 1,
+          "output": 3
+        },
+        "knowledge": "2023-12",
+        "release_date": "2025-08-25"
+      },
+      "nousresearch/hermes-4-70b": {
+        "id": "nousresearch/hermes-4-70b",
+        "name": "Hermes 4 70B",
+        "family": "hermes",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.13,
+          "output": 0.4
+        },
+        "knowledge": "2023-12",
+        "release_date": "2025-08-25"
+      },
+      "nousresearch/hermes-3-llama-3.1-405b:free": {
+        "id": "nousresearch/hermes-3-llama-3.1-405b:free",
+        "name": "Hermes 3 405B Instruct (free)",
+        "family": "hermes",
+        "reasoning": true,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2023-12",
+        "release_date": "2024-08-16"
+      },
+      "anthropic/claude-sonnet-4.5": {
+        "id": "anthropic/claude-sonnet-4.5",
+        "name": "Claude Sonnet 4.5",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2025-07-31",
+        "release_date": "2025-09-29"
+      },
+      "anthropic/claude-opus-4": {
+        "id": "anthropic/claude-opus-4",
+        "name": "Claude Opus 4",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-05-22"
+      },
+      "anthropic/claude-opus-4.5": {
+        "id": "anthropic/claude-opus-4.5",
+        "name": "Claude Opus 4.5",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "knowledge": "2025-05-30",
+        "release_date": "2025-11-24"
+      },
+      "anthropic/claude-haiku-4.5": {
+        "id": "anthropic/claude-haiku-4.5",
+        "name": "Claude Haiku 4.5",
+        "family": "claude-haiku",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        },
+        "knowledge": "2025-02-28",
+        "release_date": "2025-10-15"
+      },
+      "anthropic/claude-sonnet-4": {
+        "id": "anthropic/claude-sonnet-4",
+        "name": "Claude Sonnet 4",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-05-22"
+      },
+      "anthropic/claude-3.7-sonnet": {
+        "id": "anthropic/claude-3.7-sonnet",
+        "name": "Claude Sonnet 3.7",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "knowledge": "2024-01",
+        "release_date": "2025-02-19"
+      },
+      "anthropic/claude-3.5-haiku": {
+        "id": "anthropic/claude-3.5-haiku",
+        "name": "Claude Haiku 3.5",
+        "family": "claude-haiku",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.8,
+          "output": 4,
+          "cache_read": 0.08,
+          "cache_write": 1
+        },
+        "knowledge": "2024-07-31",
+        "release_date": "2024-10-22"
+      },
+      "anthropic/claude-opus-4.1": {
+        "id": "anthropic/claude-opus-4.1",
+        "name": "Claude Opus 4.1",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "cost": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        },
+        "knowledge": "2025-03-31",
+        "release_date": "2025-08-05"
+      },
+      "anthropic/claude-opus-4.6": {
+        "id": "anthropic/claude-opus-4.6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        },
+        "knowledge": "2025-05-30",
+        "release_date": "2026-02-05"
+      },
+      "anthropic/claude-sonnet-4.6": {
+        "id": "anthropic/claude-sonnet-4.6",
+        "name": "Claude Sonnet 4.6",
+        "family": "claude-sonnet",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        },
+        "release_date": "2026-02-17"
+      },
+      "black-forest-labs/flux.2-flex": {
+        "id": "black-forest-labs/flux.2-flex",
+        "name": "FLUX.2 Flex",
+        "family": "flux",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["image", "text"],
+          "output": ["image"]
+        },
+        "limit": {
+          "context": 67344,
+          "output": 67344
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-11-25"
+      },
+      "black-forest-labs/flux.2-max": {
+        "id": "black-forest-labs/flux.2-max",
+        "name": "FLUX.2 Max",
+        "family": "flux",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["image", "text"],
+          "output": ["image"]
+        },
+        "limit": {
+          "context": 46864,
+          "output": 46864
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-12-16"
+      },
+      "black-forest-labs/flux.2-pro": {
+        "id": "black-forest-labs/flux.2-pro",
+        "name": "FLUX.2 Pro",
+        "family": "flux",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["image", "text"],
+          "output": ["image"]
+        },
+        "limit": {
+          "context": 46864,
+          "output": 46864
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-11-25"
+      },
+      "black-forest-labs/flux.2-klein-4b": {
+        "id": "black-forest-labs/flux.2-klein-4b",
+        "name": "FLUX.2 Klein 4B",
+        "family": "flux",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["image", "text"],
+          "output": ["image"]
+        },
+        "limit": {
+          "context": 40960,
+          "output": 40960
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2026-01-14"
+      },
+      "featherless/qwerky-72b": {
+        "id": "featherless/qwerky-72b",
+        "name": "Qwerky 72B",
+        "family": "qwerky",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-20"
+      },
+      "arcee-ai/trinity-mini:free": {
+        "id": "arcee-ai/trinity-mini:free",
+        "name": "Trinity Mini",
+        "family": "trinity-mini",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2026-01-28"
+      },
+      "arcee-ai/trinity-large-preview:free": {
+        "id": "arcee-ai/trinity-large-preview:free",
+        "name": "Trinity Large Preview",
+        "family": "trinity",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2026-01-28"
+      },
+      "nvidia/nemotron-nano-9b-v2": {
+        "id": "nvidia/nemotron-nano-9b-v2",
+        "name": "nvidia-nemotron-nano-9b-v2",
+        "family": "nemotron",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.04,
+          "output": 0.16
+        },
+        "knowledge": "2024-09",
+        "release_date": "2025-08-18"
+      },
+      "nvidia/nemotron-3-nano-30b-a3b:free": {
+        "id": "nvidia/nemotron-3-nano-30b-a3b:free",
+        "name": "Nemotron 3 Nano 30B A3B (free)",
+        "family": "nemotron",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 256000,
+          "output": 256000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-11",
+        "release_date": "2025-12-14"
+      },
+      "nvidia/nemotron-nano-9b-v2:free": {
+        "id": "nvidia/nemotron-nano-9b-v2:free",
+        "name": "Nemotron Nano 9B V2 (free)",
+        "family": "nemotron",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-09",
+        "release_date": "2025-09-05"
+      },
+      "nvidia/nemotron-nano-12b-v2-vl:free": {
+        "id": "nvidia/nemotron-nano-12b-v2-vl:free",
+        "name": "Nemotron Nano 12B 2 VL (free)",
+        "family": "nemotron",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-11",
+        "release_date": "2025-10-28"
+      },
+      "xiaomi/mimo-v2-flash": {
+        "id": "xiaomi/mimo-v2-flash",
+        "name": "MiMo-V2-Flash",
+        "family": "mimo",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.3,
+          "cache_read": 0.01
+        },
+        "knowledge": "2024-12",
+        "release_date": "2025-12-14"
+      },
+      "stepfun/step-3.5-flash:free": {
+        "id": "stepfun/step-3.5-flash:free",
+        "name": "Step 3.5 Flash (free)",
+        "family": "step",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 256000,
+          "output": 256000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-01",
+        "release_date": "2026-01-29"
+      },
+      "stepfun/step-3.5-flash": {
+        "id": "stepfun/step-3.5-flash",
+        "name": "Step 3.5 Flash",
+        "family": "step",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 256000,
+          "output": 256000
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.3,
+          "cache_read": 0.02
+        },
+        "knowledge": "2025-01",
+        "release_date": "2026-01-29"
+      },
+      "x-ai/grok-3-mini": {
+        "id": "x-ai/grok-3-mini",
+        "name": "Grok 3 Mini",
+        "family": "grok",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 0.5,
+          "cache_read": 0.075,
+          "cache_write": 0.5
+        },
+        "knowledge": "2024-11",
+        "release_date": "2025-02-17"
+      },
+      "x-ai/grok-3-beta": {
+        "id": "x-ai/grok-3-beta",
+        "name": "Grok 3 Beta",
+        "family": "grok",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.75,
+          "cache_write": 15
+        },
+        "knowledge": "2024-11",
+        "release_date": "2025-02-17"
+      },
+      "x-ai/grok-3-mini-beta": {
+        "id": "x-ai/grok-3-mini-beta",
+        "name": "Grok 3 Mini Beta",
+        "family": "grok",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 0.5,
+          "cache_read": 0.075,
+          "cache_write": 0.5
+        },
+        "knowledge": "2024-11",
+        "release_date": "2025-02-17"
+      },
+      "x-ai/grok-code-fast-1": {
+        "id": "x-ai/grok-code-fast-1",
+        "name": "Grok Code Fast 1",
+        "family": "grok",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 256000,
+          "output": 10000
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 1.5,
+          "cache_read": 0.02
+        },
+        "knowledge": "2025-08",
+        "release_date": "2025-08-26"
+      },
+      "x-ai/grok-3": {
+        "id": "x-ai/grok-3",
+        "name": "Grok 3",
+        "family": "grok",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.75,
+          "cache_write": 15
+        },
+        "knowledge": "2024-11",
+        "release_date": "2025-02-17"
+      },
+      "x-ai/grok-4": {
+        "id": "x-ai/grok-4",
+        "name": "Grok 4",
+        "family": "grok",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 256000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.75,
+          "cache_write": 15
+        },
+        "knowledge": "2025-07",
+        "release_date": "2025-07-09"
+      },
+      "x-ai/grok-4-fast": {
+        "id": "x-ai/grok-4-fast",
+        "name": "Grok 4 Fast",
+        "family": "grok",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 2000000,
+          "output": 30000
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 0.5,
+          "cache_read": 0.05,
+          "cache_write": 0.05
+        },
+        "knowledge": "2024-11",
+        "release_date": "2025-08-19"
+      },
+      "x-ai/grok-4.1-fast": {
+        "id": "x-ai/grok-4.1-fast",
+        "name": "Grok 4.1 Fast",
+        "family": "grok",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 2000000,
+          "output": 30000
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 0.5,
+          "cache_read": 0.05,
+          "cache_write": 0.05
+        },
+        "knowledge": "2024-11",
+        "release_date": "2025-11-19"
+      },
+      "deepseek/deepseek-chat-v3-0324": {
+        "id": "deepseek/deepseek-chat-v3-0324",
+        "name": "DeepSeek V3 0324",
+        "family": "deepseek",
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 16384,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-24"
+      },
+      "deepseek/deepseek-v3.1-terminus:exacto": {
+        "id": "deepseek/deepseek-v3.1-terminus:exacto",
+        "name": "DeepSeek V3.1 Terminus (exacto)",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.27,
+          "output": 1
+        },
+        "knowledge": "2025-07",
+        "release_date": "2025-09-22"
+      },
+      "deepseek/deepseek-r1:free": {
+        "id": "deepseek/deepseek-r1:free",
+        "name": "R1 (free)",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 163840
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-01-20"
+      },
+      "deepseek/deepseek-v3-base:free": {
+        "id": "deepseek/deepseek-v3-base:free",
+        "name": "DeepSeek V3 Base (free)",
+        "family": "deepseek",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 163840
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-03",
+        "release_date": "2025-03-29"
+      },
+      "deepseek/deepseek-v3.2": {
+        "id": "deepseek/deepseek-v3.2",
+        "name": "DeepSeek V3.2",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.28,
+          "output": 0.4
+        },
+        "knowledge": "2024-07",
+        "release_date": "2025-12-01"
+      },
+      "deepseek/deepseek-r1-distill-qwen-14b": {
+        "id": "deepseek/deepseek-r1-distill-qwen-14b",
+        "name": "DeepSeek R1 Distill Qwen 14B",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 64000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-01-29"
+      },
+      "deepseek/deepseek-chat-v3.1": {
+        "id": "deepseek/deepseek-chat-v3.1",
+        "name": "DeepSeek-V3.1",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 163840
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 0.8
+        },
+        "knowledge": "2025-07",
+        "release_date": "2025-08-21"
+      },
+      "deepseek/deepseek-r1-distill-llama-70b": {
+        "id": "deepseek/deepseek-r1-distill-llama-70b",
+        "name": "DeepSeek R1 Distill Llama 70B",
+        "family": "deepseek-thinking",
+        "reasoning": true,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-01-23"
+      },
+      "deepseek/deepseek-v3.1-terminus": {
+        "id": "deepseek/deepseek-v3.1-terminus",
+        "name": "DeepSeek V3.1 Terminus",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.27,
+          "output": 1
+        },
+        "knowledge": "2025-07",
+        "release_date": "2025-09-22"
+      },
+      "deepseek/deepseek-r1-0528:free": {
+        "id": "deepseek/deepseek-r1-0528:free",
+        "name": "R1 0528 (free)",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 163840
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-05-28"
+      },
+      "deepseek/deepseek-v3.2-speciale": {
+        "id": "deepseek/deepseek-v3.2-speciale",
+        "name": "DeepSeek V3.2 Speciale",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.27,
+          "output": 0.41
+        },
+        "knowledge": "2024-07",
+        "release_date": "2025-12-01"
+      },
+      "deepseek/deepseek-r1-0528-qwen3-8b:free": {
+        "id": "deepseek/deepseek-r1-0528-qwen3-8b:free",
+        "name": "Deepseek R1 0528 Qwen3 8B (free)",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-05-29"
+      },
+      "sourceful/riverflow-v2-fast-preview": {
+        "id": "sourceful/riverflow-v2-fast-preview",
+        "name": "Riverflow V2 Fast Preview",
+        "family": "sourceful",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["image"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-12-08"
+      },
+      "sourceful/riverflow-v2-max-preview": {
+        "id": "sourceful/riverflow-v2-max-preview",
+        "name": "Riverflow V2 Max Preview",
+        "family": "sourceful",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["image"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-12-08"
+      },
+      "sourceful/riverflow-v2-standard-preview": {
+        "id": "sourceful/riverflow-v2-standard-preview",
+        "name": "Riverflow V2 Standard Preview",
+        "family": "sourceful",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["image"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-12-08"
+      },
+      "prime-intellect/intellect-3": {
+        "id": "prime-intellect/intellect-3",
+        "name": "Intellect 3",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 1.1
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-01-15"
+      },
+      "minimax/minimax-m2": {
+        "id": "minimax/minimax-m2",
+        "name": "MiniMax M2",
+        "family": "minimax",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 196600,
+          "output": 118000
+        },
+        "cost": {
+          "input": 0.28,
+          "output": 1.15,
+          "cache_read": 0.28,
+          "cache_write": 1.15
+        },
+        "release_date": "2025-10-23"
+      },
+      "minimax/minimax-m2.5": {
+        "id": "minimax/minimax-m2.5",
+        "name": "MiniMax M2.5",
+        "family": "minimax",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2,
+          "cache_read": 0.03
+        },
+        "release_date": "2026-02-12"
+      },
+      "minimax/minimax-m2.1": {
+        "id": "minimax/minimax-m2.1",
+        "name": "MiniMax M2.1",
+        "family": "minimax",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "release_date": "2025-12-23"
+      },
+      "minimax/minimax-m1": {
+        "id": "minimax/minimax-m1",
+        "name": "MiniMax M1",
+        "family": "minimax",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 40000
+        },
+        "cost": {
+          "input": 0.4,
+          "output": 2.2
+        },
+        "release_date": "2025-06-17"
+      },
+      "minimax/minimax-01": {
+        "id": "minimax/minimax-01",
+        "name": "MiniMax-01",
+        "family": "minimax",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 1000000
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 1.1
+        },
+        "release_date": "2025-01-15"
+      },
+      "qwen/qwen3-32b:free": {
+        "id": "qwen/qwen3-32b:free",
+        "name": "Qwen3 32B (free)",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 40960,
+          "output": 40960
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-28"
+      },
+      "qwen/qwen3-coder:free": {
+        "id": "qwen/qwen3-coder:free",
+        "name": "Qwen3 Coder 480B A35B Instruct (free)",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 66536
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-23"
+      },
+      "qwen/qwen3-14b:free": {
+        "id": "qwen/qwen3-14b:free",
+        "name": "Qwen3 14B (free)",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 40960,
+          "output": 40960
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-28"
+      },
+      "qwen/qwq-32b:free": {
+        "id": "qwen/qwq-32b:free",
+        "name": "QwQ 32B (free)",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-03",
+        "release_date": "2025-03-05"
+      },
+      "qwen/qwen3.5-plus-02-15": {
+        "id": "qwen/qwen3.5-plus-02-15",
+        "name": "Qwen3.5 Plus 2026-02-15",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.4,
+          "output": 2.4
+        },
+        "knowledge": "2025-04",
+        "release_date": "2026-02-16"
+      },
+      "qwen/qwen3-next-80b-a3b-instruct": {
+        "id": "qwen/qwen3-next-80b-a3b-instruct",
+        "name": "Qwen3 Next 80B A3B Instruct",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.14,
+          "output": 1.4
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-09-11"
+      },
+      "qwen/qwen2.5-vl-72b-instruct": {
+        "id": "qwen/qwen2.5-vl-72b-instruct",
+        "name": "Qwen2.5 VL 72B Instruct",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-02-01"
+      },
+      "qwen/qwen3-4b:free": {
+        "id": "qwen/qwen3-4b:free",
+        "name": "Qwen3 4B (free)",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 40960,
+          "output": 40960
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-30"
+      },
+      "qwen/qwen-2.5-vl-7b-instruct:free": {
+        "id": "qwen/qwen-2.5-vl-7b-instruct:free",
+        "name": "Qwen2.5-VL 7B Instruct (free)",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-02",
+        "release_date": "2024-08-28"
+      },
+      "qwen/qwen3-235b-a22b-07-25": {
+        "id": "qwen/qwen3-235b-a22b-07-25",
+        "name": "Qwen3 235B A22B Instruct 2507",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.15,
+          "output": 0.85
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-28"
+      },
+      "qwen/qwen3-next-80b-a3b-thinking": {
+        "id": "qwen/qwen3-next-80b-a3b-thinking",
+        "name": "Qwen3 Next 80B A3B Thinking",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.14,
+          "output": 1.4
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-09-11"
+      },
+      "qwen/qwen3-235b-a22b-07-25:free": {
+        "id": "qwen/qwen3-235b-a22b-07-25:free",
+        "name": "Qwen3 235B A22B Instruct 2507 (free)",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-28"
+      },
+      "qwen/qwen-2.5-coder-32b-instruct": {
+        "id": "qwen/qwen-2.5-coder-32b-instruct",
+        "name": "Qwen2.5 Coder 32B Instruct",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2024-11-11"
+      },
+      "qwen/qwen3-30b-a3b-instruct-2507": {
+        "id": "qwen/qwen3-30b-a3b-instruct-2507",
+        "name": "Qwen3 30B A3B Instruct 2507",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262000,
+          "output": 262000
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 0.8
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-29"
+      },
+      "qwen/qwen3-max": {
+        "id": "qwen/qwen3-max",
+        "name": "Qwen3 Max",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        },
+        "cost": {
+          "input": 1.2,
+          "output": 6
+        },
+        "release_date": "2025-09-05"
+      },
+      "qwen/qwen3-coder": {
+        "id": "qwen/qwen3-coder",
+        "name": "Qwen3 Coder",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 66536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-23"
+      },
+      "qwen/qwen3.5-397b-a17b": {
+        "id": "qwen/qwen3.5-397b-a17b",
+        "name": "Qwen3.5 397B A17B",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 3.6
+        },
+        "knowledge": "2025-04",
+        "release_date": "2026-02-16"
+      },
+      "qwen/qwen3-235b-a22b:free": {
+        "id": "qwen/qwen3-235b-a22b:free",
+        "name": "Qwen3 235B A22B (free)",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-28"
+      },
+      "qwen/qwen3-coder-flash": {
+        "id": "qwen/qwen3-coder-flash",
+        "name": "Qwen3 Coder Flash",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 66536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 1.5
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-23"
+      },
+      "qwen/qwen3-8b:free": {
+        "id": "qwen/qwen3-8b:free",
+        "name": "Qwen3 8B (free)",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 40960,
+          "output": 40960
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-28"
+      },
+      "qwen/qwen2.5-vl-32b-instruct:free": {
+        "id": "qwen/qwen2.5-vl-32b-instruct:free",
+        "name": "Qwen2.5 VL 32B Instruct (free)",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-03",
+        "release_date": "2025-03-24"
+      },
+      "qwen/qwen3-next-80b-a3b-instruct:free": {
+        "id": "qwen/qwen3-next-80b-a3b-instruct:free",
+        "name": "Qwen3 Next 80B A3B Instruct (free)",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-09-11"
+      },
+      "qwen/qwen3-coder:exacto": {
+        "id": "qwen/qwen3-coder:exacto",
+        "name": "Qwen3 Coder (exacto)",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.38,
+          "output": 1.53
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-23"
+      },
+      "qwen/qwen3-30b-a3b-thinking-2507": {
+        "id": "qwen/qwen3-30b-a3b-thinking-2507",
+        "name": "Qwen3 30B A3B Thinking 2507",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262000,
+          "output": 262000
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 0.8
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-29"
+      },
+      "qwen/qwen2.5-vl-72b-instruct:free": {
+        "id": "qwen/qwen2.5-vl-72b-instruct:free",
+        "name": "Qwen2.5 VL 72B Instruct (free)",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-02",
+        "release_date": "2025-02-01"
+      },
+      "qwen/qwen3-coder-30b-a3b-instruct": {
+        "id": "qwen/qwen3-coder-30b-a3b-instruct",
+        "name": "Qwen3 Coder 30B A3B Instruct",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 160000,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.07,
+          "output": 0.27
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-31"
+      },
+      "qwen/qwen3-30b-a3b:free": {
+        "id": "qwen/qwen3-30b-a3b:free",
+        "name": "Qwen3 30B A3B (free)",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 40960,
+          "output": 40960
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-28"
+      },
+      "qwen/qwen3-235b-a22b-thinking-2507": {
+        "id": "qwen/qwen3-235b-a22b-thinking-2507",
+        "name": "Qwen3 235B A22B Thinking 2507",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 81920
+        },
+        "cost": {
+          "input": 0.078,
+          "output": 0.312
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-25"
+      },
+      "allenai/molmo-2-8b:free": {
+        "id": "allenai/molmo-2-8b:free",
+        "name": "Molmo2 8B (free)",
+        "family": "allenai",
+        "reasoning": true,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 36864,
+          "output": 36864
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2026-01-09"
+      },
+      "liquid/lfm-2.5-1.2b-thinking:free": {
+        "id": "liquid/lfm-2.5-1.2b-thinking:free",
+        "name": "LFM2.5-1.2B-Thinking (free)",
+        "family": "liquid",
+        "reasoning": true,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2026-01-20"
+      },
+      "liquid/lfm-2.5-1.2b-instruct:free": {
+        "id": "liquid/lfm-2.5-1.2b-instruct:free",
+        "name": "LFM2.5-1.2B-Instruct (free)",
+        "family": "liquid",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2026-01-20"
+      },
+      "z-ai/glm-5": {
+        "id": "z-ai/glm-5",
+        "name": "GLM-5",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 202752,
+          "output": 131000
+        },
+        "cost": {
+          "input": 1,
+          "output": 3.2,
+          "cache_read": 0.2
+        },
+        "release_date": "2026-02-12"
+      },
+      "z-ai/glm-4.5": {
+        "id": "z-ai/glm-4.5",
+        "name": "GLM 4.5",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 96000
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.2
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-28"
+      },
+      "z-ai/glm-4.5-air": {
+        "id": "z-ai/glm-4.5-air",
+        "name": "GLM 4.5 Air",
+        "family": "glm-air",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 96000
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 1.1
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-28"
+      },
+      "z-ai/glm-4.5v": {
+        "id": "z-ai/glm-4.5v",
+        "name": "GLM 4.5V",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 64000,
+          "output": 16384
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 1.8
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-08-11"
+      },
+      "z-ai/glm-4.6:exacto": {
+        "id": "z-ai/glm-4.6:exacto",
+        "name": "GLM 4.6 (exacto)",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 1.9,
+          "cache_read": 0.11
+        },
+        "knowledge": "2025-09",
+        "release_date": "2025-09-30"
+      },
+      "z-ai/glm-4.7-flash": {
+        "id": "z-ai/glm-4.7-flash",
+        "name": "GLM-4.7-Flash",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 65535
+        },
+        "cost": {
+          "input": 0.07,
+          "output": 0.4
+        },
+        "release_date": "2026-01-19"
+      },
+      "z-ai/glm-4.5-air:free": {
+        "id": "z-ai/glm-4.5-air:free",
+        "name": "GLM 4.5 Air (free)",
+        "family": "glm-air",
+        "reasoning": true,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 96000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-28"
+      },
+      "z-ai/glm-4.7": {
+        "id": "z-ai/glm-4.7",
+        "name": "GLM-4.7",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.2,
+          "cache_read": 0.11
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-12-22"
+      },
+      "z-ai/glm-4.6": {
+        "id": "z-ai/glm-4.6",
+        "name": "GLM 4.6",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 200000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.2,
+          "cache_read": 0.11
+        },
+        "knowledge": "2025-09",
+        "release_date": "2025-09-30"
+      },
+      "microsoft/mai-ds-r1:free": {
+        "id": "microsoft/mai-ds-r1:free",
+        "name": "MAI DS R1 (free)",
+        "family": "mai",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 163840
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-21"
+      },
+      "google/gemini-3.1-pro-preview-customtools": {
+        "id": "google/gemini-3.1-pro-preview-customtools",
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "reasoning": 12
+        },
+        "knowledge": "2025-01",
+        "release_date": "2026-02-19"
+      },
+      "google/gemini-2.5-pro": {
+        "id": "google/gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.31
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-03-20"
+      },
+      "google/gemini-2.5-flash": {
+        "id": "google/gemini-2.5-flash",
+        "name": "Gemini 2.5 Flash",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.0375
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-07-17"
+      },
+      "google/gemini-2.0-flash-exp:free": {
+        "id": "google/gemini-2.0-flash-exp:free",
+        "name": "Gemini 2.0 Flash Experimental (free)",
+        "family": "gemini-flash",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 1048576
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-12",
+        "release_date": "2024-12-11"
+      },
+      "google/gemini-2.5-pro-preview-05-06": {
+        "id": "google/gemini-2.5-pro-preview-05-06",
+        "name": "Gemini 2.5 Pro Preview 05-06",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.31
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-05-06"
+      },
+      "google/gemma-3-4b-it:free": {
+        "id": "google/gemma-3-4b-it:free",
+        "name": "Gemma 3 4B (free)",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-13"
+      },
+      "google/gemma-2-9b-it": {
+        "id": "google/gemma-2-9b-it",
+        "name": "Gemma 2 9B",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.03,
+          "output": 0.09
+        },
+        "knowledge": "2024-06",
+        "release_date": "2024-06-28"
+      },
+      "google/gemini-3-flash-preview": {
+        "id": "google/gemini-3-flash-preview",
+        "name": "Gemini 3 Flash Preview",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.5,
+          "output": 3,
+          "cache_read": 0.05
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-12-17"
+      },
+      "google/gemini-3-pro-preview": {
+        "id": "google/gemini-3-pro-preview",
+        "name": "Gemini 3 Pro Preview",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1050000,
+          "output": 66000
+        },
+        "cost": {
+          "input": 2,
+          "output": 12
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-11-18"
+      },
+      "google/gemini-3.1-pro-preview": {
+        "id": "google/gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "reasoning": 12
+        },
+        "knowledge": "2025-01",
+        "release_date": "2026-02-19"
+      },
+      "google/gemma-3-27b-it:free": {
+        "id": "google/gemma-3-27b-it:free",
+        "name": "Gemma 3 27B (free)",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-12"
+      },
+      "google/gemma-3n-e4b-it": {
+        "id": "google/gemma-3n-e4b-it",
+        "name": "Gemma 3n 4B",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.02,
+          "output": 0.04
+        },
+        "knowledge": "2024-06",
+        "release_date": "2025-05-20"
+      },
+      "google/gemma-3n-e2b-it:free": {
+        "id": "google/gemma-3n-e2b-it:free",
+        "name": "Gemma 3n 2B (free)",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 2000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-06",
+        "release_date": "2025-07-09"
+      },
+      "google/gemini-2.5-flash-lite": {
+        "id": "google/gemini-2.5-flash-lite",
+        "name": "Gemini 2.5 Flash Lite",
+        "family": "gemini-flash-lite",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-06-17"
+      },
+      "google/gemma-3-4b-it": {
+        "id": "google/gemma-3-4b-it",
+        "name": "Gemma 3 4B",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 96000,
+          "output": 96000
+        },
+        "cost": {
+          "input": 0.01703,
+          "output": 0.06815
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-13"
+      },
+      "google/gemini-2.5-pro-preview-06-05": {
+        "id": "google/gemini-2.5-pro-preview-06-05",
+        "name": "Gemini 2.5 Pro Preview 06-05",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.31
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-06-05"
+      },
+      "google/gemma-3n-e4b-it:free": {
+        "id": "google/gemma-3n-e4b-it:free",
+        "name": "Gemma 3n 4B (free)",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 8192,
+          "output": 2000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-06",
+        "release_date": "2025-05-20"
+      },
+      "google/gemini-2.5-flash-preview-09-2025": {
+        "id": "google/gemini-2.5-flash-preview-09-2025",
+        "name": "Gemini 2.5 Flash Preview 09-25",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.031
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-09-25"
+      },
+      "google/gemma-3-12b-it": {
+        "id": "google/gemma-3-12b-it",
+        "name": "Gemma 3 12B",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.03,
+          "output": 0.1
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-13"
+      },
+      "google/gemini-2.0-flash-001": {
+        "id": "google/gemini-2.0-flash-001",
+        "name": "Gemini 2.0 Flash",
+        "family": "gemini-flash",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "knowledge": "2024-06",
+        "release_date": "2024-12-11"
+      },
+      "google/gemma-3-27b-it": {
+        "id": "google/gemma-3-27b-it",
+        "name": "Gemma 3 27B",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 96000,
+          "output": 96000
+        },
+        "cost": {
+          "input": 0.04,
+          "output": 0.15
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-12"
+      },
+      "google/gemma-3-12b-it:free": {
+        "id": "google/gemma-3-12b-it:free",
+        "name": "Gemma 3 12B (free)",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-13"
+      },
+      "google/gemini-2.5-flash-lite-preview-09-2025": {
+        "id": "google/gemini-2.5-flash-lite-preview-09-2025",
+        "name": "Gemini 2.5 Flash Lite Preview 09-25",
+        "family": "gemini-flash-lite",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "audio", "video", "pdf"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-09-25"
+      },
+      "thudm/glm-z1-32b:free": {
+        "id": "thudm/glm-z1-32b:free",
+        "name": "GLM Z1 32B (free)",
+        "family": "glm-z",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-04-17"
+      },
+      "openrouter/sherlock-think-alpha": {
+        "id": "openrouter/sherlock-think-alpha",
+        "name": "Sherlock Think Alpha",
+        "family": "sherlock",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1840000,
+          "output": 0
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-11",
+        "release_date": "2025-11-15"
+      },
+      "openrouter/aurora-alpha": {
+        "id": "openrouter/aurora-alpha",
+        "name": "Aurora Alpha",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 50000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "release_date": "2026-02-09"
+      },
+      "openrouter/sherlock-dash-alpha": {
+        "id": "openrouter/sherlock-dash-alpha",
+        "name": "Sherlock Dash Alpha",
+        "family": "sherlock",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1840000,
+          "output": 0
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-11",
+        "release_date": "2025-11-15"
+      },
+      "sarvamai/sarvam-m:free": {
+        "id": "sarvamai/sarvam-m:free",
+        "name": "Sarvam-M (free)",
+        "family": "sarvam",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-05-25"
+      },
+      "moonshotai/kimi-k2-0905:exacto": {
+        "id": "moonshotai/kimi-k2-0905:exacto",
+        "name": "Kimi K2 Instruct 0905 (exacto)",
+        "family": "kimi",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 16384
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.5
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-09-05"
+      },
+      "moonshotai/kimi-k2-0905": {
+        "id": "moonshotai/kimi-k2-0905",
+        "name": "Kimi K2 Instruct 0905",
+        "family": "kimi",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 16384
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.5
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-09-05"
+      },
+      "moonshotai/kimi-k2:free": {
+        "id": "moonshotai/kimi-k2:free",
+        "name": "Kimi K2 (free)",
+        "family": "kimi",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32800,
+          "output": 32800
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-04",
+        "release_date": "2025-07-11"
+      },
+      "moonshotai/kimi-k2-thinking": {
+        "id": "moonshotai/kimi-k2-thinking",
+        "name": "Kimi K2 Thinking",
+        "family": "kimi-thinking",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.5,
+          "cache_read": 0.15
+        },
+        "knowledge": "2024-08",
+        "release_date": "2025-11-06"
+      },
+      "moonshotai/kimi-dev-72b:free": {
+        "id": "moonshotai/kimi-dev-72b:free",
+        "name": "Kimi Dev 72b (free)",
+        "family": "kimi",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-06-16"
+      },
+      "moonshotai/kimi-k2": {
+        "id": "moonshotai/kimi-k2",
+        "name": "Kimi K2",
+        "family": "kimi",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.55,
+          "output": 2.2
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-07-11"
+      },
+      "moonshotai/kimi-k2.5": {
+        "id": "moonshotai/kimi-k2.5",
+        "name": "Kimi K2.5",
+        "family": "kimi",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 3,
+          "cache_read": 0.1
+        },
+        "knowledge": "2025-01",
+        "release_date": "2026-01-27"
+      },
+      "mistralai/devstral-small-2505": {
+        "id": "mistralai/devstral-small-2505",
+        "name": "Devstral Small",
+        "family": "devstral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.06,
+          "output": 0.12
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-05-07"
+      },
+      "mistralai/mistral-7b-instruct:free": {
+        "id": "mistralai/mistral-7b-instruct:free",
+        "name": "Mistral 7B Instruct (free)",
+        "family": "mistral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-05",
+        "release_date": "2024-05-27"
+      },
+      "mistralai/mistral-small-3.2-24b-instruct:free": {
+        "id": "mistralai/mistral-small-3.2-24b-instruct:free",
+        "name": "Mistral Small 3.2 24B (free)",
+        "family": "mistral-small",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 96000,
+          "output": 96000
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-06-20"
+      },
+      "mistralai/devstral-medium-2507": {
+        "id": "mistralai/devstral-medium-2507",
+        "name": "Devstral Medium",
+        "family": "devstral",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-07-10"
+      },
+      "mistralai/mistral-small-3.1-24b-instruct": {
+        "id": "mistralai/mistral-small-3.1-24b-instruct",
+        "name": "Mistral Small 3.1 24B Instruct",
+        "family": "mistral-small",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 128000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-03-17"
+      },
+      "mistralai/mistral-nemo:free": {
+        "id": "mistralai/mistral-nemo:free",
+        "name": "Mistral Nemo (free)",
+        "family": "mistral-nemo",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-07",
+        "release_date": "2024-07-19"
+      },
+      "mistralai/mistral-small-3.2-24b-instruct": {
+        "id": "mistralai/mistral-small-3.2-24b-instruct",
+        "name": "Mistral Small 3.2 24B Instruct",
+        "family": "mistral-small",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 96000,
+          "output": 8192
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-06-20"
+      },
+      "mistralai/devstral-2512": {
+        "id": "mistralai/devstral-2512",
+        "name": "Devstral 2 2512",
+        "family": "devstral",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "knowledge": "2025-12",
+        "release_date": "2025-09-12"
+      },
+      "mistralai/mistral-medium-3.1": {
+        "id": "mistralai/mistral-medium-3.1",
+        "name": "Mistral Medium 3.1",
+        "family": "mistral-medium",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-08-12"
+      },
+      "mistralai/devstral-small-2505:free": {
+        "id": "mistralai/devstral-small-2505:free",
+        "name": "Devstral Small 2505 (free)",
+        "family": "devstral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-05-21"
+      },
+      "mistralai/codestral-2508": {
+        "id": "mistralai/codestral-2508",
+        "name": "Codestral 2508",
+        "family": "codestral",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 256000,
+          "output": 256000
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 0.9
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-08-01"
+      },
+      "mistralai/devstral-2512:free": {
+        "id": "mistralai/devstral-2512:free",
+        "name": "Devstral 2 2512 (free)",
+        "family": "devstral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-12",
+        "release_date": "2025-09-12"
+      },
+      "mistralai/devstral-small-2507": {
+        "id": "mistralai/devstral-small-2507",
+        "name": "Devstral Small 1.1",
+        "family": "devstral",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.1,
+          "output": 0.3
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-07-10"
+      },
+      "mistralai/mistral-medium-3": {
+        "id": "mistralai/mistral-medium-3",
+        "name": "Mistral Medium 3",
+        "family": "mistral-medium",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "knowledge": "2025-05",
+        "release_date": "2025-05-07"
+      },
+      "kwaipilot/kat-coder-pro:free": {
+        "id": "kwaipilot/kat-coder-pro:free",
+        "name": "Kat Coder Pro (free)",
+        "family": "kat-coder",
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 256000,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-11",
+        "release_date": "2025-11-10"
+      },
+      "bytedance-seed/seedream-4.5": {
+        "id": "bytedance-seed/seedream-4.5",
+        "name": "Seedream 4.5",
+        "family": "seed",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": false,
+        "modalities": {
+          "input": ["image", "text"],
+          "output": ["image"]
+        },
+        "limit": {
+          "context": 4096,
+          "output": 4096
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-06",
+        "release_date": "2025-12-23"
+      },
+      "tngtech/tng-r1t-chimera:free": {
+        "id": "tngtech/tng-r1t-chimera:free",
+        "name": "R1T Chimera (free)",
+        "family": "tngtech",
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 163840
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-07",
+        "release_date": "2025-11-26"
+      },
+      "tngtech/deepseek-r1t2-chimera:free": {
+        "id": "tngtech/deepseek-r1t2-chimera:free",
+        "name": "DeepSeek R1T2 Chimera (free)",
+        "family": "deepseek-thinking",
+        "reasoning": true,
+        "tool_call": false,
+        "structured_output": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 163840
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        },
+        "knowledge": "2025-07",
+        "release_date": "2025-07-08"
+      }
+    }
+  },
+  "ollama": {
+    "id": "ollama",
+    "name": "Ollama Cloud",
+    "models": {
+      "gpt-oss:20b": {
+        "id": "gpt-oss:20b",
+        "name": "gpt-oss:20b",
+        "family": "gpt-oss",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "release_date": "2025-08-05"
+      },
+      "glm-5": {
+        "id": "glm-5",
+        "name": "glm-5",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 202752,
+          "output": 131072
+        },
+        "release_date": "2026-02-11"
+      },
+      "deepseek-v3.1:671b": {
+        "id": "deepseek-v3.1:671b",
+        "name": "deepseek-v3.1:671b",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 163840
+        },
+        "release_date": "2025-08-21"
+      },
+      "devstral-small-2:24b": {
+        "id": "devstral-small-2:24b",
+        "name": "devstral-small-2:24b",
+        "family": "devstral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "release_date": "2025-12-09"
+      },
+      "minimax-m2": {
+        "id": "minimax-m2",
+        "name": "minimax-m2",
+        "family": "minimax",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 204800,
+          "output": 128000
+        },
+        "release_date": "2025-10-23"
+      },
+      "qwen3.5:397b": {
+        "id": "qwen3.5:397b",
+        "name": "qwen3.5:397b",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 81920
+        },
+        "release_date": "2026-02-15"
+      },
+      "minimax-m2.5": {
+        "id": "minimax-m2.5",
+        "name": "minimax-m2.5",
+        "family": "minimax",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "knowledge": "2025-01",
+        "release_date": "2026-02-12"
+      },
+      "ministral-3:3b": {
+        "id": "ministral-3:3b",
+        "name": "ministral-3:3b",
+        "family": "ministral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 128000
+        },
+        "release_date": "2024-10-22"
+      },
+      "gemma3:4b": {
+        "id": "gemma3:4b",
+        "name": "gemma3:4b",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "release_date": "2024-12-01"
+      },
+      "gemma3:12b": {
+        "id": "gemma3:12b",
+        "name": "gemma3:12b",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "release_date": "2024-12-01"
+      },
+      "qwen3-vl:235b": {
+        "id": "qwen3-vl:235b",
+        "name": "qwen3-vl:235b",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        },
+        "release_date": "2025-09-22"
+      },
+      "rnj-1:8b": {
+        "id": "rnj-1:8b",
+        "name": "rnj-1:8b",
+        "family": "rnj",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 32768,
+          "output": 4096
+        },
+        "release_date": "2025-12-06"
+      },
+      "nemotron-3-nano:30b": {
+        "id": "nemotron-3-nano:30b",
+        "name": "nemotron-3-nano:30b",
+        "family": "nemotron",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        },
+        "release_date": "2025-12-15"
+      },
+      "gemini-3-flash-preview": {
+        "id": "gemini-3-flash-preview",
+        "name": "gemini-3-flash-preview",
+        "family": "gemini-flash",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "knowledge": "2025-01",
+        "release_date": "2025-12-17"
+      },
+      "gemini-3-pro-preview": {
+        "id": "gemini-3-pro-preview",
+        "name": "gemini-3-pro-preview",
+        "family": "gemini-pro",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 1048576,
+          "output": 64000
+        },
+        "release_date": "2025-11-18"
+      },
+      "qwen3-next:80b": {
+        "id": "qwen3-next:80b",
+        "name": "qwen3-next:80b",
+        "family": "qwen",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        },
+        "release_date": "2025-09-15"
+      },
+      "kimi-k2-thinking": {
+        "id": "kimi-k2-thinking",
+        "name": "kimi-k2-thinking",
+        "family": "kimi-thinking",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "knowledge": "2024-08",
+        "release_date": "2025-11-06"
+      },
+      "qwen3-vl:235b-instruct": {
+        "id": "qwen3-vl:235b-instruct",
+        "name": "qwen3-vl:235b-instruct",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        },
+        "release_date": "2025-09-22"
+      },
+      "deepseek-v3.2": {
+        "id": "deepseek-v3.2",
+        "name": "deepseek-v3.2",
+        "family": "deepseek",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 65536
+        },
+        "release_date": "2025-06-15"
+      },
+      "gemma3:27b": {
+        "id": "gemma3:27b",
+        "name": "gemma3:27b",
+        "family": "gemma",
+        "reasoning": false,
+        "tool_call": false,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 131072
+        },
+        "release_date": "2025-07-27"
+      },
+      "gpt-oss:120b": {
+        "id": "gpt-oss:120b",
+        "name": "gpt-oss:120b",
+        "family": "gpt-oss",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 131072,
+          "output": 32768
+        },
+        "release_date": "2025-08-05"
+      },
+      "devstral-2:123b": {
+        "id": "devstral-2:123b",
+        "name": "devstral-2:123b",
+        "family": "devstral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "release_date": "2025-12-09"
+      },
+      "minimax-m2.1": {
+        "id": "minimax-m2.1",
+        "name": "minimax-m2.1",
+        "family": "minimax",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "release_date": "2025-12-23"
+      },
+      "ministral-3:8b": {
+        "id": "ministral-3:8b",
+        "name": "ministral-3:8b",
+        "family": "ministral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 128000
+        },
+        "release_date": "2024-12-01"
+      },
+      "qwen3-coder-next": {
+        "id": "qwen3-coder-next",
+        "name": "qwen3-coder-next",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        },
+        "release_date": "2026-02-02"
+      },
+      "kimi-k2:1t": {
+        "id": "kimi-k2:1t",
+        "name": "kimi-k2:1t",
+        "family": "kimi",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "knowledge": "2024-10",
+        "release_date": "2025-07-11"
+      },
+      "cogito-2.1:671b": {
+        "id": "cogito-2.1:671b",
+        "name": "cogito-2.1:671b",
+        "family": "cogito",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 163840,
+          "output": 32000
+        },
+        "release_date": "2025-11-19"
+      },
+      "ministral-3:14b": {
+        "id": "ministral-3:14b",
+        "name": "ministral-3:14b",
+        "family": "ministral",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 128000
+        },
+        "release_date": "2024-12-01"
+      },
+      "kimi-k2.5": {
+        "id": "kimi-k2.5",
+        "name": "kimi-k2.5",
+        "family": "kimi",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "release_date": "2026-01-27"
+      },
+      "glm-4.7": {
+        "id": "glm-4.7",
+        "name": "glm-4.7",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 202752,
+          "output": 131072
+        },
+        "release_date": "2025-12-22"
+      },
+      "qwen3-coder:480b": {
+        "id": "qwen3-coder:480b",
+        "name": "qwen3-coder:480b",
+        "family": "qwen",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 65536
+        },
+        "release_date": "2025-07-22"
+      },
+      "mistral-large-3:675b": {
+        "id": "mistral-large-3:675b",
+        "name": "mistral-large-3:675b",
+        "family": "mistral-large",
+        "reasoning": false,
+        "tool_call": true,
+        "attachment": true,
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "release_date": "2025-12-02"
+      },
+      "glm-4.6": {
+        "id": "glm-4.6",
+        "name": "glm-4.6",
+        "family": "glm",
+        "reasoning": true,
+        "tool_call": true,
+        "attachment": false,
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "limit": {
+          "context": 202752,
+          "output": 131072
+        },
+        "release_date": "2025-09-29"
+      }
+    }
+  }
+}

--- a/packages/models-dev/src/registry.ts
+++ b/packages/models-dev/src/registry.ts
@@ -16,10 +16,14 @@ export function getModelDefaults(
   provider: string,
   modelId: string,
 ): ModelInfo | undefined {
-  return registry[provider]?.models[modelId]
+  if (!Object.hasOwn(registry, provider)) return undefined
+  const p = registry[provider]
+  if (!Object.hasOwn(p.models, modelId)) return undefined
+  return p.models[modelId]
 }
 
 export function getProviderModels(provider: string): ProviderInfo | undefined {
+  if (!Object.hasOwn(registry, provider)) return undefined
   return registry[provider]
 }
 

--- a/packages/models-dev/src/registry.ts
+++ b/packages/models-dev/src/registry.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Model registry lookup functions.
+ * Data is sourced from models.dev and pre-built into registry.json.
+ */
+
+import data from './data/registry.json'
+import type { ModelInfo, ModelRegistry, ProviderInfo } from './types'
+
+const registry: ModelRegistry = data as ModelRegistry
+
+export function getModelDefaults(
+  provider: string,
+  modelId: string,
+): ModelInfo | undefined {
+  return registry[provider]?.models[modelId]
+}
+
+export function getProviderModels(provider: string): ProviderInfo | undefined {
+  return registry[provider]
+}
+
+export function getAllProviders(): Record<string, ProviderInfo> {
+  return registry
+}

--- a/packages/models-dev/src/types.ts
+++ b/packages/models-dev/src/types.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Model metadata types sourced from models.dev.
+ */
+
+export interface ModelCost {
+  input: number
+  output: number
+  reasoning?: number
+  cache_read?: number
+  cache_write?: number
+}
+
+export interface ModelInfo {
+  id: string
+  name: string
+  family?: string
+  reasoning: boolean
+  tool_call: boolean
+  structured_output?: boolean
+  attachment: boolean
+  modalities: {
+    input: string[]
+    output: string[]
+  }
+  limit: {
+    context: number
+    input?: number
+    output: number
+  }
+  cost?: ModelCost
+  knowledge?: string
+  status?: 'alpha' | 'beta' | 'deprecated'
+  release_date: string
+}
+
+export interface ProviderInfo {
+  id: string
+  name: string
+  models: Record<string, ModelInfo>
+}
+
+export type ModelRegistry = Record<string, ProviderInfo>

--- a/packages/models-dev/tsconfig.json
+++ b/packages/models-dev/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- New `packages/models-dev` package that ships a pre-built JSON registry of 312 AI models across 5 providers (OpenAI, Anthropic, Google, OpenRouter, Ollama), sourced from the open-source [models.dev](https://models.dev) project
- Server auto-populates `contextWindowSize` and `supportsImages` from the registry when not explicitly provided by the client — no more 200K default for all models
- New `GET /api/models/:provider` endpoint for the UI to fetch model metadata (context window, pricing, capabilities) per provider
- Build script (`bun run generate:models`) reads TOML files from a local models.dev clone and generates the registry JSON — easy to keep in sync with upstream

## Design
Created a standalone `@browseros/models-dev` package with a build-time pipeline: TOML files from models.dev → filtered to 5 target providers → pre-built JSON registry committed to the repo. The registry is imported as a static JSON file at runtime (zero startup cost). The server's `chat-v2-service` uses `getModelDefaults(provider, model)` to resolve model metadata, with fallback to `upstreamProvider` for the browseros meta-provider case. The `supportsImages` Zod default was removed so the registry can properly fill it in when the client doesn't specify it.

## Test plan
- [ ] Run `bun run typecheck` — passes
- [ ] Run `bun run lint` — passes
- [ ] Verify `GET /api/models/anthropic` returns model list with context windows
- [ ] Verify `GET /api/models/openai` returns model list
- [ ] Verify chat with a known model (e.g., `claude-sonnet-4`) auto-populates correct context window
- [ ] Verify chat with an unknown model falls back to existing behavior
- [ ] Run `bun run generate:models -- /path/to/models.dev/providers` to verify build script works

🤖 Generated with [Claude Code](https://claude.com/claude-code)