### PR TITLE
feat: add codex provider support

### DIFF
--- a/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
@@ -112,6 +112,7 @@ export const AISettingsPage: FC = () => {
       name: template.name,
       baseUrl: template.defaultBaseUrl,
       modelId: template.defaultModelId,
+      authMode: template.defaultAuthMode,
       supportsImages: template.supportsImages,
       contextWindow: template.contextWindow,
       temperature: 0.2,

--- a/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -1,8 +1,17 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { CheckCircle2, ExternalLink, Loader2, XCircle } from 'lucide-react'
-import { type FC, useEffect, useState } from 'react'
+import {
+  CheckCircle2,
+  ExternalLink,
+  Info,
+  Loader2,
+  RefreshCw,
+  TerminalSquare,
+  XCircle,
+} from 'lucide-react'
+import { type FC, useEffect, useEffectEvent, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod/v3'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
@@ -30,17 +39,26 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Feature } from '@/lib/browseros/capabilities'
 import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
 import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import { AI_PROVIDER_ADDED_EVENT } from '@/lib/constants/analyticsEvents'
+import {
+  type CodexStatus,
+  getCodexStatus,
+} from '@/lib/llm-providers/codexStatus'
 import {
   getDefaultBaseUrlForProviders,
   getProviderTemplate,
   providerTypeOptions,
 } from '@/lib/llm-providers/providerTemplates'
 import { type TestResult, testProvider } from '@/lib/llm-providers/testProvider'
-import type { LlmProviderConfig, ProviderType } from '@/lib/llm-providers/types'
+import type {
+  LlmProviderConfig,
+  ProviderAuthMode,
+  ProviderType,
+} from '@/lib/llm-providers/types'
 import { track } from '@/lib/metrics/track'
 import { getModelContextLength, getModelOptions } from './models'
 
@@ -48,6 +66,7 @@ const providerTypeEnum = z.enum([
   'moonshot',
   'anthropic',
   'openai',
+  'codex',
   'openai-compatible',
   'google',
   'openrouter',
@@ -69,6 +88,7 @@ export const providerFormSchema = z
     baseUrl: z.string().optional(),
     modelId: z.string().min(1, 'Model ID is required'),
     apiKey: z.string().optional(),
+    authMode: z.enum(['chatgpt', 'api-key']).optional(),
     supportsImages: z.boolean(),
     contextWindow: z.number().int().min(1000).max(2000000),
     temperature: z.number().min(0).max(2),
@@ -81,6 +101,17 @@ export const providerFormSchema = z
     sessionToken: z.string().optional(),
   })
   .superRefine((data, ctx) => {
+    if (data.type === 'codex') {
+      if (data.authMode === 'api-key' && !data.apiKey) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'API Key is required for Codex API key mode',
+          path: ['apiKey'],
+        })
+      }
+      return
+    }
+
     // Azure: require either resourceName or baseUrl
     if (data.type === 'azure') {
       if (!data.resourceName && !data.baseUrl) {
@@ -159,6 +190,67 @@ export interface NewProviderDialogProps {
   onSave: (provider: LlmProviderConfig) => Promise<void>
 }
 
+function getDefaultAuthMode(
+  provider?: Partial<LlmProviderConfig>,
+): ProviderAuthMode | undefined {
+  if (provider?.type !== 'codex') {
+    return provider?.authMode
+  }
+
+  return provider.authMode || 'chatgpt'
+}
+
+function buildProviderPayload(values: ProviderFormValues): ProviderFormValues {
+  if (values.type !== 'codex') {
+    return values
+  }
+
+  if (values.authMode === 'api-key') {
+    return {
+      ...values,
+      baseUrl: undefined,
+    }
+  }
+
+  return {
+    ...values,
+    apiKey: undefined,
+    baseUrl: undefined,
+    authMode: 'chatgpt',
+  }
+}
+
+function canTestProvider(values: {
+  type: ProviderType
+  modelId: string
+  authMode?: ProviderAuthMode
+  apiKey?: string
+  baseUrl?: string
+  resourceName?: string
+  accessKeyId?: string
+  secretAccessKey?: string
+  region?: string
+}): boolean {
+  if (!values.modelId) return false
+
+  if (values.type === 'codex') {
+    return values.authMode === 'api-key' ? !!values.apiKey : true
+  }
+  if (values.type === 'azure') {
+    return !!(values.resourceName || values.baseUrl) && !!values.apiKey
+  }
+  if (values.type === 'bedrock') {
+    return !!(values.accessKeyId && values.secretAccessKey && values.region)
+  }
+
+  if (!values.baseUrl) return false
+  if (!['ollama', 'lmstudio'].includes(values.type) && !values.apiKey) {
+    return false
+  }
+
+  return true
+}
+
 /**
  * Dialog for configuring a new LLM provider
  * @public
@@ -172,6 +264,9 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   const [isCustomModel, setIsCustomModel] = useState(false)
   const [isTesting, setIsTesting] = useState(false)
   const [testResult, setTestResult] = useState<TestResult | null>(null)
+  const [codexStatus, setCodexStatus] = useState<CodexStatus | null>(null)
+  const [codexStatusError, setCodexStatusError] = useState<string | null>(null)
+  const [isCodexStatusLoading, setIsCodexStatusLoading] = useState(false)
   const { supports } = useCapabilities()
   const { baseUrl: agentServerUrl } = useAgentServerUrl()
 
@@ -188,9 +283,11 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
       type: initialValues?.type || 'openai',
       name: initialValues?.name || '',
       baseUrl:
-        initialValues?.baseUrl || getDefaultBaseUrlForProviders('openai'),
+        initialValues?.baseUrl ||
+        getDefaultBaseUrlForProviders(initialValues?.type || 'openai'),
       modelId: initialValues?.modelId || '',
       apiKey: initialValues?.apiKey || '',
+      authMode: getDefaultAuthMode(initialValues),
       supportsImages: initialValues?.supportsImages ?? false,
       contextWindow: initialValues?.contextWindow || 128000,
       temperature: initialValues?.temperature ?? 0.2,
@@ -206,6 +303,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
 
   const watchedType = form.watch('type')
   const watchedModelId = form.watch('modelId')
+  const watchedAuthMode = form.watch('authMode')
 
   // Watch credential fields to clear test result when they change
   const watchedApiKey = form.watch('apiKey')
@@ -224,6 +322,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     watchedType,
     watchedModelId,
     watchedApiKey,
+    watchedAuthMode,
     watchedBaseUrl,
     watchedResourceName,
     watchedAccessKeyId,
@@ -232,8 +331,39 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     watchedSessionToken,
   ])
 
+  const resolvedCodexAuthMode =
+    watchedType === 'codex'
+      ? ((watchedAuthMode || 'chatgpt') as ProviderAuthMode)
+      : undefined
+
   // Get model options for current provider type
-  const modelOptions = getModelOptions(watchedType as ProviderType)
+  const modelOptions = getModelOptions(
+    watchedType as ProviderType,
+    resolvedCodexAuthMode,
+  )
+
+  const refreshCodexStatus = useEffectEvent(async () => {
+    if (!agentServerUrl) {
+      setCodexStatus(null)
+      setCodexStatusError('Server URL not available')
+      return
+    }
+
+    setIsCodexStatusLoading(true)
+    setCodexStatusError(null)
+
+    try {
+      const nextStatus = await getCodexStatus(agentServerUrl)
+      setCodexStatus(nextStatus)
+    } catch (error) {
+      setCodexStatus(null)
+      setCodexStatusError(
+        error instanceof Error ? error.message : 'Failed to load Codex status',
+      )
+    } finally {
+      setIsCodexStatusLoading(false)
+    }
+  })
 
   // Handle provider type change (user-initiated via Select)
   const handleTypeChange = (newType: ProviderType) => {
@@ -241,9 +371,36 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     const defaultUrl = getDefaultBaseUrlForProviders(newType)
     if (defaultUrl) {
       form.setValue('baseUrl', defaultUrl)
+    } else {
+      form.setValue('baseUrl', '')
     }
+    form.setValue('authMode', newType === 'codex' ? 'chatgpt' : undefined)
     form.setValue('modelId', '')
     setIsCustomModel(false)
+  }
+
+  const handleCodexAuthModeChange = (authMode: ProviderAuthMode) => {
+    form.setValue('authMode', authMode)
+
+    if (watchedType !== 'codex' || isCustomModel) return
+
+    const nextModelOptions = getModelOptions('codex', authMode).filter(
+      (modelId) => modelId !== 'custom',
+    )
+
+    if (!watchedModelId || nextModelOptions.includes(watchedModelId)) {
+      return
+    }
+
+    const nextModelId = nextModelOptions[0] || ''
+    form.setValue('modelId', nextModelId)
+
+    if (!nextModelId) return
+
+    const contextLength = getModelContextLength('codex', nextModelId, authMode)
+    if (contextLength) {
+      form.setValue('contextWindow', contextLength)
+    }
   }
 
   // Auto-fill context window when model changes (only for new providers)
@@ -254,12 +411,19 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
       const contextLength = getModelContextLength(
         watchedType as ProviderType,
         watchedModelId,
+        resolvedCodexAuthMode,
       )
       if (contextLength) {
         form.setValue('contextWindow', contextLength)
       }
     }
-  }, [watchedModelId, watchedType, form, initialValues?.id])
+  }, [
+    watchedModelId,
+    watchedType,
+    resolvedCodexAuthMode,
+    form,
+    initialValues?.id,
+  ])
 
   // Handle model selection (including custom option)
   const handleModelChange = (value: string) => {
@@ -283,6 +447,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
           getDefaultBaseUrlForProviders(initialValues.type || 'openai'),
         modelId: initialValues.modelId || '',
         apiKey: initialValues.apiKey || '',
+        authMode: getDefaultAuthMode(initialValues),
         supportsImages: initialValues.supportsImages ?? false,
         contextWindow: initialValues.contextWindow || 128000,
         temperature: initialValues.temperature ?? 0.2,
@@ -308,6 +473,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         baseUrl: getDefaultBaseUrlForProviders(defaultType),
         modelId: '',
         apiKey: '',
+        authMode: undefined,
         supportsImages: false,
         contextWindow: 128000,
         temperature: 0.2,
@@ -325,11 +491,22 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     setTestResult(null)
   }, [open, initialValues, form])
 
+  useEffect(() => {
+    if (open && watchedType === 'codex') {
+      refreshCodexStatus().catch(() => {})
+      return
+    }
+
+    setCodexStatus(null)
+    setCodexStatusError(null)
+  }, [open, watchedType])
+
   const onSubmit = async (values: ProviderFormValues) => {
     const isNewProvider = !initialValues?.id
+    const normalizedValues = buildProviderPayload(values)
     const provider: LlmProviderConfig = {
       id: initialValues?.id || crypto.randomUUID(),
-      ...values,
+      ...normalizedValues,
       createdAt: initialValues?.createdAt || Date.now(),
       updatedAt: Date.now(),
     }
@@ -337,8 +514,8 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     await onSave(provider)
     if (isNewProvider) {
       track(AI_PROVIDER_ADDED_EVENT, {
-        provider_type: values.type,
-        model: values.modelId,
+        provider_type: normalizedValues.type,
+        model: normalizedValues.modelId,
       })
     }
     form.reset()
@@ -347,20 +524,17 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
 
   // Check if we have enough info to test the connection
   const canTest = (): boolean => {
-    if (!watchedModelId) return false
-
-    if (watchedType === 'azure') {
-      return !!(watchedResourceName || watchedBaseUrl) && !!watchedApiKey
-    }
-    if (watchedType === 'bedrock') {
-      return !!watchedAccessKeyId && !!watchedSecretAccessKey && !!watchedRegion
-    }
-    // Standard providers need baseUrl, most need apiKey (except ollama/lmstudio)
-    if (!watchedBaseUrl) return false
-    if (!['ollama', 'lmstudio'].includes(watchedType) && !watchedApiKey) {
-      return false
-    }
-    return true
+    return canTestProvider({
+      type: watchedType,
+      modelId: watchedModelId,
+      authMode: resolvedCodexAuthMode,
+      apiKey: watchedApiKey,
+      baseUrl: watchedBaseUrl,
+      resourceName: watchedResourceName,
+      accessKeyId: watchedAccessKeyId,
+      secretAccessKey: watchedSecretAccessKey,
+      region: watchedRegion,
+    })
   }
 
   const handleTest = async () => {
@@ -376,7 +550,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     setTestResult(null)
 
     try {
-      const values = form.getValues()
+      const values = buildProviderPayload(form.getValues())
 
       const result = await testProvider(
         {
@@ -386,6 +560,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
           baseUrl: values.baseUrl,
           modelId: values.modelId,
           apiKey: values.apiKey,
+          authMode: values.authMode,
           supportsImages: values.supportsImages,
           contextWindow: values.contextWindow,
           temperature: values.temperature,
@@ -421,12 +596,176 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         ? `${providerName} setup guide`
         : 'Provider setup guide'
 
-  const handleSetupGuideClick = (e: React.MouseEvent) => {
+  const handleSetupGuideClick = (
+    e: React.MouseEvent,
+    url: string | undefined = setupGuideUrl,
+  ) => {
     e.preventDefault()
-    if (setupGuideUrl) chrome.tabs.create({ url: setupGuideUrl })
+    if (url) chrome.tabs.create({ url })
   }
 
   const renderProviderSpecificFields = () => {
+    if (watchedType === 'codex') {
+      const codexAuthMode = (watchedAuthMode || 'chatgpt') as ProviderAuthMode
+      const hasChatGptStatus = !codexStatusError && codexStatus?.canUseChatGpt
+
+      return (
+        <div className="space-y-4 rounded-xl border border-border bg-muted/20 p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h4 className="font-medium text-sm">Codex Authentication</h4>
+              <p className="mt-1 text-muted-foreground text-sm">
+                Use your local Codex ChatGPT login or provide an OpenAI API key.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => refreshCodexStatus().catch(() => {})}
+              disabled={isCodexStatusLoading}
+            >
+              {isCodexStatusLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4" />
+              )}
+              Refresh
+            </Button>
+          </div>
+
+          <FormField
+            control={form.control}
+            name="authMode"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Authentication Method</FormLabel>
+                <FormControl>
+                  <Tabs
+                    value={(field.value || 'chatgpt') as string}
+                    onValueChange={(value) =>
+                      handleCodexAuthModeChange(value as ProviderAuthMode)
+                    }
+                    className="w-full"
+                  >
+                    <TabsList className="grid w-full grid-cols-2">
+                      <TabsTrigger value="chatgpt">
+                        Sign in with ChatGPT
+                      </TabsTrigger>
+                      <TabsTrigger value="api-key">Use API key</TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+                </FormControl>
+                <FormDescription>
+                  ChatGPT mode reuses the local Codex login on this device.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {codexAuthMode === 'chatgpt' ? (
+            <>
+              <Alert
+                className={
+                  hasChatGptStatus
+                    ? 'border-green-200 bg-green-50/70 text-green-900 dark:border-green-900 dark:bg-green-950/40 dark:text-green-100'
+                    : 'border-border bg-background/70'
+                }
+              >
+                <Info />
+                <AlertTitle>Reuse your local Codex login</AlertTitle>
+                <AlertDescription>
+                  <p>
+                    {codexStatus?.message ||
+                      codexStatusError ||
+                      'Run `codex login` on this machine, then refresh the status.'}
+                  </p>
+                  <p className="font-mono text-[11px]">
+                    {codexStatus?.authPath || '~/.codex/auth.json'}
+                  </p>
+                </AlertDescription>
+              </Alert>
+
+              <div className="rounded-lg border border-border border-dashed bg-background/60 p-3">
+                <div className="flex items-center gap-2 font-medium text-sm">
+                  <TerminalSquare className="h-4 w-4 text-[var(--accent-orange)]" />
+                  Terminal setup
+                </div>
+                <div className="mt-2 space-y-1 font-mono text-[11px] text-muted-foreground">
+                  <p>codex login</p>
+                  <p>codex login --device-auth</p>
+                </div>
+                <p className="mt-3 text-muted-foreground text-xs">
+                  BrowserOS reads the Codex login already stored by the CLI on
+                  this machine.{' '}
+                  {setupGuideUrl && (
+                    <a
+                      href={setupGuideUrl}
+                      onClick={(e) => handleSetupGuideClick(e, setupGuideUrl)}
+                      className="inline-flex cursor-pointer items-center gap-1 text-primary hover:underline"
+                    >
+                      <ExternalLink className="h-3 w-3" />
+                      Codex auth guide
+                    </a>
+                  )}
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <Alert className="border-border bg-background/70">
+                <Info />
+                <AlertTitle>Paste an OpenAI API key</AlertTitle>
+                <AlertDescription>
+                  <p>
+                    BrowserOS cannot recover a key from an existing Codex CLI
+                    API-key login. Create or copy a key and paste it below.
+                  </p>
+                  {providerTemplate?.apiKeyUrl && (
+                    <p>
+                      <a
+                        href={providerTemplate.apiKeyUrl}
+                        onClick={(e) =>
+                          handleSetupGuideClick(e, providerTemplate.apiKeyUrl)
+                        }
+                        className="inline-flex cursor-pointer items-center gap-1 text-primary hover:underline"
+                      >
+                        <ExternalLink className="h-3 w-3" />
+                        OpenAI API keys
+                      </a>
+                    </p>
+                  )}
+                </AlertDescription>
+              </Alert>
+
+              <FormField
+                control={form.control}
+                name="apiKey"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>API Key *</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="password"
+                        placeholder="Enter your OpenAI API key"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Stored locally in BrowserOS and not synced to your other
+                      devices.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </>
+          )}
+        </div>
+      )
+    }
+
     if (watchedType === 'azure') {
       return (
         <>
@@ -599,7 +938,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                   {setupGuideUrl && (
                     <a
                       href={setupGuideUrl}
-                      onClick={handleSetupGuideClick}
+                      onClick={(e) => handleSetupGuideClick(e, setupGuideUrl)}
                       className="inline-flex cursor-pointer items-center gap-1 text-primary hover:underline"
                     >
                       <ExternalLink className="h-3 w-3" />

--- a/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -31,6 +31,14 @@ export const ProviderCard: FC<ProviderCardProps> = ({
 }) => {
   const inputId = `provider-${provider.id}`
   const kimiLaunch = useKimiLaunch()
+  const providerDetails =
+    provider.type === 'codex'
+      ? `${provider.modelId} • ${
+          provider.authMode === 'api-key' || provider.apiKey
+            ? 'OpenAI API key'
+            : 'ChatGPT sign-in on this device'
+        }`
+      : `${provider.modelId} • ${provider.baseUrl}`
 
   return (
     <label
@@ -104,7 +112,7 @@ export const ProviderCard: FC<ProviderCardProps> = ({
               </>
             )
           ) : (
-            `${provider.modelId} • ${provider.baseUrl}`
+            providerDetails
           )}
         </p>
       </div>

--- a/apps/agent/entrypoints/app/ai-settings/ProviderTemplateCard.tsx
+++ b/apps/agent/entrypoints/app/ai-settings/ProviderTemplateCard.tsx
@@ -41,6 +41,11 @@ export const ProviderTemplateCard: FC<ProviderTemplateCardProps> = ({
               </span>
             )}
           </div>
+          {template.description && (
+            <p className="mt-1 text-muted-foreground text-xs">
+              {template.description}
+            </p>
+          )}
         </div>
       </div>
       <Badge

--- a/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -1,4 +1,4 @@
-import type { ProviderType } from '@/lib/llm-providers/types'
+import type { ProviderAuthMode, ProviderType } from '@/lib/llm-providers/types'
 
 /**
  * Model information with context length
@@ -6,6 +6,7 @@ import type { ProviderType } from '@/lib/llm-providers/types'
 export interface ModelInfo {
   modelId: string
   contextLength: number
+  authModes?: ProviderAuthMode[]
 }
 
 /**
@@ -14,6 +15,7 @@ export interface ModelInfo {
 export interface ModelsData {
   anthropic: ModelInfo[]
   openai: ModelInfo[]
+  codex: ModelInfo[]
   'openai-compatible': ModelInfo[]
   google: ModelInfo[]
   openrouter: ModelInfo[]
@@ -52,6 +54,26 @@ export const MODELS_DATA: ModelsData = {
     { modelId: 'o3-mini', contextLength: 200000 },
     { modelId: 'gpt-4o', contextLength: 128000 },
     { modelId: 'gpt-4o-mini', contextLength: 128000 },
+  ],
+  codex: [
+    { modelId: 'gpt-5.4', contextLength: 400000 },
+    {
+      modelId: 'gpt-5.3-codex-spark',
+      contextLength: 400000,
+      authModes: ['chatgpt'],
+    },
+    { modelId: 'gpt-5.3-codex', contextLength: 400000 },
+    { modelId: 'gpt-5.2', contextLength: 200000 },
+    {
+      modelId: 'gpt-5',
+      contextLength: 200000,
+      authModes: ['api-key'],
+    },
+    {
+      modelId: 'gpt-5-mini',
+      contextLength: 200000,
+      authModes: ['api-key'],
+    },
   ],
   'openai-compatible': [],
   google: [
@@ -95,15 +117,31 @@ export const MODELS_DATA: ModelsData = {
 /**
  * Get models for a specific provider type
  */
-export function getModelsForProvider(providerType: ProviderType): ModelInfo[] {
-  return MODELS_DATA[providerType] || []
+export function getModelsForProvider(
+  providerType: ProviderType,
+  authMode?: ProviderAuthMode,
+): ModelInfo[] {
+  const models = MODELS_DATA[providerType] || []
+  if (!authMode) {
+    return models
+  }
+
+  return models.filter((model) => {
+    if (!model.authModes?.length) {
+      return true
+    }
+    return model.authModes.includes(authMode)
+  })
 }
 
 /**
  * Get model options for select dropdown (model IDs + custom option)
  */
-export function getModelOptions(providerType: ProviderType): string[] {
-  const models = getModelsForProvider(providerType)
+export function getModelOptions(
+  providerType: ProviderType,
+  authMode?: ProviderAuthMode,
+): string[] {
+  const models = getModelsForProvider(providerType, authMode)
   const modelIds = models.map((m) => m.modelId)
   return modelIds.length > 0 ? [...modelIds, 'custom'] : ['custom']
 }
@@ -114,8 +152,9 @@ export function getModelOptions(providerType: ProviderType): string[] {
 export function getModelContextLength(
   providerType: ProviderType,
   modelId: string,
+  authMode?: ProviderAuthMode,
 ): number | undefined {
-  const models = getModelsForProvider(providerType)
+  const models = getModelsForProvider(providerType, authMode)
   const model = models.find((m) => m.modelId === modelId)
   return model?.contextLength
 }
@@ -126,7 +165,8 @@ export function getModelContextLength(
 export function isCustomModel(
   providerType: ProviderType,
   modelId: string,
+  authMode?: ProviderAuthMode,
 ): boolean {
-  const models = getModelsForProvider(providerType)
+  const models = getModelsForProvider(providerType, authMode)
   return !models.some((m) => m.modelId === modelId)
 }

--- a/apps/agent/entrypoints/app/create-graph/CreateGraph.tsx
+++ b/apps/agent/entrypoints/app/create-graph/CreateGraph.tsx
@@ -221,6 +221,7 @@ export const CreateGraph: FC = () => {
               providerType: provider?.type,
               providerName: provider?.name,
               model: provider?.modelId ?? 'browseros',
+              authMode: provider?.authMode,
               contextWindowSize: provider?.contextWindow,
               temperature: provider?.temperature,
               resourceName: provider?.resourceName,

--- a/apps/agent/entrypoints/app/workflows/useRunWorkflow.ts
+++ b/apps/agent/entrypoints/app/workflows/useRunWorkflow.ts
@@ -54,6 +54,7 @@ export const useRunWorkflow = () => {
             providerType: provider?.type,
             providerName: provider?.name,
             model: provider?.modelId ?? 'browseros',
+            authMode: provider?.authMode,
             contextWindowSize: provider?.contextWindow,
             temperature: provider?.temperature,
             resourceName: provider?.resourceName,

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -288,6 +288,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
             providerType: provider?.type,
             providerName: provider?.name,
             apiKey: provider?.apiKey,
+            authMode: provider?.authMode,
             baseUrl: provider?.baseUrl,
             conversationId: conversationIdRef.current,
             model: provider?.modelId ?? 'default',

--- a/apps/agent/lib/llm-providers/codexStatus.ts
+++ b/apps/agent/lib/llm-providers/codexStatus.ts
@@ -1,0 +1,19 @@
+export interface CodexStatus {
+  isAuthenticated: boolean
+  authMode: 'chatgpt' | 'api-key' | null
+  canUseChatGpt: boolean
+  authPath: string
+  message: string
+}
+
+export async function getCodexStatus(
+  agentServerUrl: string,
+): Promise<CodexStatus> {
+  const response = await fetch(`${agentServerUrl}/codex/status`)
+
+  if (!response.ok) {
+    throw new Error('Failed to load Codex status')
+  }
+
+  return (await response.json()) as CodexStatus
+}

--- a/apps/agent/lib/llm-providers/providerIcons.tsx
+++ b/apps/agent/lib/llm-providers/providerIcons.tsx
@@ -23,6 +23,7 @@ type IconComponent = FC<IconProps>
 const providerIconMap: Record<ProviderType, IconComponent | null> = {
   anthropic: Anthropic,
   openai: OpenAI,
+  codex: OpenAI,
   'openai-compatible': OpenAI,
   google: Gemini,
   openrouter: OpenRouter,

--- a/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -1,4 +1,4 @@
-import type { ProviderType } from './types'
+import type { ProviderAuthMode, ProviderType } from './types'
 
 /**
  * Provider template for quick setup
@@ -9,8 +9,10 @@ export interface ProviderTemplate {
   name: string
   defaultBaseUrl: string
   defaultModelId: string
+  defaultAuthMode?: ProviderAuthMode
   supportsImages: boolean
   contextWindow: number
+  description?: string
   setupGuideUrl?: string
   apiKeyUrl?: string
 }
@@ -40,6 +42,18 @@ export const providerTemplates: ProviderTemplate[] = [
     apiKeyUrl: 'https://platform.openai.com/api-keys',
     setupGuideUrl:
       'https://docs.browseros.com/features/bring-your-own-llm#openai',
+  },
+  {
+    id: 'codex',
+    name: 'Codex',
+    defaultBaseUrl: '',
+    defaultModelId: 'gpt-5.4',
+    defaultAuthMode: 'chatgpt',
+    supportsImages: true,
+    contextWindow: 400000,
+    description: 'Reuse `codex login` or paste an OpenAI API key',
+    setupGuideUrl: 'https://developers.openai.com/codex/auth',
+    apiKeyUrl: 'https://platform.openai.com/api-keys',
   },
   {
     id: 'openai-compatible',
@@ -132,6 +146,7 @@ export const providerTypeOptions: { value: ProviderType; label: string }[] = [
   { value: 'moonshot', label: 'Moonshot AI' },
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'openai', label: 'OpenAI' },
+  { value: 'codex', label: 'Codex' },
   { value: 'openai-compatible', label: 'OpenAI Compatible' },
   { value: 'google', label: 'Gemini' },
   { value: 'openrouter', label: 'OpenRouter' },
@@ -160,6 +175,7 @@ export const DEFAULT_BASE_URLS: Record<ProviderType, string> = {
   moonshot: 'https://api.moonshot.ai/v1',
   anthropic: 'https://api.anthropic.com/v1',
   openai: 'https://api.openai.com/v1',
+  codex: '',
   'openai-compatible': '',
   google: 'https://generativelanguage.googleapis.com/v1beta',
   openrouter: 'https://openrouter.ai/api/v1',

--- a/apps/agent/lib/llm-providers/testProvider.ts
+++ b/apps/agent/lib/llm-providers/testProvider.ts
@@ -28,6 +28,7 @@ export async function testProvider(
         provider: provider.type,
         model: provider.modelId,
         apiKey: provider.apiKey,
+        authMode: provider.authMode,
         baseUrl: provider.baseUrl,
         // Azure
         resourceName: provider.resourceName,

--- a/apps/agent/lib/llm-providers/types.ts
+++ b/apps/agent/lib/llm-providers/types.ts
@@ -5,6 +5,7 @@
 export type ProviderType =
   | 'anthropic'
   | 'openai'
+  | 'codex'
   | 'openai-compatible'
   | 'google'
   | 'openrouter'
@@ -14,6 +15,8 @@ export type ProviderType =
   | 'bedrock'
   | 'browseros'
   | 'moonshot'
+
+export type ProviderAuthMode = 'chatgpt' | 'api-key'
 
 /**
  * LLM Provider configuration
@@ -32,6 +35,8 @@ export interface LlmProviderConfig {
   modelId: string
   /** API key (encrypted and stored locally) */
   apiKey?: string
+  /** Optional auth mode for providers that support multiple credential sources */
+  authMode?: ProviderAuthMode
   /** Whether this provider supports image inputs */
   supportsImages: boolean
   /** Context window size (number of tokens) */

--- a/apps/agent/lib/llm-providers/uploadLlmProvidersToGraphql.ts
+++ b/apps/agent/lib/llm-providers/uploadLlmProvidersToGraphql.ts
@@ -27,6 +27,7 @@ const IGNORED_FIELDS = [
   'createdAt',
   'updatedAt',
   'apiKey',
+  'authMode',
   'accessKeyId',
   'secretAccessKey',
   'sessionToken',

--- a/apps/agent/lib/schedules/getChatServerResponse.ts
+++ b/apps/agent/lib/schedules/getChatServerResponse.ts
@@ -106,6 +106,7 @@ export async function getChatServerResponse(
       providerType: provider?.type,
       providerName: provider?.name,
       apiKey: provider?.apiKey,
+      authMode: provider?.authMode,
       baseUrl: provider?.baseUrl,
       conversationId,
       model: provider?.modelId ?? 'default',

--- a/apps/server/src/agent/tool-loop/provider-factory.ts
+++ b/apps/server/src/agent/tool-loop/provider-factory.ts
@@ -7,6 +7,7 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import type { LanguageModel } from 'ai'
+import { createCodexProvider } from '../../lib/clients/llm/codex-auth'
 import { logger } from '../../lib/logger'
 import { createOpenRouterCompatibleFetch } from '../../lib/openrouter-fetch'
 import type { ResolvedAgentConfig } from '../types'
@@ -27,6 +28,15 @@ function createOpenAIFactory(
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('OpenAI provider requires apiKey')
   return createOpenAI({ apiKey: config.apiKey })
+}
+
+function createCodexFactory(
+  config: ResolvedAgentConfig,
+): (modelId: string) => unknown {
+  return createCodexProvider({
+    apiKey: config.apiKey,
+    authMode: config.authMode,
+  })
 }
 
 function createGoogleFactory(
@@ -151,6 +161,7 @@ function createMoonshotFactory(
 const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.ANTHROPIC]: createAnthropicFactory,
   [LLM_PROVIDERS.OPENAI]: createOpenAIFactory,
+  [LLM_PROVIDERS.CODEX]: createCodexFactory,
   [LLM_PROVIDERS.GOOGLE]: createGoogleFactory,
   [LLM_PROVIDERS.OPENROUTER]: createOpenRouterFactory,
   [LLM_PROVIDERS.AZURE]: createAzureFactory,

--- a/apps/server/src/agent/types.ts
+++ b/apps/server/src/agent/types.ts
@@ -3,12 +3,13 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { LLMProvider } from '@browseros/shared/schemas/llm'
+import type { LLMAuthMode, LLMProvider } from '@browseros/shared/schemas/llm'
 
 export interface ProviderConfig {
   provider: LLMProvider
   model: string
   apiKey?: string
+  authMode?: LLMAuthMode
   baseUrl?: string
   upstreamProvider?: string
   resourceName?: string
@@ -23,6 +24,7 @@ export interface ResolvedAgentConfig {
   provider: LLMProvider
   model: string
   apiKey?: string
+  authMode?: LLMAuthMode
   baseUrl?: string
   upstreamProvider?: string
   resourceName?: string

--- a/apps/server/src/api/routes/codex.ts
+++ b/apps/server/src/api/routes/codex.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Hono } from 'hono'
+import { getCodexStatus } from '../../lib/clients/llm/codex-auth'
+
+export function createCodexRoutes() {
+  return new Hono().get('/status', async (c) => {
+    return c.json(await getCodexStatus())
+  })
+}

--- a/apps/server/src/api/routes/codex.ts
+++ b/apps/server/src/api/routes/codex.ts
@@ -6,9 +6,17 @@
 
 import { Hono } from 'hono'
 import { getCodexStatus } from '../../lib/clients/llm/codex-auth'
+import { logger } from '../../lib/logger'
 
 export function createCodexRoutes() {
   return new Hono().get('/status', async (c) => {
-    return c.json(await getCodexStatus())
+    try {
+      return c.json(await getCodexStatus())
+    } catch (error) {
+      logger.error('Error reading Codex status', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return c.json({ error: 'Failed to read Codex status' }, 500)
+    }
   })
 }

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -17,6 +17,7 @@ import { HttpAgentError } from '../agent/errors'
 import { KlavisClient } from '../lib/clients/klavis/klavis-client'
 import { logger } from '../lib/logger'
 import { createChatRoutes } from './routes/chat'
+import { createCodexRoutes } from './routes/codex'
 import { createGraphRoutes } from './routes/graph'
 import { createHealthRoute } from './routes/health'
 import { createKlavisRoutes } from './routes/klavis'
@@ -107,6 +108,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     )
     .route('/status', createStatusRoute({ controller }))
     .route('/soul', createSoulRoutes())
+    .route('/codex', createCodexRoutes())
     .route('/test-provider', createProviderRoutes())
     .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))
     .route(

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -45,6 +45,7 @@ export class ChatService {
       provider: llmConfig.provider,
       model: llmConfig.model,
       apiKey: llmConfig.apiKey,
+      authMode: llmConfig.authMode,
       baseUrl: llmConfig.baseUrl,
       upstreamProvider: llmConfig.upstreamProvider,
       resourceName: llmConfig.resourceName,

--- a/apps/server/src/api/services/graph-service.ts
+++ b/apps/server/src/api/services/graph-service.ts
@@ -137,6 +137,7 @@ export class GraphService {
           provider: request.provider,
           model: request.model,
           apiKey: request.apiKey,
+          authMode: request.authMode,
           baseUrl: request.baseUrl,
           resourceName: request.resourceName,
           region: request.region,

--- a/apps/server/src/api/services/sdk/chat.ts
+++ b/apps/server/src/api/services/sdk/chat.ts
@@ -63,6 +63,7 @@ export class ChatService {
         provider: llmConfig.provider,
         model: llmConfig.model ?? 'default',
         apiKey: llmConfig.apiKey,
+        authMode: llmConfig.authMode,
         baseUrl: llmConfig.baseUrl,
         resourceName: llmConfig.resourceName,
         region: llmConfig.region,

--- a/apps/server/src/lib/clients/llm/codex-auth.ts
+++ b/apps/server/src/lib/clients/llm/codex-auth.ts
@@ -1,0 +1,392 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { createOpenAI } from '@ai-sdk/openai'
+import type { LLMAuthMode } from '@browseros/shared/schemas/llm'
+import { z } from 'zod'
+
+const CODEX_AUTH_ISSUER = 'https://auth.openai.com'
+const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+const CODEX_RESPONSES_URL = 'https://chatgpt.com/backend-api/codex/responses'
+const BROWSEROS_ORIGINATOR = 'browseros'
+const PLACEHOLDER_API_KEY = 'codex-local-chatgpt-auth'
+
+const CodexAuthTokensSchema = z
+  .object({
+    id_token: z.string().optional(),
+    access_token: z.string().optional(),
+    refresh_token: z.string().optional(),
+    account_id: z.string().optional(),
+  })
+  .partial()
+
+const CodexAuthFileSchema = z
+  .object({
+    auth_mode: z.string().optional(),
+    tokens: CodexAuthTokensSchema.optional(),
+    last_refresh: z.union([z.string(), z.number()]).optional(),
+  })
+  .passthrough()
+
+const CodexTokenResponseSchema = z.object({
+  id_token: z.string().optional(),
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number().optional(),
+})
+
+type CodexAuthFile = z.infer<typeof CodexAuthFileSchema>
+type CodexTokenResponse = z.infer<typeof CodexTokenResponseSchema>
+
+export interface CodexStatus {
+  isAuthenticated: boolean
+  authMode: 'chatgpt' | 'api-key' | null
+  canUseChatGpt: boolean
+  authPath: string
+  message: string
+}
+
+type JwtClaims = {
+  chatgpt_account_id?: string
+  organizations?: Array<{ id: string }>
+  'https://api.openai.com/auth'?: {
+    chatgpt_account_id?: string
+  }
+}
+
+type CodexProviderConfig = {
+  apiKey?: string
+  authMode?: LLMAuthMode
+}
+
+type CodexFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>
+
+function normalizeAuthMode(
+  authMode?: string | null,
+): 'chatgpt' | 'api-key' | null {
+  if (authMode === 'chatgpt') return 'chatgpt'
+  if (authMode === 'apikey' || authMode === 'api-key') return 'api-key'
+  return null
+}
+
+export function getCodexAuthFilePath(): string {
+  const homeDir = process.env.HOME || os.homedir()
+  return path.join(homeDir, '.codex', 'auth.json')
+}
+
+function parseJwtClaims(token: string | undefined): JwtClaims | undefined {
+  if (!token) return undefined
+
+  const parts = token.split('.')
+  if (parts.length !== 3) return undefined
+
+  try {
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString())
+  } catch {
+    return undefined
+  }
+}
+
+function extractAccountIdFromClaims(
+  claims: JwtClaims | undefined,
+): string | undefined {
+  if (!claims) return undefined
+  return (
+    claims.chatgpt_account_id ||
+    claims['https://api.openai.com/auth']?.chatgpt_account_id ||
+    claims.organizations?.[0]?.id
+  )
+}
+
+function extractAccountId(tokens: CodexTokenResponse): string | undefined {
+  return (
+    extractAccountIdFromClaims(parseJwtClaims(tokens.id_token)) ||
+    extractAccountIdFromClaims(parseJwtClaims(tokens.access_token))
+  )
+}
+
+function getChatGptAccountId(auth: CodexAuthFile): string | undefined {
+  return (
+    auth.tokens?.account_id ||
+    extractAccountIdFromClaims(parseJwtClaims(auth.tokens?.id_token)) ||
+    extractAccountIdFromClaims(parseJwtClaims(auth.tokens?.access_token))
+  )
+}
+
+async function readCodexAuthFile(): Promise<CodexAuthFile | null> {
+  try {
+    const raw = await readFile(getCodexAuthFilePath(), 'utf8')
+    return CodexAuthFileSchema.parse(JSON.parse(raw))
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return null
+    }
+    throw error
+  }
+}
+
+async function writeCodexAuthFile(auth: CodexAuthFile): Promise<void> {
+  const authFile = getCodexAuthFilePath()
+  await mkdir(path.dirname(authFile), { recursive: true })
+  await writeFile(authFile, `${JSON.stringify(auth, null, 2)}\n`, 'utf8')
+}
+
+async function refreshChatGptTokens(
+  currentAuth: CodexAuthFile,
+): Promise<CodexAuthFile> {
+  const refreshToken = currentAuth.tokens?.refresh_token
+  if (!refreshToken) {
+    throw new Error(
+      'Local Codex ChatGPT login is missing a refresh token. Run `codex login` again.',
+    )
+  }
+
+  const response = await fetch(`${CODEX_AUTH_ISSUER}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: CODEX_CLIENT_ID,
+    }).toString(),
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to refresh local Codex ChatGPT login (${response.status}). Run \`codex login\` again.`,
+    )
+  }
+
+  const nextTokens = CodexTokenResponseSchema.parse(await response.json())
+  const nextAuth: CodexAuthFile = {
+    ...currentAuth,
+    auth_mode: 'chatgpt',
+    tokens: {
+      ...currentAuth.tokens,
+      id_token: nextTokens.id_token ?? currentAuth.tokens?.id_token,
+      access_token: nextTokens.access_token,
+      refresh_token: nextTokens.refresh_token ?? refreshToken,
+      account_id:
+        currentAuth.tokens?.account_id ||
+        extractAccountId({
+          ...nextTokens,
+          id_token: nextTokens.id_token ?? currentAuth.tokens?.id_token,
+        }),
+    },
+    last_refresh: Date.now(),
+  }
+
+  await writeCodexAuthFile(nextAuth)
+
+  return nextAuth
+}
+
+async function loadChatGptAuth(): Promise<CodexAuthFile> {
+  const auth = await readCodexAuthFile()
+
+  if (!auth) {
+    throw new Error(
+      'No local Codex login found. Run `codex login` first, then use "Sign in with ChatGPT" in BrowserOS.',
+    )
+  }
+
+  const authMode = normalizeAuthMode(auth.auth_mode)
+  if (authMode !== 'chatgpt') {
+    throw new Error(
+      'Local Codex CLI auth is not ChatGPT-backed. Switch BrowserOS to "Use API key" or run `codex login` again.',
+    )
+  }
+
+  if (!auth.tokens?.access_token) {
+    throw new Error(
+      'Local Codex ChatGPT login is incomplete. Run `codex login` again.',
+    )
+  }
+
+  return auth
+}
+
+function rewriteCodexUrl(input: RequestInfo | URL): string {
+  const currentUrl =
+    input instanceof URL
+      ? input
+      : typeof input === 'string'
+        ? new URL(input)
+        : new URL(input.url)
+
+  if (
+    currentUrl.pathname.includes('/chat/completions') ||
+    currentUrl.pathname.includes('/v1/responses') ||
+    currentUrl.pathname.includes('/responses')
+  ) {
+    return CODEX_RESPONSES_URL
+  }
+
+  return currentUrl.toString()
+}
+
+function buildCodexHeaders(
+  headersInit: HeadersInit | undefined,
+  auth: CodexAuthFile,
+): Headers {
+  const headers = new Headers(headersInit)
+  headers.delete('authorization')
+  headers.delete('Authorization')
+  headers.set('authorization', `Bearer ${auth.tokens?.access_token}`)
+  headers.set('originator', BROWSEROS_ORIGINATOR)
+
+  const accountId = getChatGptAccountId(auth)
+  if (accountId) {
+    headers.set('ChatGPT-Account-Id', accountId)
+  }
+
+  return headers
+}
+
+async function createCodexRequestInit(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  auth: CodexAuthFile,
+): Promise<RequestInit> {
+  if (!(input instanceof Request)) {
+    return {
+      ...init,
+      headers: buildCodexHeaders(init?.headers, auth),
+    }
+  }
+
+  const mergedHeaders = new Headers(input.headers)
+  if (init?.headers) {
+    new Headers(init.headers).forEach((value, key) => {
+      mergedHeaders.set(key, value)
+    })
+  }
+
+  const nextInit: RequestInit = {
+    ...init,
+    cache: init?.cache ?? input.cache,
+    credentials: init?.credentials ?? input.credentials,
+    headers: buildCodexHeaders(mergedHeaders, auth),
+    integrity: init?.integrity ?? input.integrity,
+    keepalive: init?.keepalive ?? input.keepalive,
+    method: init?.method ?? input.method,
+    mode: init?.mode ?? input.mode,
+    redirect: init?.redirect ?? input.redirect,
+    referrer: init?.referrer ?? input.referrer,
+    referrerPolicy: init?.referrerPolicy ?? input.referrerPolicy,
+    signal: init?.signal ?? input.signal,
+  }
+
+  if (init?.body !== undefined) {
+    nextInit.body = init.body
+    return nextInit
+  }
+
+  if (!['GET', 'HEAD'].includes(input.method)) {
+    nextInit.body = await input.clone().arrayBuffer()
+  }
+
+  return nextInit
+}
+
+export function createCodexChatGptFetch(): CodexFetch {
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    let auth = await loadChatGptAuth()
+    const url = rewriteCodexUrl(input)
+    const execute = async () =>
+      fetch(url, {
+        ...(await createCodexRequestInit(input, init, auth)),
+      })
+
+    let response = await execute()
+
+    if (
+      (response.status === 401 || response.status === 403) &&
+      auth.tokens?.refresh_token
+    ) {
+      auth = await refreshChatGptTokens(auth)
+      response = await execute()
+    }
+
+    return response
+  }
+}
+
+function getResolvedAuthMode({
+  apiKey,
+  authMode,
+}: CodexProviderConfig): LLMAuthMode {
+  if (authMode) return authMode
+  return apiKey ? 'api-key' : 'chatgpt'
+}
+
+export function createCodexProvider({ apiKey, authMode }: CodexProviderConfig) {
+  const resolvedAuthMode = getResolvedAuthMode({ apiKey, authMode })
+
+  if (resolvedAuthMode === 'api-key') {
+    if (!apiKey) {
+      throw new Error('Codex API key mode requires an OpenAI API key')
+    }
+
+    return createOpenAI({
+      apiKey,
+      name: 'codex',
+      headers: { originator: BROWSEROS_ORIGINATOR },
+    })
+  }
+
+  return createOpenAI({
+    apiKey: PLACEHOLDER_API_KEY,
+    name: 'codex',
+    headers: { originator: BROWSEROS_ORIGINATOR },
+    fetch: createCodexChatGptFetch() as typeof fetch,
+  })
+}
+
+export async function getCodexStatus(): Promise<CodexStatus> {
+  const auth = await readCodexAuthFile()
+  const authMode = normalizeAuthMode(auth?.auth_mode)
+
+  if (!auth || !authMode) {
+    return {
+      isAuthenticated: false,
+      authMode: null,
+      canUseChatGpt: false,
+      authPath: getCodexAuthFilePath(),
+      message:
+        'Run `codex login` on this device to reuse your ChatGPT Codex access in BrowserOS.',
+    }
+  }
+
+  if (authMode === 'api-key') {
+    return {
+      isAuthenticated: true,
+      authMode,
+      canUseChatGpt: false,
+      authPath: getCodexAuthFilePath(),
+      message:
+        'Codex CLI is logged in with an API key. BrowserOS cannot import that key, so paste it directly in BrowserOS if you want API-key mode.',
+    }
+  }
+
+  const canUseChatGpt = Boolean(auth.tokens?.access_token)
+
+  return {
+    isAuthenticated: canUseChatGpt,
+    authMode,
+    canUseChatGpt,
+    authPath: getCodexAuthFilePath(),
+    message: canUseChatGpt
+      ? 'Local Codex ChatGPT login found. BrowserOS can reuse it on this device.'
+      : 'Local Codex auth was found, but it is incomplete. Run `codex login` again.',
+  }
+}

--- a/apps/server/src/lib/clients/llm/codex-auth.ts
+++ b/apps/server/src/lib/clients/llm/codex-auth.ts
@@ -70,6 +70,8 @@ type CodexFetch = (
   init?: RequestInit,
 ) => Promise<Response>
 
+let pendingChatGptRefresh: Promise<CodexAuthFile> | null = null
+
 function normalizeAuthMode(
   authMode?: string | null,
 ): 'chatgpt' | 'api-key' | null {
@@ -188,6 +190,18 @@ async function refreshChatGptTokens(
   await writeCodexAuthFile(nextAuth)
 
   return nextAuth
+}
+
+async function refreshChatGptTokensOnce(
+  currentAuth: CodexAuthFile,
+): Promise<CodexAuthFile> {
+  if (!pendingChatGptRefresh) {
+    pendingChatGptRefresh = refreshChatGptTokens(currentAuth).finally(() => {
+      pendingChatGptRefresh = null
+    })
+  }
+
+  return pendingChatGptRefresh
 }
 
 async function loadChatGptAuth(): Promise<CodexAuthFile> {
@@ -313,7 +327,7 @@ export function createCodexChatGptFetch(): CodexFetch {
       (response.status === 401 || response.status === 403) &&
       auth.tokens?.refresh_token
     ) {
-      auth = await refreshChatGptTokens(auth)
+      auth = await refreshChatGptTokensOnce(auth)
       response = await execute()
     }
 

--- a/apps/server/src/lib/clients/llm/provider.ts
+++ b/apps/server/src/lib/clients/llm/provider.ts
@@ -17,6 +17,7 @@ import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import type { LanguageModel } from 'ai'
 import { logger } from '../../logger'
 import { createOpenRouterCompatibleFetch } from '../../openrouter-fetch'
+import { createCodexProvider } from './codex-auth'
 import type { ResolvedLLMConfig } from './types'
 
 type ProviderFactory = (config: ResolvedLLMConfig) => LanguageModel
@@ -29,6 +30,13 @@ function createAnthropicModel(config: ResolvedLLMConfig): LanguageModel {
 function createOpenAIModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('OpenAI provider requires apiKey')
   return createOpenAI({ apiKey: config.apiKey })(config.model)
+}
+
+function createCodexModel(config: ResolvedLLMConfig): LanguageModel {
+  return createCodexProvider({
+    apiKey: config.apiKey,
+    authMode: config.authMode,
+  })(config.model)
 }
 
 function createGoogleModel(config: ResolvedLLMConfig): LanguageModel {
@@ -137,6 +145,7 @@ function createMoonshotModel(config: ResolvedLLMConfig): LanguageModel {
 const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.ANTHROPIC]: createAnthropicModel,
   [LLM_PROVIDERS.OPENAI]: createOpenAIModel,
+  [LLM_PROVIDERS.CODEX]: createCodexModel,
   [LLM_PROVIDERS.GOOGLE]: createGoogleModel,
   [LLM_PROVIDERS.OPENROUTER]: createOpenRouterModel,
   [LLM_PROVIDERS.AZURE]: createAzureModel,

--- a/apps/server/tests/api/routes/codex.test.ts
+++ b/apps/server/tests/api/routes/codex.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, beforeEach, describe, it } from 'bun:test'
+import assert from 'node:assert'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createCodexRoutes } from '../../../src/api/routes/codex'
+import { getCodexAuthFilePath } from '../../../src/lib/clients/llm/codex-auth'
+
+describe('createCodexRoutes', () => {
+  let tempHome: string
+  let originalHome: string | undefined
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'browseros-codex-route-'))
+    originalHome = process.env.HOME
+    process.env.HOME = tempHome
+  })
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.HOME
+    } else {
+      process.env.HOME = originalHome
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  it('returns a 500 response when the local auth file is malformed', async () => {
+    const authPath = getCodexAuthFilePath()
+    fs.mkdirSync(path.dirname(authPath), { recursive: true })
+    fs.writeFileSync(authPath, '{not-json')
+
+    const route = createCodexRoutes()
+    const response = await route.request('/status')
+    const body = await response.json()
+
+    assert.strictEqual(response.status, 500)
+    assert.deepStrictEqual(body, { error: 'Failed to read Codex status' })
+  })
+})

--- a/apps/server/tests/codex-auth.test.ts
+++ b/apps/server/tests/codex-auth.test.ts
@@ -1,0 +1,255 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, beforeEach, describe, it } from 'bun:test'
+import assert from 'node:assert'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  createCodexChatGptFetch,
+  getCodexAuthFilePath,
+  getCodexStatus,
+} from '../src/lib/clients/llm/codex-auth'
+
+function createJwt(payload: object): string {
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+    'base64url',
+  )
+  return `header.${encodedPayload}.signature`
+}
+
+describe('codex auth', () => {
+  let tempHome: string
+  let originalHome: string | undefined
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'browseros-codex-test-'))
+    originalHome = process.env.HOME
+    originalFetch = globalThis.fetch
+    process.env.HOME = tempHome
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalHome === undefined) {
+      delete process.env.HOME
+    } else {
+      process.env.HOME = originalHome
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true })
+  })
+
+  it('reports missing local codex auth', async () => {
+    const status = await getCodexStatus()
+
+    assert.strictEqual(status.isAuthenticated, false)
+    assert.strictEqual(status.authMode, null)
+    assert.strictEqual(status.canUseChatGpt, false)
+    assert.strictEqual(status.authPath, getCodexAuthFilePath())
+  })
+
+  it('reports available local chatgpt auth', async () => {
+    const authPath = getCodexAuthFilePath()
+    fs.mkdirSync(path.dirname(authPath), { recursive: true })
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          account_id: 'acct_123',
+        },
+      }),
+    )
+
+    const status = await getCodexStatus()
+
+    assert.strictEqual(status.isAuthenticated, true)
+    assert.strictEqual(status.authMode, 'chatgpt')
+    assert.strictEqual(status.canUseChatGpt, true)
+  })
+
+  it('refreshes chatgpt auth on unauthorized codex response', async () => {
+    const authPath = getCodexAuthFilePath()
+    fs.mkdirSync(path.dirname(authPath), { recursive: true })
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: {
+          access_token: 'stale-token',
+          refresh_token: 'refresh-token',
+          account_id: 'acct_123',
+        },
+      }),
+    )
+
+    let codexRequests = 0
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url =
+        input instanceof URL
+          ? input.toString()
+          : typeof input === 'string'
+            ? input
+            : input.url
+
+      if (url === 'https://auth.openai.com/oauth/token') {
+        return new Response(
+          JSON.stringify({
+            access_token: 'fresh-token',
+            refresh_token: 'fresh-refresh-token',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        )
+      }
+
+      if (url === 'https://chatgpt.com/backend-api/codex/responses') {
+        codexRequests += 1
+        const headers = new Headers(init?.headers)
+
+        if (codexRequests === 1) {
+          assert.strictEqual(headers.get('authorization'), 'Bearer stale-token')
+          return new Response('unauthorized', { status: 401 })
+        }
+
+        assert.strictEqual(headers.get('authorization'), 'Bearer fresh-token')
+        assert.strictEqual(headers.get('ChatGPT-Account-Id'), 'acct_123')
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+
+      throw new Error(`Unexpected fetch URL in test: ${url}`)
+    }) as typeof globalThis.fetch
+
+    const codexFetch = createCodexChatGptFetch()
+    const response = await codexFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer ignored-by-codex-fetch',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ model: 'gpt-5.4' }),
+    })
+
+    assert.strictEqual(response.status, 200)
+
+    const savedAuth = JSON.parse(fs.readFileSync(authPath, 'utf8'))
+    assert.strictEqual(savedAuth.tokens.access_token, 'fresh-token')
+    assert.strictEqual(savedAuth.tokens.refresh_token, 'fresh-refresh-token')
+  })
+
+  it('preserves request method and body when the SDK passes a Request', async () => {
+    const authPath = getCodexAuthFilePath()
+    fs.mkdirSync(path.dirname(authPath), { recursive: true })
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          account_id: 'acct_123',
+        },
+      }),
+    )
+
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url =
+        input instanceof URL
+          ? input.toString()
+          : typeof input === 'string'
+            ? input
+            : input.url
+
+      assert.strictEqual(url, 'https://chatgpt.com/backend-api/codex/responses')
+      const request = new Request(url, init)
+      assert.strictEqual(request.method, 'POST')
+      assert.strictEqual(
+        request.headers.get('authorization'),
+        'Bearer access-token',
+      )
+      assert.strictEqual(request.headers.get('ChatGPT-Account-Id'), 'acct_123')
+      assert.strictEqual(
+        await request.text(),
+        JSON.stringify({ model: 'gpt-5.4' }),
+      )
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as typeof globalThis.fetch
+
+    const codexFetch = createCodexChatGptFetch()
+    const response = await codexFetch(
+      new Request('https://api.openai.com/v1/responses', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: 'gpt-5.4' }),
+      }),
+    )
+
+    assert.strictEqual(response.status, 200)
+  })
+
+  it('derives the chatgpt account id from the token when needed', async () => {
+    const authPath = getCodexAuthFilePath()
+    fs.mkdirSync(path.dirname(authPath), { recursive: true })
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: {
+          access_token: createJwt({ chatgpt_account_id: 'acct_from_token' }),
+          refresh_token: 'refresh-token',
+        },
+      }),
+    )
+
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url =
+        input instanceof URL
+          ? input.toString()
+          : typeof input === 'string'
+            ? input
+            : input.url
+
+      assert.strictEqual(url, 'https://chatgpt.com/backend-api/codex/responses')
+      const headers = new Headers(init?.headers)
+      assert.strictEqual(headers.get('ChatGPT-Account-Id'), 'acct_from_token')
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }) as typeof globalThis.fetch
+
+    const codexFetch = createCodexChatGptFetch()
+    const response = await codexFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-5.4' }),
+    })
+
+    assert.strictEqual(response.status, 200)
+  })
+})

