### PR TITLE
fix: respect custom baseUrl when initializing OpenAI provider

### DIFF
--- a/apps/server/src/agent/provider-factory.ts
+++ b/apps/server/src/agent/provider-factory.ts
@@ -26,7 +26,10 @@ function createOpenAIFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('OpenAI provider requires apiKey')
-  return createOpenAI({ apiKey: config.apiKey })
+  return createOpenAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+  })
 }
 
 function createGoogleFactory(

--- a/apps/server/src/lib/clients/llm/provider.ts
+++ b/apps/server/src/lib/clients/llm/provider.ts
@@ -28,7 +28,10 @@ function createAnthropicModel(config: ResolvedLLMConfig): LanguageModel {
 
 function createOpenAIModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('OpenAI provider requires apiKey')
-  return createOpenAI({ apiKey: config.apiKey })(config.model)
+  return createOpenAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+  })(config.model)
 }
 
 function createGoogleModel(config: ResolvedLLMConfig): LanguageModel {


### PR DESCRIPTION
### Problem

When users configure a custom `baseUrl` for the OpenAI provider (e.g. a
self-hosted proxy, Azure-compatible endpoint, or any OpenAI-compatible
service), it was silently ignored. Both call sites that create the OpenAI
client only forwarded `apiKey`, so all requests always went to the
official `api.openai.com` endpoint regardless of the configured base URL.

### Root Cause

Two functions were missing the `baseURL` option in their `createOpenAI()`
calls:

| File | Function |
|------|----------|
| `apps/server/src/agent/provider-factory.ts` | `createOpenAIFactory` |
| `apps/server/src/lib/clients/llm/provider.ts` | `createOpenAIModel` |

### Fix

Both functions now conditionally forward `baseURL` from the config when
it is provided:

```ts
// Before
return createOpenAI({ apiKey: config.apiKey })

// After
return createOpenAI({
  apiKey: config.apiKey,
  ...(config.baseUrl && { baseURL: config.baseUrl }),
})