### PR TITLE
fix: update Kimi K2.5 context window from 128K to 256K

### DIFF
--- a/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -30,7 +30,7 @@ export interface ModelsData {
  * Based on: https://github.com/browseros-ai/BrowserOS-agent/blob/main/src/options/data/models.ts
  */
 export const MODELS_DATA: ModelsData = {
-  moonshot: [{ modelId: 'kimi-k2.5', contextLength: 128000 }],
+  moonshot: [{ modelId: 'kimi-k2.5', contextLength: 256000 }],
   anthropic: [
     { modelId: 'claude-opus-4-5-20251101', contextLength: 200000 },
     { modelId: 'claude-haiku-4-5-20251001', contextLength: 200000 },

--- a/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -26,7 +26,7 @@ export const providerTemplates: ProviderTemplate[] = [
     defaultBaseUrl: 'https://api.moonshot.ai/v1',
     defaultModelId: 'kimi-k2.5',
     supportsImages: true,
-    contextWindow: 128000,
+    contextWindow: 256000,
     apiKeyUrl: 'https://platform.moonshot.ai/console/api-keys',
     setupGuideUrl: 'https://platform.moonshot.ai/console/api-keys',
   },


### PR DESCRIPTION
## Summary
- Updated Kimi K2.5 context window from 128,000 to 256,000 tokens in provider templates and model config
- Corrects the context window value per Moonshot AI partner feedback

## Changes
- `apps/agent/lib/llm-providers/providerTemplates.ts` — moonshot contextWindow: 128000 → 256000
- `apps/agent/entrypoints/app/ai-settings/models.ts` — moonshot contextLength: 128000 → 256000

## Test plan
- [ ] Verify AI Settings page shows 256,000 context window for Kimi K2.5
- [ ] Verify Moonshot AI provider template uses correct context window

🤖 Generated with [Claude Code](https://claude.com/claude-code)