--- a/apps/server/tests/codex-auth.test.ts
+++ b/apps/server/tests/codex-auth.test.ts
@@ -151,6 +151,101 @@ describe('codex auth', () => {
     assert.strictEqual(savedAuth.tokens.refresh_token, 'fresh-refresh-token')
   })
 
+  it('deduplicates concurrent chatgpt token refreshes', async () => {
+    const authPath = getCodexAuthFilePath()
+    fs.mkdirSync(path.dirname(authPath), { recursive: true })
+    fs.writeFileSync(
+      authPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: {
+          access_token: 'stale-token',
+          refresh_token: 'refresh-token',
+          account_id: 'acct_123',
+        },
+      }),
+    )
+
+    let refreshCalls = 0
+    let codexCalls = 0
+    let releaseRefresh!: () => void
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve
+    })
+
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url =
+        input instanceof URL
+          ? input.toString()
+          : typeof input === 'string'
+            ? input
+            : input.url
+
+      if (url === 'https://auth.openai.com/oauth/token') {
+        refreshCalls += 1
+        await refreshGate
+        return new Response(
+          JSON.stringify({
+            access_token: 'fresh-token',
+            refresh_token: 'fresh-refresh-token',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        )
+      }
+
+      if (url === 'https://chatgpt.com/backend-api/codex/responses') {
+        codexCalls += 1
+        const headers = new Headers(init?.headers)
+        const authHeader = headers.get('authorization')
+
+        if (authHeader === 'Bearer stale-token') {
+          return new Response('unauthorized', { status: 401 })
+        }
+
+        assert.strictEqual(authHeader, 'Bearer fresh-token')
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+
+      throw new Error(`Unexpected fetch URL in test: ${url}`)
+    }) as typeof globalThis.fetch
+
+    const codexFetch = createCodexChatGptFetch()
+    const firstRequest = codexFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-5.4' }),
+    })
+    const secondRequest = codexFetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: 'gpt-5.4' }),
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    assert.strictEqual(refreshCalls, 1)
+
+    releaseRefresh()
+
+    const [firstResponse, secondResponse] = await Promise.all([
+      firstRequest,
+      secondRequest,
+    ])
+
+    assert.strictEqual(firstResponse.status, 200)
+    assert.strictEqual(secondResponse.status, 200)
+    assert.strictEqual(refreshCalls, 1)
+    assert.strictEqual(codexCalls, 4)
+  })
+
   it('preserves request method and body when the SDK passes a Request', async () => {
     const authPath = getCodexAuthFilePath()
     fs.mkdirSync(path.dirname(authPath), { recursive: true })

--- a/packages/shared/src/schemas/llm.ts
+++ b/packages/shared/src/schemas/llm.ts
@@ -15,6 +15,7 @@ import { z } from 'zod'
 export const LLM_PROVIDERS = {
   ANTHROPIC: 'anthropic',
   OPENAI: 'openai',
+  CODEX: 'codex',
   GOOGLE: 'google',
   OPENROUTER: 'openrouter',
   AZURE: 'azure',
@@ -33,6 +34,7 @@ export const LLMProviderSchema: z.ZodEnum<
   [
     'anthropic',
     'openai',
+    'codex',
     'google',
     'openrouter',
     'azure',
@@ -46,6 +48,7 @@ export const LLMProviderSchema: z.ZodEnum<
 > = z.enum([
   LLM_PROVIDERS.ANTHROPIC,
   LLM_PROVIDERS.OPENAI,
+  LLM_PROVIDERS.CODEX,
   LLM_PROVIDERS.GOOGLE,
   LLM_PROVIDERS.OPENROUTER,
   LLM_PROVIDERS.AZURE,
@@ -59,6 +62,10 @@ export const LLMProviderSchema: z.ZodEnum<
 
 export type LLMProvider = z.infer<typeof LLMProviderSchema>
 
+export const LLMAuthModeSchema = z.enum(['chatgpt', 'api-key'])
+
+export type LLMAuthMode = z.infer<typeof LLMAuthModeSchema>
+
 /**
  * LLM configuration schema
  * Used by SDK endpoints and agent configuration
@@ -67,6 +74,7 @@ export const LLMConfigSchema: z.ZodObject<{
   provider: typeof LLMProviderSchema
   model: z.ZodOptional<z.ZodString>
   apiKey: z.ZodOptional<z.ZodString>
+  authMode: z.ZodOptional<typeof LLMAuthModeSchema>
   baseUrl: z.ZodOptional<z.ZodString>
   resourceName: z.ZodOptional<z.ZodString>
   region: z.ZodOptional<z.ZodString>
@@ -77,6 +85,7 @@ export const LLMConfigSchema: z.ZodObject<{
   provider: LLMProviderSchema,
   model: z.string().optional(),
   apiKey: z.string().optional(),
+  authMode: LLMAuthModeSchema.optional(),
   baseUrl: z.string().optional(),
   // Azure-specific
   resourceName: z.string().optional(),


### PR DESCRIPTION
## Summary
- add a first-class `codex` provider across shared schemas, server factories, and agent request payloads
- add a Codex template and setup UX with `Sign in with ChatGPT` and `Use API key` auth modes plus curated Codex model presets
- add server-side local Codex auth reuse, ChatGPT token refresh, and a `/codex/status` route so provider testing and runtime use the same backend path

## Design
This introduces Codex as its own provider instead of overloading OpenAI. BrowserOS now reuses local `codex login` state for ChatGPT-backed access by reading `~/.codex/auth.json` on the server, refreshing tokens when needed, and routing requests to the Codex backend with the required headers. API-key mode stays explicit in the UI and uses a direct OpenAI API key, which keeps ChatGPT credentials local-only while fitting the existing BrowserOS provider patterns.

## Test plan
- `bun run lint`
- `bun test apps/server/tests/codex-auth.test.ts`
- `bun run --filter @browseros/server test:tools`
- `bun run --filter @browseros/server typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 bun run --filter @browseros/agent typecheck` *(OOM in repo typecheck before surfacing TS errors)*
- `NODE_OPTIONS=--max-old-space-size=12288 bun run --filter @browseros/agent typecheck` *(still memory-bound; no TS diagnostics emitted before stopping)*