### PR TITLE
feat: update new tab placeholder copy

### DIFF
--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -126,6 +126,10 @@ export const NewTab = () => {
     query: inputValue,
     selectedTabs,
   })
+  const searchPlaceholder =
+    providerConfig.id === 'google'
+      ? 'Ask BrowserOS or search Google...'
+      : `Ask BrowserOS or search ${providerConfig.name}...`
 
   const {
     isOpen,
@@ -424,7 +428,7 @@ export const NewTab = () => {
               />
               <input
                 type="text"
-                placeholder={`Ask AI or search ${providerConfig.name}...`}
+                placeholder={searchPlaceholder}
                 className="flex-1 border-none bg-transparent text-base text-foreground outline-none placeholder:text-muted-foreground"
                 {...getInputProps({
                   ref: inputRef,

--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -126,10 +126,7 @@ export const NewTab = () => {
     query: inputValue,
     selectedTabs,
   })
-  const searchPlaceholder =
-    providerConfig.id === 'google'
-      ? 'Ask BrowserOS or search Google...'
-      : `Ask BrowserOS or search ${providerConfig.name}...`
+  const searchPlaceholder = `Ask BrowserOS or search ${providerConfig.name}...`
 
   const {
     isOpen,


### PR DESCRIPTION
## Summary
- Update the new-tab input placeholder to say `Ask BrowserOS or search Google...` for the default Google search provider.
- Preserve accurate provider labeling for non-Google search engines in the same input.
- Limit the change to the new-tab search/chat entry point without altering search execution behavior.

## Design
The new-tab component now derives its placeholder from the selected provider configuration. Google uses the requested BrowserOS-branded copy, while alternate search engines keep their existing provider-specific naming so the UI remains accurate without adding new shared abstractions.

## Test plan
- Run `bunx biome check apps/agent/entrypoints/newtab/index/NewTab.tsx`.
- Attempt `bun run --filter @browseros/agent typecheck`.
- Inspect the new-tab placeholder logic in `apps/agent/entrypoints/newtab/index/NewTab.tsx` for Google and non-Google provider behavior.