### PR TITLE
feat: flow route and agent errors to sentry

### DIFF
--- a/apps/agent/entrypoints/app/create-graph/CreateGraph.tsx
+++ b/apps/agent/entrypoints/app/create-graph/CreateGraph.tsx
@@ -31,6 +31,7 @@ import {
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { track } from '@/lib/metrics/track'
 import { useRpcClient } from '@/lib/rpc/RpcClientProvider'
+import { captureChatError } from '@/lib/sentry/captureChatError'
 import { sentry } from '@/lib/sentry/sentry'
 import { useWorkflows } from '@/lib/workflows/workflowStorage'
 import { GraphCanvas } from './GraphCanvas'
@@ -183,6 +184,14 @@ export const CreateGraph: FC = () => {
   }, [agentServerUrl, codeId])
 
   const { sendMessage, stop, status, messages, error, setMessages } = useChat({
+    onError: (error) => {
+      captureChatError(error, {
+        surface: 'create-graph',
+        codeId: codeIdRef.current,
+        provider: selectedLlmProviderRef.current?.type,
+        agentServerUrl: agentUrlRef.current,
+      })
+    },
     transport: new DefaultChatTransport({
       prepareSendMessagesRequest: async ({ messages }) => {
         const lastMessage = messages[messages.length - 1]

--- a/apps/agent/entrypoints/app/workflows/useRunWorkflow.ts
+++ b/apps/agent/entrypoints/app/workflows/useRunWorkflow.ts
@@ -10,6 +10,7 @@ import {
   WORKFLOW_RUN_STOPPED_EVENT,
 } from '@/lib/constants/analyticsEvents'
 import { track } from '@/lib/metrics/track'
+import { captureChatError } from '@/lib/sentry/captureChatError'
 
 type WorkflowMessageMetadata = {
   window?: chrome.windows.Window
@@ -37,6 +38,14 @@ export const useRunWorkflow = () => {
   }, [agentServerUrl])
 
   const { sendMessage, stop, status, messages, setMessages, error } = useChat({
+    onError: (error) => {
+      captureChatError(error, {
+        surface: 'workflow-run',
+        codeId: codeIdRef.current,
+        provider: selectedLlmProviderRef.current?.type,
+        agentServerUrl: agentUrlRef.current,
+      })
+    },
     transport: new DefaultChatTransport({
       prepareSendMessagesRequest: async ({ messages }) => {
         const lastMessage = messages[messages.length - 1]

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -25,6 +25,7 @@ import { useGraphqlQuery } from '@/lib/graphql/useGraphqlQuery'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { track } from '@/lib/metrics/track'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
+import { captureChatError } from '@/lib/sentry/captureChatError'
 import { stopAgentStorage } from '@/lib/stop-agent/stop-agent-storage'
 import { selectedWorkspaceStorage } from '@/lib/workspace/workspace-storage'
 import type { ChatMode } from './chatTypes'
@@ -198,6 +199,16 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     stop,
     error: chatError,
   } = useChat({
+    onError: (error) => {
+      captureChatError(error, {
+        surface:
+          options?.origin === 'newtab' ? 'newtab-chat' : 'sidepanel-chat',
+        conversationId: conversationIdRef.current,
+        mode: modeRef.current,
+        provider: selectedLlmProviderRef.current?.type,
+        agentServerUrl: agentUrlRef.current,
+      })
+    },
     transport: new DefaultChatTransport({
       // Important: this chat logic is also used in apps/agent/lib/schedules/getChatServerResponse.ts for scheduled jobs. Make sure to keep them in sync for any future changes.
       prepareSendMessagesRequest: async ({ messages }) => {

--- a/apps/agent/lib/schedules/getChatServerResponse.ts
+++ b/apps/agent/lib/schedules/getChatServerResponse.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/llm-providers/storage'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { mcpServerStorage } from '@/lib/mcp/mcpServerStorage'
+import { captureChatError } from '@/lib/sentry/captureChatError'
 import { personalizationStorage } from '../personalization/personalizationStorage'
 import { scheduleSystemPrompt } from './scheduleSystemPrompt'
 import type { ToolCallExecution } from './scheduleTypes'
@@ -92,69 +93,96 @@ export async function getChatServerResponse(
     // biome-ignore lint/style/noNonNullAssertion: filter guarantees url exists
     .map((s) => ({ name: s.displayName, url: s.config!.url }))
 
-  const response = await fetch(`${agentServerUrl}/chat`, {
-    method: 'POST',
-    signal: request.signal,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    // Important: this chat logic is also used in apps/agent/entrypoints/sidepanel/index/useChatSession.ts for sidepanel conversation. Make sure to keep them in sync for any future changes.
-    body: JSON.stringify({
-      messages: [{ role: 'user', content: request.message }],
-      message: request.message,
-      provider: provider?.type,
-      providerType: provider?.type,
-      providerName: provider?.name,
-      apiKey: provider?.apiKey,
-      baseUrl: provider?.baseUrl,
+  try {
+    const response = await fetch(`${agentServerUrl}/chat`, {
+      method: 'POST',
+      signal: request.signal,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      // Important: this chat logic is also used in apps/agent/entrypoints/sidepanel/index/useChatSession.ts for sidepanel conversation. Make sure to keep them in sync for any future changes.
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: request.message }],
+        message: request.message,
+        provider: provider?.type,
+        providerType: provider?.type,
+        providerName: provider?.name,
+        apiKey: provider?.apiKey,
+        baseUrl: provider?.baseUrl,
+        conversationId,
+        model: provider?.modelId ?? 'default',
+        mode: request.mode ?? 'agent',
+        contextWindowSize: provider?.contextWindow,
+        temperature: provider?.temperature,
+        resourceName: provider?.resourceName,
+        accessKeyId: provider?.accessKeyId,
+        secretAccessKey: provider?.secretAccessKey,
+        region: provider?.region,
+        sessionToken: provider?.sessionToken,
+        browserContext:
+          request.activeTab ||
+          request.windowId ||
+          enabledMcpServers.length ||
+          customMcpServers.length
+            ? {
+                windowId: request.windowId,
+                activeTab: request.activeTab,
+                enabledMcpServers:
+                  enabledMcpServers.length > 0 ? enabledMcpServers : undefined,
+                customMcpServers:
+                  customMcpServers.length > 0 ? customMcpServers : undefined,
+              }
+            : undefined,
+        userSystemPrompt: `${personalization}\n${scheduleSystemPrompt}`,
+        isScheduledTask: true,
+        supportsImages: provider?.supportsImages,
+      }),
+    })
+
+    if (!response.ok) {
+      const error = new Error(
+        `Chat request failed: ${response.status} ${response.statusText}`,
+      )
+      captureChatError(error, {
+        surface: 'scheduled-job-chat',
+        conversationId,
+        mode: request.mode ?? 'agent',
+        provider: provider?.type,
+        agentServerUrl,
+      })
+      throw error
+    }
+
+    const parsed = await parseUIMessageStream(response)
+
+    if (parsed.error) {
+      const error = new Error(parsed.error)
+      captureChatError(error, {
+        surface: 'scheduled-job-chat',
+        conversationId,
+        mode: request.mode ?? 'agent',
+        provider: provider?.type,
+        agentServerUrl,
+      })
+      throw error
+    }
+
+    return {
+      text: parsed.fullText,
       conversationId,
-      model: provider?.modelId ?? 'default',
+      finalResult: parsed.finalResult,
+      executionLog: parsed.executionLog,
+      toolCalls: parsed.toolCalls,
+    }
+  } catch (error) {
+    captureChatError(error, {
+      surface: 'scheduled-job-chat',
+      conversationId,
       mode: request.mode ?? 'agent',
-      contextWindowSize: provider?.contextWindow,
-      temperature: provider?.temperature,
-      resourceName: provider?.resourceName,
-      accessKeyId: provider?.accessKeyId,
-      secretAccessKey: provider?.secretAccessKey,
-      region: provider?.region,
-      sessionToken: provider?.sessionToken,
-      browserContext:
-        request.activeTab ||
-        request.windowId ||
-        enabledMcpServers.length ||
-        customMcpServers.length
-          ? {
-              windowId: request.windowId,
-              activeTab: request.activeTab,
-              enabledMcpServers:
-                enabledMcpServers.length > 0 ? enabledMcpServers : undefined,
-              customMcpServers:
-                customMcpServers.length > 0 ? customMcpServers : undefined,
-            }
-          : undefined,
-      userSystemPrompt: `${personalization}\n${scheduleSystemPrompt}`,
-      isScheduledTask: true,
-      supportsImages: provider?.supportsImages,
-    }),
-  })
-
-  if (!response.ok) {
-    throw new Error(
-      `Chat request failed: ${response.status} ${response.statusText}`,
-    )
-  }
-
-  const parsed = await parseUIMessageStream(response)
-
-  if (parsed.error) {
-    throw new Error(parsed.error)
-  }
-
-  return {
-    text: parsed.fullText,
-    conversationId,
-    finalResult: parsed.finalResult,
-    executionLog: parsed.executionLog,
-    toolCalls: parsed.toolCalls,
+      provider: provider?.type,
+      agentServerUrl,
+    })
+    throw error
   }
 }
 

--- a/apps/agent/lib/sentry/captureChatError.ts
+++ b/apps/agent/lib/sentry/captureChatError.ts
@@ -1,0 +1,44 @@
+import { sentry } from './sentry'
+
+const CAPTURED_ERROR_SYMBOL = Symbol.for('browseros.agent.sentry.captured')
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error
+  }
+  return new Error(typeof error === 'string' ? error : String(error))
+}
+
+export function captureChatError(
+  error: unknown,
+  context: { surface: string } & Record<string, unknown>,
+): void {
+  if (error instanceof Error && error.name === 'AbortError') {
+    return
+  }
+
+  if (isRecord(error) && error[CAPTURED_ERROR_SYMBOL] === true) {
+    return
+  }
+
+  const normalizedError = toError(error)
+
+  sentry.captureException(normalizedError, {
+    tags: {
+      surface: context.surface,
+    },
+    extra: context,
+  })
+
+  if (!isRecord(error)) {
+    return
+  }
+
+  try {
+    error[CAPTURED_ERROR_SYMBOL] = true
+  } catch {}
+}

--- a/apps/server/src/agent/ai-sdk-agent.ts
+++ b/apps/server/src/agent/ai-sdk-agent.ts
@@ -4,6 +4,7 @@ import { stepCountIs, ToolLoopAgent, type UIMessage } from 'ai'
 import type { Browser } from '../browser/browser'
 import type { KlavisClient } from '../lib/clients/klavis/klavis-client'
 import { logger } from '../lib/logger'
+import { captureExceptionOnce } from '../lib/sentry-utils'
 import { isSoulBootstrap, readSoul } from '../lib/soul'
 import { buildFilesystemToolSet } from '../tools/filesystem/build-toolset'
 import { buildMemoryToolSet } from '../tools/memory/build-toolset'
@@ -34,96 +35,116 @@ export class AiSdkAgent {
   ) {}
 
   static async create(config: AiSdkAgentConfig): Promise<AiSdkAgent> {
-    // Build language model from provider config
-    const model = createLanguageModel(config.resolvedConfig)
-
-    // Build browser tools from the unified tool registry
-    const allBrowserTools = buildBrowserToolSet(config.registry, config.browser)
-    const browserTools = config.resolvedConfig.chatMode
-      ? Object.fromEntries(
-          Object.entries(allBrowserTools).filter(([name]) =>
-            CHAT_MODE_ALLOWED_TOOLS.has(name),
-          ),
+    try {
+      const model = createLanguageModel(config.resolvedConfig)
+      const allBrowserTools = buildBrowserToolSet(
+        config.registry,
+        config.browser,
+      )
+      const browserTools = config.resolvedConfig.chatMode
+        ? Object.fromEntries(
+            Object.entries(allBrowserTools).filter(([name]) =>
+              CHAT_MODE_ALLOWED_TOOLS.has(name),
+            ),
+          )
+        : allBrowserTools
+      if (config.resolvedConfig.chatMode) {
+        logger.info(
+          'Chat mode enabled, restricting to read-only browser tools',
+          {
+            allowedTools: Array.from(CHAT_MODE_ALLOWED_TOOLS),
+          },
         )
-      : allBrowserTools
-    if (config.resolvedConfig.chatMode) {
-      logger.info('Chat mode enabled, restricting to read-only browser tools', {
-        allowedTools: Array.from(CHAT_MODE_ALLOWED_TOOLS),
+      }
+
+      const specs = await buildMcpServerSpecs({
+        browserContext: config.browserContext,
+        klavisClient: config.klavisClient,
+        browserosId: config.browserosId,
       })
+      const { clients, tools: externalMcpTools } = await createMcpClients(specs)
+
+      const filesystemTools = config.resolvedConfig.chatMode
+        ? {}
+        : buildFilesystemToolSet(config.resolvedConfig.sessionExecutionDir)
+      const memoryTools = config.resolvedConfig.chatMode
+        ? {}
+        : buildMemoryToolSet()
+      const tools = {
+        ...browserTools,
+        ...externalMcpTools,
+        ...filesystemTools,
+        ...memoryTools,
+      }
+
+      const excludeSections: string[] = ['tool-reference']
+      if (config.resolvedConfig.isScheduledTask) {
+        excludeSections.push('tab-grouping')
+      }
+      const soulContent = await readSoul()
+      const isBootstrap = await isSoulBootstrap()
+      const instructions = buildSystemPrompt({
+        userSystemPrompt: config.resolvedConfig.userSystemPrompt,
+        exclude: excludeSections,
+        isScheduledTask: config.resolvedConfig.isScheduledTask,
+        scheduledTaskWindowId: config.browserContext?.windowId,
+        workspaceDir: config.resolvedConfig.sessionExecutionDir,
+        soulContent,
+        isSoulBootstrap: isBootstrap,
+        chatMode: config.resolvedConfig.chatMode,
+      })
+
+      const contextWindow =
+        config.resolvedConfig.contextWindowSize ??
+        AGENT_LIMITS.DEFAULT_CONTEXT_WINDOW
+      const prepareStep = createCompactionPrepareStep({
+        contextWindow,
+      })
+
+      const agent = new ToolLoopAgent({
+        model,
+        instructions,
+        tools,
+        stopWhen: [stepCountIs(AGENT_LIMITS.MAX_TURNS)],
+        prepareStep,
+      })
+
+      logger.info('Agent session created (v2)', {
+        conversationId: config.resolvedConfig.conversationId,
+        provider: config.resolvedConfig.provider,
+        model: config.resolvedConfig.model,
+        toolCount: Object.keys(tools).length,
+      })
+
+      return new AiSdkAgent(
+        agent,
+        [],
+        clients,
+        config.resolvedConfig.conversationId,
+      )
+    } catch (error) {
+      captureExceptionOnce(error, {
+        tags: {
+          component: 'ai-sdk-agent',
+          phase: 'create',
+          provider: config.resolvedConfig.provider,
+          model: config.resolvedConfig.model,
+          chat_mode: config.resolvedConfig.chatMode,
+          is_scheduled_task: config.resolvedConfig.isScheduledTask,
+        },
+        contexts: {
+          agent: {
+            conversationId: config.resolvedConfig.conversationId,
+            windowId: config.browserContext?.windowId,
+            enabledMcpServerCount:
+              config.browserContext?.enabledMcpServers?.length ?? 0,
+            customMcpServerCount:
+              config.browserContext?.customMcpServers?.length ?? 0,
+          },
+        },
+      })
+      throw error
     }
-
-    // Build external MCP server specs (Klavis, custom) and connect clients
-    const specs = await buildMcpServerSpecs({
-      browserContext: config.browserContext,
-      klavisClient: config.klavisClient,
-      browserosId: config.browserosId,
-    })
-    const { clients, tools: externalMcpTools } = await createMcpClients(specs)
-
-    // Add filesystem tools (Pi coding agent) — skip in chat mode (read-only)
-    const filesystemTools = config.resolvedConfig.chatMode
-      ? {}
-      : buildFilesystemToolSet(config.resolvedConfig.sessionExecutionDir)
-    const memoryTools = config.resolvedConfig.chatMode
-      ? {}
-      : buildMemoryToolSet()
-    const tools = {
-      ...browserTools,
-      ...externalMcpTools,
-      ...filesystemTools,
-      ...memoryTools,
-    }
-
-    // Build system prompt with optional section exclusions
-    // Tool definitions are already injected by the AI SDK via tool schemas,
-    // so skip the redundant tool-reference section.
-    const excludeSections: string[] = ['tool-reference']
-    if (config.resolvedConfig.isScheduledTask) {
-      excludeSections.push('tab-grouping')
-    }
-    const soulContent = await readSoul()
-    const isBootstrap = await isSoulBootstrap()
-    const instructions = buildSystemPrompt({
-      userSystemPrompt: config.resolvedConfig.userSystemPrompt,
-      exclude: excludeSections,
-      isScheduledTask: config.resolvedConfig.isScheduledTask,
-      scheduledTaskWindowId: config.browserContext?.windowId,
-      workspaceDir: config.resolvedConfig.sessionExecutionDir,
-      soulContent,
-      isSoulBootstrap: isBootstrap,
-      chatMode: config.resolvedConfig.chatMode,
-    })
-
-    // Configure compaction for context window management
-    const contextWindow =
-      config.resolvedConfig.contextWindowSize ??
-      AGENT_LIMITS.DEFAULT_CONTEXT_WINDOW
-    const prepareStep = createCompactionPrepareStep({
-      contextWindow,
-    })
-
-    // Create the ToolLoopAgent
-    const agent = new ToolLoopAgent({
-      model,
-      instructions,
-      tools,
-      stopWhen: [stepCountIs(AGENT_LIMITS.MAX_TURNS)],
-      prepareStep,
-    })
-
-    logger.info('Agent session created (v2)', {
-      conversationId: config.resolvedConfig.conversationId,
-      provider: config.resolvedConfig.provider,
-      model: config.resolvedConfig.model,
-      toolCount: Object.keys(tools).length,
-    })
-
-    return new AiSdkAgent(
-      agent,
-      [],
-      clients,
-      config.resolvedConfig.conversationId,
-    )
   }
 
   get toolLoopAgent(): ToolLoopAgent {

--- a/apps/server/src/api/routes/chat.ts
+++ b/apps/server/src/api/routes/chat.ts
@@ -7,7 +7,7 @@ import { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import type { RateLimiter } from '../../lib/rate-limiter/rate-limiter'
-import { Sentry } from '../../lib/sentry'
+import { withSentryIsolationScope } from '../../lib/sentry-utils'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import { createBrowserosRateLimitMiddleware } from '../middleware/rate-limit'
 import { ChatService } from '../services/chat-service'
@@ -44,30 +44,44 @@ export function createChatRoutes(deps: ChatRouteDeps) {
       createBrowserosRateLimitMiddleware({ rateLimiter, browserosId }),
       async (c) => {
         const request = c.req.valid('json')
+        const requestType = request.isScheduledTask ? 'schedule' : 'chat'
 
-        // Sentry + metrics (HTTP concerns only)
-        Sentry.getCurrentScope().setTag(
-          'request-type',
-          request.isScheduledTask ? 'schedule' : 'chat',
+        return withSentryIsolationScope(
+          {
+            tags: {
+              route: 'chat',
+              request_type: requestType,
+              provider: request.provider,
+              model: request.model,
+              mode: request.mode,
+            },
+            contexts: {
+              request: {
+                conversationId: request.conversationId,
+                provider: request.provider,
+                model: request.model,
+                baseUrl: request.baseUrl,
+                mode: request.mode,
+                isScheduledTask: request.isScheduledTask,
+                hasPreviousConversation: !!request.previousConversation?.length,
+              },
+            },
+          },
+          () => {
+            metrics.log('chat.request', {
+              provider: request.provider,
+              model: request.model,
+            })
+
+            logger.info('Chat request received', {
+              conversationId: request.conversationId,
+              provider: request.provider,
+              model: request.model,
+            })
+
+            return service.processMessage(request, c.req.raw.signal)
+          },
         )
-        Sentry.setContext('request', {
-          provider: request.provider,
-          model: request.model,
-          baseUrl: request.baseUrl,
-        })
-
-        metrics.log('chat.request', {
-          provider: request.provider,
-          model: request.model,
-        })
-
-        logger.info('Chat request received', {
-          conversationId: request.conversationId,
-          provider: request.provider,
-          model: request.model,
-        })
-
-        return service.processMessage(request, c.req.raw.signal)
       },
     )
     .delete(

--- a/apps/server/src/api/routes/graph.ts
+++ b/apps/server/src/api/routes/graph.ts
@@ -10,6 +10,7 @@ import type { Context } from 'hono'
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { logger } from '../../lib/logger'
+import { captureExceptionOnce } from '../../lib/sentry-utils'
 import { GraphService } from '../services/graph-service'
 import {
   CreateGraphRequestSchema,
@@ -31,6 +32,22 @@ type SSEStreamCallback = (
   stream: { write: (data: string) => Promise<unknown> },
   signal: AbortSignal,
 ) => Promise<void>
+
+function captureGraphRouteError(
+  error: unknown,
+  action: string,
+  request: Record<string, unknown>,
+): void {
+  captureExceptionOnce(error, {
+    tags: {
+      route: 'graph',
+      action,
+    },
+    contexts: {
+      graph_request: request,
+    },
+  })
+}
 
 function createSSEStream(
   c: Context,
@@ -101,6 +118,9 @@ export function createGraphRoutes(deps: GraphRouteDeps) {
               signal,
             )
           } catch (error) {
+            captureGraphRouteError(error, 'create', {
+              queryLength: request.query.length,
+            })
             const errorMessage =
               error instanceof Error ? error.message : String(error)
             await s.write(
@@ -150,6 +170,10 @@ export function createGraphRoutes(deps: GraphRouteDeps) {
                 signal,
               )
             } catch (error) {
+              captureGraphRouteError(error, 'update', {
+                sessionId,
+                queryLength: request.query.length,
+              })
               const errorMessage =
                 error instanceof Error ? error.message : String(error)
               await s.write(
@@ -238,6 +262,11 @@ export function createGraphRoutes(deps: GraphRouteDeps) {
                 }),
               )
             } catch (error) {
+              captureGraphRouteError(error, 'run', {
+                sessionId,
+                provider: request.provider,
+                model: request.model,
+              })
               const errorMessage =
                 error instanceof Error ? error.message : String(error)
               await s.write(

--- a/apps/server/src/api/routes/klavis.ts
+++ b/apps/server/src/api/routes/klavis.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { OAUTH_MCP_SERVERS } from '../../lib/clients/klavis/oauth-mcp-servers'
 import { logger } from '../../lib/logger'
+import { captureExceptionOnce } from '../../lib/sentry-utils'
 
 const ServerNameSchema = z.object({
   serverName: z.string().min(1),
@@ -40,6 +41,22 @@ const getAuthUrlForServer = (
     }
   }
   return undefined
+}
+
+function captureKlavisRouteError(
+  error: unknown,
+  action: string,
+  request: Record<string, unknown>,
+): void {
+  captureExceptionOnce(error, {
+    tags: {
+      route: 'klavis',
+      action,
+    },
+    contexts: {
+      klavis_request: request,
+    },
+  })
 }
 
 export function createKlavisRoutes(deps: KlavisRouteDeps) {
@@ -76,6 +93,9 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
           servers: serverNames,
         })
       } catch (error) {
+        captureKlavisRouteError(error, 'oauth-urls', {
+          browserosId: browserosId?.slice(0, 12),
+        })
         logger.error('Error getting OAuth URLs', {
           browserosId: browserosId?.slice(0, 12),
           error: error instanceof Error ? error.message : String(error),
@@ -103,6 +123,9 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
           count: normalizedIntegrations.length,
         })
       } catch (error) {
+        captureKlavisRouteError(error, 'user-integrations', {
+          browserosId: browserosId?.slice(0, 12),
+        })
         logger.error('Error fetching user integrations', {
           browserosId: browserosId?.slice(0, 12),
           error: error instanceof Error ? error.message : String(error),
@@ -124,16 +147,30 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
 
       logger.info('Adding server to strata', { serverName })
 
-      const result = await klavisClient.createStrata(browserosId, [serverName])
+      try {
+        const result = await klavisClient.createStrata(browserosId, [
+          serverName,
+        ])
 
-      return c.json({
-        success: true,
-        serverName,
-        strataId: result.strataId,
-        addedServers: result.addedServers,
-        oauthUrl: getAuthUrlForServer(result.oauthUrls, serverName),
-        apiKeyUrl: getAuthUrlForServer(result.apiKeyUrls, serverName),
-      })
+        return c.json({
+          success: true,
+          serverName,
+          strataId: result.strataId,
+          addedServers: result.addedServers,
+          oauthUrl: getAuthUrlForServer(result.oauthUrls, serverName),
+          apiKeyUrl: getAuthUrlForServer(result.apiKeyUrls, serverName),
+        })
+      } catch (error) {
+        captureKlavisRouteError(error, 'servers-add', {
+          browserosId: browserosId.slice(0, 12),
+          serverName,
+        })
+        logger.error('Error adding server to strata', {
+          serverName,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        return c.json({ error: 'Failed to add server' }, 500)
+      }
     })
     .post(
       '/servers/submit-api-key',
@@ -159,6 +196,10 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
 
           return c.json({ success: true, serverName })
         } catch (error) {
+          captureKlavisRouteError(error, 'submit-api-key', {
+            browserosId: browserosId.slice(0, 12),
+            serverName,
+          })
           logger.error('Error submitting API key', {
             serverName,
             error: error instanceof Error ? error.message : String(error),
@@ -184,12 +225,24 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
 
         logger.info('Removing server from strata', { serverName })
 
-        await klavisClient.removeServer(browserosId, serverName)
+        try {
+          await klavisClient.removeServer(browserosId, serverName)
 
-        return c.json({
-          success: true,
-          serverName,
-        })
+          return c.json({
+            success: true,
+            serverName,
+          })
+        } catch (error) {
+          captureKlavisRouteError(error, 'servers-remove', {
+            browserosId: browserosId.slice(0, 12),
+            serverName,
+          })
+          logger.error('Error removing server from strata', {
+            serverName,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return c.json({ error: 'Failed to remove server' }, 500)
+        }
       },
     )
 }

--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -9,7 +9,7 @@ import { Hono } from 'hono'
 import type { Browser } from '../../browser/browser'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
-import { Sentry } from '../../lib/sentry'
+import { captureExceptionOnce } from '../../lib/sentry-utils'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import { createMcpServer } from '../services/mcp/mcp-server'
 import type { KlavisProxyHandle } from '../services/mcp/register-klavis-mcp'
@@ -39,7 +39,20 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       await mcpServer.connect(transport)
       return transport.handleRequest(c)
     } catch (error) {
-      Sentry.captureException(error)
+      captureExceptionOnce(error, {
+        tags: {
+          route: 'mcp',
+          action: 'handle-request',
+          scope_id: scopeId,
+        },
+        contexts: {
+          request: {
+            scopeId,
+            path: c.req.path,
+            method: c.req.method,
+          },
+        },
+      })
       logger.error('Error handling MCP request', {
         error: error instanceof Error ? error.message : String(error),
       })

--- a/apps/server/src/api/routes/sdk.ts
+++ b/apps/server/src/api/routes/sdk.ts
@@ -12,6 +12,7 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { logger } from '../../lib/logger'
+import { captureExceptionOnce } from '../../lib/sentry-utils'
 import { BrowserService } from '../services/sdk/browser'
 import { ChatService } from '../services/sdk/chat'
 import { ExtractService } from '../services/sdk/extract'
@@ -29,6 +30,27 @@ import {
   formatUIMessageStreamDone,
   formatUIMessageStreamEvent,
 } from '../utils/ui-message-stream'
+
+function captureSdkRouteError(
+  error: SdkError,
+  action: string,
+  request: Record<string, unknown>,
+): void {
+  if (error.statusCode < 500) {
+    return
+  }
+
+  captureExceptionOnce(error, {
+    tags: {
+      route: 'sdk',
+      action,
+      status_code: error.statusCode,
+    },
+    contexts: {
+      sdk_request: request,
+    },
+  })
+}
 
 async function waitForPageLoad(
   browserService: BrowserService,
@@ -79,6 +101,11 @@ export function createSdkRoutes(deps: SdkDeps) {
             : new SdkError(
                 error instanceof Error ? error.message : 'Navigation failed',
               )
+        captureSdkRouteError(err, 'nav', {
+          urlLength: url.length,
+          tabId,
+          windowId,
+        })
         logger.error('SDK nav error', { url, error: err.message })
         return c.json(
           { error: { message: err.message } },
@@ -157,6 +184,12 @@ export function createSdkRoutes(deps: SdkDeps) {
                     ? error.message
                     : 'Action execution failed',
                 )
+          captureSdkRouteError(err, 'act', {
+            instructionLength: instruction.length,
+            hasContext: !!context,
+            hasBrowserContext: !!browserContext,
+            hasSessionId: !!sessionId,
+          })
           logger.error('SDK act error', { instruction, error: err.message })
           await honoStream.write(
             formatUIMessageStreamEvent({
@@ -208,6 +241,11 @@ export function createSdkRoutes(deps: SdkDeps) {
             : new SdkError(
                 error instanceof Error ? error.message : 'Extraction failed',
               )
+        captureSdkRouteError(err, 'extract', {
+          instructionLength: instruction.length,
+          windowId,
+          tabId: requestTabId,
+        })
         logger.error('SDK extract error', { instruction, error: err.message })
         return c.json(
           { error: { message: err.message } },
@@ -257,6 +295,11 @@ export function createSdkRoutes(deps: SdkDeps) {
             : new SdkError(
                 error instanceof Error ? error.message : 'Verification failed',
               )
+        captureSdkRouteError(err, 'verify', {
+          expectationLength: expectation.length,
+          windowId,
+          tabId: requestTabId,
+        })
         logger.error('SDK verify error', { expectation, error: err.message })
         return c.json(
           { error: { message: err.message } },

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -16,6 +16,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { HttpAgentError } from '../agent/errors'
 import { KlavisClient } from '../lib/clients/klavis/klavis-client'
 import { logger } from '../lib/logger'
+import { captureExceptionOnce } from '../lib/sentry-utils'
 import { createChatRoutes } from './routes/chat'
 import { createGraphRoutes } from './routes/graph'
 import { createHealthRoute } from './routes/health'
@@ -150,6 +151,22 @@ export async function createHttpServer(config: HttpServerConfig) {
     const error = err as Error
 
     if (error instanceof HttpAgentError) {
+      if (error.statusCode >= 500) {
+        captureExceptionOnce(error, {
+          tags: {
+            route: c.req.path,
+            method: c.req.method,
+            error_code: error.code,
+          },
+          contexts: {
+            request: {
+              path: c.req.path,
+              method: c.req.method,
+              statusCode: error.statusCode,
+            },
+          },
+        })
+      }
       logger.warn('HTTP Agent Error', {
         name: error.name,
         message: error.message,
@@ -158,6 +175,19 @@ export async function createHttpServer(config: HttpServerConfig) {
       })
       return c.json(error.toJSON(), error.statusCode as ContentfulStatusCode)
     }
+
+    captureExceptionOnce(error, {
+      tags: {
+        route: c.req.path,
+        method: c.req.method,
+      },
+      contexts: {
+        request: {
+          path: c.req.path,
+          method: c.req.method,
+        },
+      },
+    })
 
     logger.error('Unhandled Error', {
       message: error.message,

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -15,6 +15,10 @@ import type { Browser } from '../../browser/browser'
 import type { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { resolveLLMConfig } from '../../lib/clients/llm/config'
 import { logger } from '../../lib/logger'
+import {
+  captureExceptionOnce,
+  getPublicErrorMessage,
+} from '../../lib/sentry-utils'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import type { BrowserContext, ChatRequest } from '../types'
 
@@ -60,101 +64,107 @@ export class ChatService {
       isScheduledTask: request.isScheduledTask,
     }
 
-    let session = sessionStore.get(request.conversationId)
-    let isNewSession = false
+    try {
+      let session = sessionStore.get(request.conversationId)
+      let isNewSession = false
 
-    if (!session) {
-      isNewSession = true
-      let hiddenWindowId: number | undefined
-      let browserContext = await this.resolvePageIds(request.browserContext)
-      if (request.isScheduledTask) {
-        try {
-          const win = await this.deps.browser.createWindow({ hidden: true })
-          hiddenWindowId = win.windowId
-          const pageId = await this.deps.browser.newPage('about:blank', {
-            windowId: hiddenWindowId,
-          })
-          browserContext = {
-            ...browserContext,
-            windowId: hiddenWindowId,
-            activeTab: {
-              id: pageId,
+      if (!session) {
+        isNewSession = true
+        let hiddenWindowId: number | undefined
+        let browserContext = await this.resolvePageIds(request.browserContext)
+        if (request.isScheduledTask) {
+          try {
+            const win = await this.deps.browser.createWindow({ hidden: true })
+            hiddenWindowId = win.windowId
+            const pageId = await this.deps.browser.newPage('about:blank', {
+              windowId: hiddenWindowId,
+            })
+            browserContext = {
+              ...browserContext,
+              windowId: hiddenWindowId,
+              activeTab: {
+                id: pageId,
+                pageId,
+                url: 'about:blank',
+                title: 'Scheduled Task',
+              },
+            }
+            logger.info('Created hidden window for scheduled task', {
+              conversationId: request.conversationId,
+              windowId: hiddenWindowId,
               pageId,
-              url: 'about:blank',
-              title: 'Scheduled Task',
-            },
+            })
+          } catch (error) {
+            logger.warn('Failed to create hidden window, using default', {
+              error: error instanceof Error ? error.message : String(error),
+            })
           }
-          logger.info('Created hidden window for scheduled task', {
-            conversationId: request.conversationId,
-            windowId: hiddenWindowId,
-            pageId,
-          })
-        } catch (error) {
-          logger.warn('Failed to create hidden window, using default', {
-            error: error instanceof Error ? error.message : String(error),
+        }
+
+        const agent = await AiSdkAgent.create({
+          resolvedConfig: agentConfig,
+          browser: this.deps.browser,
+          registry: this.deps.registry,
+          browserContext,
+          klavisClient: this.deps.klavisClient,
+          browserosId: this.deps.browserosId,
+        })
+        session = { agent, hiddenWindowId, browserContext }
+        sessionStore.set(request.conversationId, session)
+      }
+
+      if (isNewSession && request.previousConversation?.length) {
+        for (const msg of request.previousConversation) {
+          session.agent.messages.push({
+            id: crypto.randomUUID(),
+            role: msg.role === 'assistant' ? 'assistant' : 'user',
+            parts: [{ type: 'text', text: msg.content }],
           })
         }
-      }
-
-      const agent = await AiSdkAgent.create({
-        resolvedConfig: agentConfig,
-        browser: this.deps.browser,
-        registry: this.deps.registry,
-        browserContext,
-        klavisClient: this.deps.klavisClient,
-        browserosId: this.deps.browserosId,
-      })
-      session = { agent, hiddenWindowId, browserContext }
-      sessionStore.set(request.conversationId, session)
-    }
-
-    if (isNewSession && request.previousConversation?.length) {
-      for (const msg of request.previousConversation) {
-        session.agent.messages.push({
-          id: crypto.randomUUID(),
-          role: msg.role === 'assistant' ? 'assistant' : 'user',
-          parts: [{ type: 'text', text: msg.content }],
-        })
-      }
-      logger.info('Injected previous conversation history', {
-        conversationId: request.conversationId,
-        messageCount: request.previousConversation.length,
-      })
-    }
-
-    const messageContext = request.isScheduledTask
-      ? (session.browserContext ?? request.browserContext)
-      : request.browserContext
-    // Scheduled tasks already have correct internal pageIds from browser.newPage();
-    // calling resolvePageIds would pass those to resolveTabIds (which expects Chrome
-    // tab IDs), corrupting them back to undefined.
-    const resolvedMessageContext = request.isScheduledTask
-      ? messageContext
-      : await this.resolvePageIds(messageContext)
-    const userContent = formatUserMessage(
-      request.message,
-      resolvedMessageContext,
-    )
-    session.agent.appendUserMessage(userContent)
-
-    return createAgentUIStreamResponse({
-      agent: session.agent.toolLoopAgent,
-      uiMessages: session.agent.messages,
-      abortSignal,
-      onFinish: async ({ messages }: { messages: UIMessage[] }) => {
-        session.agent.messages = messages
-        logger.info('Agent execution complete', {
+        logger.info('Injected previous conversation history', {
           conversationId: request.conversationId,
-          totalMessages: messages.length,
+          messageCount: request.previousConversation.length,
         })
+      }
 
-        if (session?.hiddenWindowId) {
-          const windowId = session.hiddenWindowId
-          session.hiddenWindowId = undefined
-          this.closeHiddenWindow(windowId, request.conversationId)
-        }
-      },
-    })
+      const messageContext = request.isScheduledTask
+        ? (session.browserContext ?? request.browserContext)
+        : request.browserContext
+      const resolvedMessageContext = request.isScheduledTask
+        ? messageContext
+        : await this.resolvePageIds(messageContext)
+      const userContent = formatUserMessage(
+        request.message,
+        resolvedMessageContext,
+      )
+      session.agent.appendUserMessage(userContent)
+
+      return await createAgentUIStreamResponse({
+        agent: session.agent.toolLoopAgent,
+        uiMessages: session.agent.messages,
+        abortSignal,
+        onError: (error) => {
+          this.captureChatError(error, request, agentConfig, 'stream')
+          return getPublicErrorMessage(error, 'Agent execution failed')
+        },
+        onFinish: async ({ messages }: { messages: UIMessage[] }) => {
+          session.agent.messages = messages
+          logger.info('Agent execution complete', {
+            conversationId: request.conversationId,
+            totalMessages: messages.length,
+          })
+
+          if (session?.hiddenWindowId) {
+            const windowId = session.hiddenWindowId
+            session.hiddenWindowId = undefined
+            this.closeHiddenWindow(windowId, request.conversationId)
+          }
+        },
+      })
+    } catch (error) {
+      this.captureChatError(error, request, agentConfig, 'setup')
+      throw error
+    }
   }
 
   async deleteSession(
@@ -228,5 +238,32 @@ export class ChatService {
       : path.join(this.deps.executionDir, 'sessions', request.conversationId)
     await mkdir(dir, { recursive: true })
     return dir
+  }
+
+  private captureChatError(
+    error: unknown,
+    request: ChatRequest,
+    config: ResolvedAgentConfig,
+    phase: 'setup' | 'stream',
+  ): void {
+    captureExceptionOnce(error, {
+      tags: {
+        route: 'chat',
+        phase,
+        provider: config.provider,
+        model: config.model,
+        mode: request.mode,
+        is_scheduled_task: request.isScheduledTask,
+      },
+      contexts: {
+        chat_request: {
+          conversationId: request.conversationId,
+          mode: request.mode,
+          isScheduledTask: request.isScheduledTask,
+          hasBrowserContext: !!request.browserContext,
+          hasPreviousConversation: !!request.previousConversation?.length,
+        },
+      },
+    })
   }
 }

--- a/apps/server/src/lib/sentry-utils.ts
+++ b/apps/server/src/lib/sentry-utils.ts
@@ -1,0 +1,129 @@
+import { Sentry } from './sentry'
+
+const CAPTURED_ERROR_SYMBOL = Symbol.for('browseros.sentry.captured')
+
+interface SentryScopeLike {
+  setTag(key: string, value: string): void
+  setContext(key: string, value: Record<string, unknown> | null): void
+  setExtra(key: string, value: unknown): void
+}
+
+interface SentryClientLike {
+  withScope<T>(callback: (scope: SentryScopeLike) => T): T
+  withIsolationScope<T>(callback: (scope: SentryScopeLike) => T): T
+  captureException(error: unknown): string
+}
+
+type SentryMetadataMap = Record<string, unknown>
+
+export interface SentryMetadata {
+  tags?: SentryMetadataMap
+  contexts?: Record<string, Record<string, unknown> | null | undefined>
+  extras?: SentryMetadataMap
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function normalizeTagValue(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined
+  }
+  return String(value)
+}
+
+function applyMetadata(
+  scope: SentryScopeLike,
+  metadata?: SentryMetadata,
+): void {
+  if (!metadata) {
+    return
+  }
+
+  if (metadata.tags) {
+    for (const [key, value] of Object.entries(metadata.tags)) {
+      const normalizedValue = normalizeTagValue(value)
+      if (normalizedValue !== undefined) {
+        scope.setTag(key, normalizedValue)
+      }
+    }
+  }
+
+  if (metadata.contexts) {
+    for (const [key, value] of Object.entries(metadata.contexts)) {
+      if (value !== undefined) {
+        scope.setContext(key, value)
+      }
+    }
+  }
+
+  if (metadata.extras) {
+    for (const [key, value] of Object.entries(metadata.extras)) {
+      if (value !== undefined) {
+        scope.setExtra(key, value)
+      }
+    }
+  }
+}
+
+function markErrorAsCaptured(error: unknown): void {
+  if (!isRecord(error)) {
+    return
+  }
+
+  try {
+    error[CAPTURED_ERROR_SYMBOL] = true
+  } catch {}
+}
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+export function isErrorCaptured(error: unknown): boolean {
+  return isRecord(error) && error[CAPTURED_ERROR_SYMBOL] === true
+}
+
+export function withSentryIsolationScope<T>(
+  metadata: SentryMetadata,
+  callback: () => T,
+  sentryClient: SentryClientLike = Sentry,
+): T {
+  return sentryClient.withIsolationScope((scope) => {
+    applyMetadata(scope, metadata)
+    return callback()
+  })
+}
+
+export function captureExceptionOnce(
+  error: unknown,
+  metadata?: SentryMetadata,
+  sentryClient: SentryClientLike = Sentry,
+): string | undefined {
+  if (isAbortError(error) || isErrorCaptured(error)) {
+    return undefined
+  }
+
+  return sentryClient.withScope((scope) => {
+    applyMetadata(scope, metadata)
+    const eventId = sentryClient.captureException(error)
+    markErrorAsCaptured(error)
+    return eventId
+  })
+}
+
+export function getPublicErrorMessage(
+  error: unknown,
+  fallback = 'An unexpected error occurred',
+): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error
+  }
+
+  return fallback
+}

--- a/apps/server/tests/lib/sentry-utils.test.ts
+++ b/apps/server/tests/lib/sentry-utils.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'bun:test'
+import assert from 'node:assert'
+import {
+  captureExceptionOnce,
+  getPublicErrorMessage,
+  withSentryIsolationScope,
+} from '../../src/lib/sentry-utils'
+
+function createFakeSentry() {
+  const state = {
+    tags: {} as Record<string, string>,
+    contexts: {} as Record<string, Record<string, unknown> | null>,
+    extras: {} as Record<string, unknown>,
+    captured: [] as unknown[],
+  }
+
+  const scope = {
+    setTag(key: string, value: string) {
+      state.tags[key] = value
+    },
+    setContext(key: string, value: Record<string, unknown> | null) {
+      state.contexts[key] = value
+    },
+    setExtra(key: string, value: unknown) {
+      state.extras[key] = value
+    },
+  }
+
+  return {
+    state,
+    client: {
+      withScope<T>(callback: (scope: typeof scope) => T): T {
+        return callback(scope)
+      },
+      withIsolationScope<T>(callback: (scope: typeof scope) => T): T {
+        return callback(scope)
+      },
+      captureException(error: unknown): string {
+        state.captured.push(error)
+        return 'event-id'
+      },
+    },
+  }
+}
+
+describe('sentry-utils', () => {
+  it('captures the same error only once', () => {
+    const fakeSentry = createFakeSentry()
+    const error = new Error('boom')
+
+    const firstEventId = captureExceptionOnce(
+      error,
+      { tags: { route: 'chat' } },
+      fakeSentry.client,
+    )
+    const secondEventId = captureExceptionOnce(
+      error,
+      { tags: { route: 'chat' } },
+      fakeSentry.client,
+    )
+
+    assert.strictEqual(firstEventId, 'event-id')
+    assert.strictEqual(secondEventId, undefined)
+    assert.strictEqual(fakeSentry.state.captured.length, 1)
+    assert.deepStrictEqual(fakeSentry.state.tags, { route: 'chat' })
+  })
+
+  it('skips abort errors', () => {
+    const fakeSentry = createFakeSentry()
+    const abortError = new Error('aborted')
+    abortError.name = 'AbortError'
+
+    const eventId = captureExceptionOnce(abortError, {}, fakeSentry.client)
+
+    assert.strictEqual(eventId, undefined)
+    assert.strictEqual(fakeSentry.state.captured.length, 0)
+  })
+
+  it('applies tags, contexts, and extras inside an isolation scope', () => {
+    const fakeSentry = createFakeSentry()
+
+    const result = withSentryIsolationScope(
+      {
+        tags: { route: 'chat', is_scheduled_task: false },
+        contexts: { request: { conversationId: '123' } },
+        extras: { provider: 'openai' },
+      },
+      () => 'ok',
+      fakeSentry.client,
+    )
+
+    assert.strictEqual(result, 'ok')
+    assert.deepStrictEqual(fakeSentry.state.tags, {
+      route: 'chat',
+      is_scheduled_task: 'false',
+    })
+    assert.deepStrictEqual(fakeSentry.state.contexts, {
+      request: { conversationId: '123' },
+    })
+    assert.deepStrictEqual(fakeSentry.state.extras, { provider: 'openai' })
+  })
+
+  it('returns safe public error messages', () => {
+    assert.strictEqual(
+      getPublicErrorMessage(new Error('provider limit exceeded')),
+      'provider limit exceeded',
+    )
+    assert.strictEqual(getPublicErrorMessage('bad request'), 'bad request')
+    assert.strictEqual(
+      getPublicErrorMessage(new Error(''), 'fallback'),
+      'fallback',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- capture chat, graph, SDK, MCP, and Klavis server-side failures that previously only logged or returned JSON/SSE
- capture AI SDK agent creation and chat stream errors with scoped Sentry metadata and duplicate-suppression
- capture extension chat transport failures for sidepanel, new tab, workflow, graph, and scheduled-job chat flows

## Design

This change adds small shared Sentry helpers on the server and extension, then applies them at the actual error boundaries: Hono route catches, global `onError`, `ChatService` stream setup, `createAgentUIStreamResponse` `onError`, and the main `useChat` entrypoints. The server keeps existing response shapes while attaching route/conversation/provider context and preventing duplicate captures when the same exception crosses multiple layers.

## Test Plan

- `bun run lint`
- `bun run --filter @browseros/server typecheck`
- `bun test apps/server/tests/lib/sentry-utils.test.ts`
- `bun test apps/server/tests/api/routes/klavis.test.ts`
- `bun run --filter @browseros/agent typecheck` currently hits Node heap limits in this repo before emitting diagnostics
