### PR TITLE
feat: make agent compaction boundary-aware

### DIFF
--- a/apps/server/src/agent/compaction-prompt.ts
+++ b/apps/server/src/agent/compaction-prompt.ts
@@ -70,6 +70,29 @@ Summarize the prefix to provide context for the retained suffix:
 
 Be concise. Focus on what's needed to understand the kept suffix.`
 
+const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
+
+<summary>
+`
+
+const COMPACTION_SUMMARY_SUFFIX = `
+</summary>
+
+Continue from where you left off.`
+
+const LEGACY_COMPACTION_SUMMARY_SUFFIX = '\n\nContinue from where you left off.'
+
+export function buildCompactionSummaryMessage(summary: string): string {
+  return `${COMPACTION_SUMMARY_PREFIX}${summary}${COMPACTION_SUMMARY_SUFFIX}`
+}
+
+export function extractCompactionSummaryFromMessage(
+  message: ModelMessage | undefined,
+): string | null {
+  if (!message || message.role !== 'user') return null
+  return extractCompactionSummaryFromText(extractTextContent(message.content))
+}
+
 export function buildSummarizationPrompt(
   existingSummary: string | null,
 ): string {
@@ -97,7 +120,13 @@ export function messagesToTranscript(messages: ModelMessage[]): string {
 
   for (const msg of messages) {
     if (msg.role === 'user') {
-      parts.push(`[User]: ${extractTextContent(msg.content)}`)
+      const text = extractTextContent(msg.content)
+      const compactionSummary = extractCompactionSummaryFromText(text)
+      if (compactionSummary) {
+        parts.push(`[Compaction Summary]: ${compactionSummary}`)
+      } else {
+        parts.push(`[User]: ${text}`)
+      }
     } else if (msg.role === 'assistant') {
       const { text, toolCalls } = extractAssistantContent(msg.content)
       if (text) parts.push(`[Assistant]: ${text}`)
@@ -117,6 +146,30 @@ export function messagesToTranscript(messages: ModelMessage[]): string {
   }
 
   return parts.join('\n\n')
+}
+
+function extractCompactionSummaryFromText(text: string): string | null {
+  if (
+    text.startsWith(COMPACTION_SUMMARY_PREFIX) &&
+    text.endsWith(COMPACTION_SUMMARY_SUFFIX)
+  ) {
+    return text
+      .slice(
+        COMPACTION_SUMMARY_PREFIX.length,
+        -COMPACTION_SUMMARY_SUFFIX.length,
+      )
+      .trim()
+  }
+
+  if (
+    text.startsWith('## Goal') &&
+    text.includes('## Progress') &&
+    text.endsWith(LEGACY_COMPACTION_SUMMARY_SUFFIX)
+  ) {
+    return text.slice(0, -LEGACY_COMPACTION_SUMMARY_SUFFIX.length).trim()
+  }
+
+  return null
 }
 
 function extractTextContent(content: UserContent): string {

--- a/apps/server/src/agent/compaction.ts
+++ b/apps/server/src/agent/compaction.ts
@@ -2,9 +2,11 @@ import { AGENT_LIMITS } from '@browseros/shared/constants/limits'
 import { type LanguageModel, type ModelMessage, streamText } from 'ai'
 import { logger } from '../lib/logger'
 import {
+  buildCompactionSummaryMessage,
   buildSummarizationPrompt,
   buildSummarizationSystemPrompt,
   buildTurnPrefixPrompt,
+  extractCompactionSummaryFromMessage,
   messagesToTranscript,
 } from './compaction-prompt'
 
@@ -442,6 +444,20 @@ export function slidingWindow(
   return messages.slice(startIndex)
 }
 
+function slidingWindowWithBoundary(
+  boundaryMessages: ModelMessage[],
+  liveMessages: ModelMessage[],
+  maxTokens: number,
+): ModelMessage[] {
+  if (boundaryMessages.length === 0) {
+    return slidingWindow(liveMessages, maxTokens)
+  }
+
+  const boundaryTokens = estimateTokens(boundaryMessages)
+  const liveBudget = Math.max(0, maxTokens - boundaryTokens)
+  return [...boundaryMessages, ...slidingWindow(liveMessages, liveBudget)]
+}
+
 // ---------------------------------------------------------------------------
 // Main compaction orchestrator
 // ---------------------------------------------------------------------------
@@ -454,35 +470,53 @@ async function compactMessages(
   state: CompactionState,
 ): Promise<ModelMessage[]> {
   const triggerThreshold = config.triggerThreshold
+  const existingBoundarySummary = extractCompactionSummaryFromMessage(
+    messages[0],
+  )
+  const boundaryMessages = existingBoundarySummary ? messages.slice(0, 1) : []
+  const liveMessages = messages.slice(boundaryMessages.length)
+
+  if (liveMessages.length <= 2) {
+    return slidingWindowWithBoundary(
+      boundaryMessages,
+      liveMessages,
+      triggerThreshold,
+    )
+  }
 
   // 1. Find safe split point
   const { splitIndex, turnStartIndex, isSplitTurn } = findSafeSplitPoint(
-    messages,
+    liveMessages,
     config.keepRecentTokens,
     config.imageTokenEstimate,
   )
 
   if (splitIndex === -1) {
     logger.info('Cannot find safe split point, using sliding window')
-    return slidingWindow(messages, triggerThreshold)
+    return slidingWindowWithBoundary(
+      boundaryMessages,
+      liveMessages,
+      triggerThreshold,
+    )
   }
 
-  const toKeep = messages.slice(splitIndex)
+  const toKeep = liveMessages.slice(splitIndex)
 
   // 2. Partition messages based on split turn detection
   let historyMessages: ModelMessage[]
   let turnPrefixMessages: ModelMessage[] = []
 
   if (isSplitTurn && turnStartIndex >= 0) {
-    historyMessages = messages.slice(0, turnStartIndex)
-    turnPrefixMessages = messages.slice(turnStartIndex, splitIndex)
+    historyMessages = liveMessages.slice(0, turnStartIndex)
+    turnPrefixMessages = liveMessages.slice(turnStartIndex, splitIndex)
     logger.info('Split turn detected', {
       historyMessages: historyMessages.length,
       turnPrefixMessages: turnPrefixMessages.length,
       toKeepMessages: toKeep.length,
+      hasExistingBoundary: boundaryMessages.length > 0,
     })
   } else {
-    historyMessages = messages.slice(0, splitIndex)
+    historyMessages = liveMessages.slice(0, splitIndex)
   }
 
   // Truncate tool outputs for summarization input
@@ -527,7 +561,11 @@ async function compactMessages(
     estimateTokens(toSummarize) + estimateTokens(truncatedTurnPrefix)
   if (totalSummarizable < config.minSummarizableTokens) {
     logger.info('Too little content to summarize, using sliding window')
-    return slidingWindow(messages, triggerThreshold)
+    return slidingWindowWithBoundary(
+      boundaryMessages,
+      liveMessages,
+      triggerThreshold,
+    )
   }
 
   // 5. Try LLM summarization
@@ -548,6 +586,7 @@ async function compactMessages(
     toKeepTokens: estimateTokens(toKeep),
     isSplitTurn,
     hasExistingSummary: state.existingSummary != null,
+    hasExistingBoundary: boundaryMessages.length > 0,
     compactionCount: state.compactionCount,
   })
 
@@ -580,13 +619,17 @@ async function compactMessages(
         summary = turnPrefixSummary
       }
     } else {
-      // Only turn prefix (first and only turn)
-      summary = await summarizeTurnPrefix(
+      const turnPrefixSummary = await summarizeTurnPrefix(
         model,
         truncatedTurnPrefix,
         config.summarizationTimeoutMs,
         turnPrefixOutputBudget,
       )
+      if (turnPrefixSummary && state.existingSummary) {
+        summary = `${state.existingSummary}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixSummary}`
+      } else {
+        summary = turnPrefixSummary
+      }
     }
   } else {
     // Non-split turn — standard summarization
@@ -602,7 +645,11 @@ async function compactMessages(
   // 6. Validate summary
   if (!summary) {
     logger.warn('Summarization returned empty, using sliding window fallback')
-    return slidingWindow(messages, triggerThreshold)
+    return slidingWindowWithBoundary(
+      boundaryMessages,
+      liveMessages,
+      triggerThreshold,
+    )
   }
 
   const allSummarized = [...toSummarize, ...truncatedTurnPrefix]
@@ -616,7 +663,11 @@ async function compactMessages(
         originalTokens,
       },
     )
-    return slidingWindow(messages, triggerThreshold)
+    return slidingWindowWithBoundary(
+      boundaryMessages,
+      liveMessages,
+      triggerThreshold,
+    )
   }
 
   // 7. Inject summary as first message + keep recent messages
@@ -635,7 +686,7 @@ async function compactMessages(
 
   const summaryMessage: ModelMessage = {
     role: 'user',
-    content: `${summary}\n\nContinue from where you left off.`,
+    content: buildCompactionSummaryMessage(summary),
   }
 
   return [summaryMessage, ...toKeep]
@@ -652,6 +703,26 @@ function isCompactionState(v: unknown): v is CompactionState {
     'compactionCount' in v &&
     typeof (v as CompactionState).compactionCount === 'number'
   )
+}
+
+function getCompactionState(
+  experimentalContext: unknown,
+  messages: ModelMessage[],
+): CompactionState {
+  const extractedSummary = extractCompactionSummaryFromMessage(messages[0])
+  if (!isCompactionState(experimentalContext)) {
+    return extractedSummary
+      ? { existingSummary: extractedSummary, compactionCount: 1 }
+      : { existingSummary: null, compactionCount: 0 }
+  }
+
+  return {
+    existingSummary: extractedSummary ?? experimentalContext.existingSummary,
+    compactionCount: Math.max(
+      experimentalContext.compactionCount,
+      extractedSummary ? 1 : 0,
+    ),
+  }
 }
 
 export function createCompactionPrepareStep(
@@ -683,9 +754,7 @@ export function createCompactionPrepareStep(
     model: LanguageModel
     experimental_context: unknown
   }) => {
-    const state: CompactionState = isCompactionState(experimental_context)
-      ? experimental_context
-      : { existingSummary: null, compactionCount: 0 }
+    const state = getCompactionState(experimental_context, messages)
 
     // Stage 1: Check if compaction is needed using the current prompt as-is.
     const currentTokens = getCurrentTokenCount(steps, messages, config)

--- a/apps/server/tests/agent/compaction-e2e.test.ts
+++ b/apps/server/tests/agent/compaction-e2e.test.ts
@@ -13,6 +13,7 @@ import {
   computeConfig,
   createCompactionPrepareStep,
 } from '../../src/agent/compaction'
+import { extractCompactionSummaryFromMessage } from '../../src/agent/compaction-prompt'
 
 // ---------------------------------------------------------------------------
 // Test infrastructure
@@ -623,6 +624,97 @@ describe('compaction E2E — iterative compaction', () => {
     expect(state2.compactionCount).toBe(1) // unchanged
     expect(state2.existingSummary).toBeTruthy() // preserved
   })
+
+  it('rehydrates previous summary from the first compaction message across calls', async () => {
+    const contextWindow = 10_000
+    const prepareStep = createCompactionPrepareStep({ contextWindow })
+    const config = computeConfig(contextWindow)
+    const triggerAt = Math.floor(contextWindow * config.triggerRatio)
+
+    let sawPreviousSummary = false
+    let sawBoundaryWrapperInTranscript = false
+    let summarizationCalls = 0
+
+    const model = createMock(async (options) => {
+      if (isSummarizationCall(options)) {
+        summarizationCalls++
+        if (summarizationCalls === 2) {
+          const promptText = extractUserText(options)
+          sawPreviousSummary = promptText.includes('<previous_summary>')
+          sawBoundaryWrapperInTranscript = promptText.includes(
+            'The conversation history before this point was compacted',
+          )
+        }
+        return summaryResponse(200)
+      }
+      return textResponse('unused', 100)
+    })
+
+    const firstResult = await prepareStep({
+      messages: buildModerateMessages(8, 2000),
+      steps: [{ usage: { inputTokens: triggerAt + 1000 } }] as StepsStub,
+      model,
+      experimental_context: null,
+    })
+
+    const secondMessages: ModelMessage[] = [
+      ...firstResult.messages,
+      ...buildModerateMessages(6, 1000).slice(1),
+    ]
+
+    const secondResult = await prepareStep({
+      messages: secondMessages,
+      steps: [{ usage: { inputTokens: triggerAt + 1000 } }] as StepsStub,
+      model,
+      experimental_context: null,
+    })
+
+    const state = secondResult.experimental_context as CompactionState
+    expect(state.compactionCount).toBe(2)
+    expect(sawPreviousSummary).toBe(true)
+    expect(sawBoundaryWrapperInTranscript).toBe(false)
+  })
+
+  it('preserves the previous summary boundary when a later compaction fails', async () => {
+    const contextWindow = 10_000
+    const prepareStep = createCompactionPrepareStep({ contextWindow })
+    const config = computeConfig(contextWindow)
+    const triggerAt = Math.floor(contextWindow * config.triggerRatio)
+
+    const initialModel = createMock(async () => summaryResponse(200))
+
+    const firstResult = await prepareStep({
+      messages: buildModerateMessages(8, 2000),
+      steps: [{ usage: { inputTokens: triggerAt + 1000 } }] as StepsStub,
+      model: initialModel,
+      experimental_context: null,
+    })
+
+    const firstSummary = extractCompactionSummaryFromMessage(
+      firstResult.messages[0],
+    )
+    expect(firstSummary).toBeTruthy()
+
+    const failingModel = createMock(async () => {
+      throw new Error('Model unavailable')
+    })
+
+    const secondMessages: ModelMessage[] = [
+      ...firstResult.messages,
+      ...buildModerateMessages(6, 1000).slice(1),
+    ]
+
+    const secondResult = await prepareStep({
+      messages: secondMessages,
+      steps: [{ usage: { inputTokens: triggerAt + 1000 } }] as StepsStub,
+      model: failingModel,
+      experimental_context: null,
+    })
+
+    expect(extractCompactionSummaryFromMessage(secondResult.messages[0])).toBe(
+      firstSummary,
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1099,5 +1191,68 @@ describe('compaction E2E — split turn handling', () => {
 
     // The merged summary should contain the split turn separator
     expect(state.existingSummary).toContain('Turn Context (split turn)')
+  })
+})
+
+describe('compaction E2E — legacy boundary recovery', () => {
+  it('rehydrates legacy plain-text summary messages from older sessions', async () => {
+    const contextWindow = 10_000
+    const prepareStep = createCompactionPrepareStep({ contextWindow })
+    const config = computeConfig(contextWindow)
+    const triggerAt = Math.floor(contextWindow * config.triggerRatio)
+
+    let sawPreviousSummary = false
+    const legacySummary = `## Goal
+Legacy task
+
+## Constraints & Preferences
+- (none)
+
+## Progress
+### Done
+- [x] Previous compaction
+
+### In Progress
+- [ ] Continue
+
+### Blocked
+- (none)
+
+## Key Decisions
+- (none)
+
+## Active State
+- Page 1 open
+
+## Next Steps
+1. Continue
+
+## Critical Context
+- Legacy context`
+
+    const model = createMock(async (options) => {
+      if (isSummarizationCall(options)) {
+        sawPreviousSummary =
+          extractUserText(options).includes('<previous_summary>')
+        return summaryResponse(200)
+      }
+      return textResponse('unused', 100)
+    })
+
+    const result = await prepareStep({
+      messages: [
+        {
+          role: 'user',
+          content: `${legacySummary}\n\nContinue from where you left off.`,
+        },
+        ...buildModerateMessages(8, 2000).slice(1),
+      ],
+      steps: [{ usage: { inputTokens: triggerAt + 1000 } }] as StepsStub,
+      model,
+      experimental_context: null,
+    })
+
+    expect(extractCompactionSummaryFromMessage(result.messages[0])).toBeTruthy()
+    expect(sawPreviousSummary).toBe(true)
   })
 })

--- a/apps/server/tests/agent/compaction.test.ts
+++ b/apps/server/tests/agent/compaction.test.ts
@@ -8,8 +8,10 @@ import {
   truncateToolOutputs,
 } from '../../src/agent/compaction'
 import {
+  buildCompactionSummaryMessage,
   buildSummarizationPrompt,
   buildTurnPrefixPrompt,
+  extractCompactionSummaryFromMessage,
   messagesToTranscript,
 } from '../../src/agent/compaction-prompt'
 
@@ -588,6 +590,54 @@ describe('slidingWindow', () => {
 })
 
 // ---------------------------------------------------------------------------
+// compaction-prompt: compaction summary wrappers
+// ---------------------------------------------------------------------------
+
+describe('compaction summary wrappers', () => {
+  it('wraps summaries in an explicit compaction envelope', () => {
+    const message = buildCompactionSummaryMessage('## Goal\nShip compaction')
+    expect(message).toContain(
+      'The conversation history before this point was compacted',
+    )
+    expect(message).toContain('<summary>')
+    expect(message).toContain('## Goal')
+    expect(message).toContain('Continue from where you left off.')
+  })
+
+  it('extracts summaries from the wrapped envelope', () => {
+    const summary = '## Goal\nShip compaction'
+    const extracted = extractCompactionSummaryFromMessage(
+      userMsg(buildCompactionSummaryMessage(summary)),
+    )
+    expect(extracted).toBe(summary)
+  })
+
+  it('extracts legacy BrowserOS summary messages', () => {
+    const legacySummary = `## Goal
+Ship compaction
+
+## Constraints & Preferences
+- (none)
+
+## Progress
+### Done
+- [x] Previous compaction
+
+### In Progress
+- [ ] Keep going
+
+### Blocked
+- (none)`
+
+    const extracted = extractCompactionSummaryFromMessage(
+      userMsg(`${legacySummary}\n\nContinue from where you left off.`),
+    )
+
+    expect(extracted).toBe(legacySummary)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // compaction-prompt: buildSummarizationPrompt
 // ---------------------------------------------------------------------------
 
@@ -668,6 +718,15 @@ describe('messagesToTranscript', () => {
     const transcript = messagesToTranscript([userMsgWithImage('look at this')])
     expect(transcript).toContain('[Image]')
     expect(transcript).toContain('look at this')
+  })
+
+  it('serializes compaction summaries without wrapper noise', () => {
+    const transcript = messagesToTranscript([
+      userMsg(buildCompactionSummaryMessage('## Goal\nContinue task')),
+    ])
+    expect(transcript).toContain('[Compaction Summary]: ## Goal')
+    expect(transcript).not.toContain('<summary>')
+    expect(transcript).not.toContain('Continue from where you left off.')
   })
 
   it('handles a full conversation', () => {


### PR DESCRIPTION
## Summary
- make compaction summaries explicit boundary messages so state can be recovered across later agent calls
- stop re-summarizing old compaction summaries as normal transcript content during iterative compaction
- preserve the previous boundary summary during fallback windowing and add regression coverage for legacy and cross-call recovery

## Design
This keeps the existing AI SDK `prepareStep` compaction flow, but borrows the key boundary idea from stronger session-based loops like Pi and OpenCode. A compaction summary is now wrapped in a stable format, recovered from the first message when needed, and treated as the left boundary of live context. That lets later compactions update the previous summary cleanly instead of summarizing the summary again.

## Test plan
- `bun run lint`
- `bun --env-file=.env.development test apps/server/tests/agent/compaction.test.ts apps/server/tests/agent/compaction-e2e.test.ts`
- `bun --env-file=.env.development test apps/server/tests/agent` (fails on unrelated baseline import path issue in `rate-limiter.integration.test.ts`)
- `bun run test` (tool suite started successfully but is long-running/environment-heavy)