### PR TITLE
feat: move MCP nav and hide workflows

### DIFF
--- a/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -7,7 +7,6 @@ import {
   Palette,
   RotateCcw,
   Search,
-  Server,
   Sparkles,
 } from 'lucide-react'
 import type { FC } from 'react'
@@ -27,7 +26,6 @@ type NavItem = {
 const settingsNavItems: NavItem[] = [
   { name: 'BrowserOS AI', to: '/settings/ai', icon: Bot },
   { name: 'LLM Chat & Hub', to: '/settings/chat', icon: MessageSquare },
-  { name: 'BrowserOS as MCP', to: '/settings/mcp', icon: Server },
   {
     name: 'Customization',
     to: '/settings/customization',

--- a/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -3,6 +3,7 @@ import {
   GitBranch,
   Home,
   PlugZap,
+  Server,
   Settings,
   UserPen,
 } from 'lucide-react'
@@ -29,14 +30,21 @@ type NavItem = {
   feature?: Feature
 }
 
+const SHOW_WORKFLOWS = false
+
 const primaryNavItems: NavItem[] = [
   { name: 'Home', to: '/home', icon: Home },
-  {
-    name: 'Workflows',
-    to: '/workflows',
-    icon: GitBranch,
-    feature: Feature.WORKFLOW_SUPPORT,
-  },
+  { name: 'BrowserOS MCP', to: '/settings/mcp', icon: Server },
+  ...(SHOW_WORKFLOWS
+    ? [
+        {
+          name: 'Workflows',
+          to: '/workflows',
+          icon: GitBranch,
+          feature: Feature.WORKFLOW_SUPPORT,
+        },
+      ]
+    : []),
   { name: 'Scheduled Tasks', to: '/scheduled', icon: CalendarClock },
   {
     name: 'Connect Apps',
@@ -71,7 +79,8 @@ export const SidebarNavigation: FC<SidebarNavigationProps> = ({
             const Icon = item.icon
             const isActive =
               item.to === '/settings/ai'
-                ? location.pathname.startsWith('/settings')
+                ? location.pathname.startsWith('/settings') &&
+                  location.pathname !== '/settings/mcp'
                 : location.pathname === item.to
 
             const navItem = (


### PR DESCRIPTION
## Summary
- move the BrowserOS MCP entry from the settings sidebar into the main app sidebar
- temporarily hide the Workflows nav entry behind a local boolean flag
- keep the existing MCP settings route functional while changing discovery

## Design
This change stays in the app navigation layer. The MCP page remains at `/settings/mcp`, but its primary entry point now lives in the main sidebar instead of the settings sidebar. Workflows remains routed but is hidden from the main nav with an easy-to-revert flag.

## Test plan
- run `bunx biome check apps/agent/components/sidebar/SidebarNavigation.tsx apps/agent/components/sidebar/SettingsSidebar.tsx`
- run `bun test apps/agent/lib/mcp/client.test.ts`
- attempt `bun run --filter @browseros/agent typecheck` (currently fails in this environment with Node heap OOM before reporting TS diagnostics)