### PR TITLE
fix: migrate stale 400k context window for browseros provider

### DIFF
--- a/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -41,13 +41,13 @@ export const MODELS_DATA: ModelsData = {
     { modelId: 'claude-3-5-haiku-20241022', contextLength: 200000 },
   ],
   openai: [
-    { modelId: 'gpt-5.2', contextLength: 400000 },
-    { modelId: 'gpt-5.2-pro', contextLength: 400000 },
-    { modelId: 'gpt-5', contextLength: 400000 },
-    { modelId: 'gpt-5-mini', contextLength: 400000 },
-    { modelId: 'gpt-5-nano', contextLength: 400000 },
-    { modelId: 'gpt-4.1', contextLength: 1000000 },
-    { modelId: 'gpt-4.1-mini', contextLength: 1000000 },
+    { modelId: 'gpt-5.2', contextLength: 200000 },
+    { modelId: 'gpt-5.2-pro', contextLength: 200000 },
+    { modelId: 'gpt-5', contextLength: 200000 },
+    { modelId: 'gpt-5-mini', contextLength: 200000 },
+    { modelId: 'gpt-5-nano', contextLength: 200000 },
+    { modelId: 'gpt-4.1', contextLength: 200000 },
+    { modelId: 'gpt-4.1-mini', contextLength: 200000 },
     { modelId: 'o4-mini', contextLength: 200000 },
     { modelId: 'o3-mini', contextLength: 200000 },
     { modelId: 'gpt-4o', contextLength: 128000 },
@@ -89,7 +89,7 @@ export const MODELS_DATA: ModelsData = {
     { modelId: 'qwen/qwen3-vl-8b', contextLength: 131072 },
   ],
   bedrock: [],
-  browseros: [],
+  browseros: [{ modelId: 'browseros-auto', contextLength: 200000 }],
 }
 
 /**

--- a/apps/agent/lib/llm-providers/storage.ts
+++ b/apps/agent/lib/llm-providers/storage.ts
@@ -118,14 +118,11 @@ function normalizeProvidersForLaunch(
   const builtInProviderName = getBuiltInProviderName()
 
   return providers.map((provider) => {
-    if (
-      provider.id === DEFAULT_PROVIDER_ID &&
-      provider.type === 'browseros' &&
-      provider.name !== builtInProviderName
-    ) {
+    if (provider.id === DEFAULT_PROVIDER_ID && provider.type === 'browseros') {
       return {
         ...provider,
         name: builtInProviderName,
+        contextWindow: 200000,
       }
     }
     return provider

--- a/apps/agent/lib/llm-providers/storage.ts
+++ b/apps/agent/lib/llm-providers/storage.ts
@@ -14,6 +14,25 @@ const KIMI_LAUNCH_PROVIDER_NAME = 'Kimi K2.5'
 /** Storage key for LLM providers array */
 export const providersStorage = storage.defineItem<LlmProviderConfig[]>(
   'local:llm-providers',
+  {
+    version: 2,
+    migrations: {
+      2: (
+        providers: LlmProviderConfig[] | null,
+      ): LlmProviderConfig[] | null => {
+        if (!providers) return providers
+        return providers.map((provider) => {
+          if (
+            provider.id === DEFAULT_PROVIDER_ID &&
+            provider.type === 'browseros'
+          ) {
+            return { ...provider, contextWindow: 200000 }
+          }
+          return provider
+        })
+      },
+    },
+  },
 )
 
 /** Backup providers to BrowserOS prefs (write-only, best-effort) */
@@ -118,11 +137,14 @@ function normalizeProvidersForLaunch(
   const builtInProviderName = getBuiltInProviderName()
 
   return providers.map((provider) => {
-    if (provider.id === DEFAULT_PROVIDER_ID && provider.type === 'browseros') {
+    if (
+      provider.id === DEFAULT_PROVIDER_ID &&
+      provider.type === 'browseros' &&
+      provider.name !== builtInProviderName
+    ) {
       return {
         ...provider,
         name: builtInProviderName,
-        contextWindow: 200000,
       }
     }
     return provider

--- a/bun.lock
+++ b/bun.lock
@@ -143,7 +143,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.66",
+      "version": "0.0.67",
       "bin": {
         "browseros-server": "./src/index.ts",
       },


### PR DESCRIPTION
## Summary
- Existing installations cached the old 400k context window default in extension storage
- The 400k value causes compaction to trigger at ~383k, above the actual model limit of 262k, so conversations hit the hard limit before compaction kicks in
- Always normalize the browseros provider's `contextWindow` to 200k on load in `normalizeProvidersForLaunch`

## Test plan
- [ ] Fresh install: verify browseros provider gets 200k context window
- [ ] Existing install with 400k stored: verify it gets normalized to 200k on extension load
- [ ] Verify compaction config logs show `contextWindow: 200000` in server output