### PR TITLE
feat: add full-page conversation history rail

### DIFF
--- a/apps/agent/entrypoints/app/create-graph/GraphChat.tsx
+++ b/apps/agent/entrypoints/app/create-graph/GraphChat.tsx
@@ -145,6 +145,7 @@ export const GraphChat: FC<GraphChatProps> = ({
             status={status}
             messagesEndRef={messagesEndRef}
             showJtbdPopup={popupVisible}
+            showDontShowAgain={false}
             onTakeSurvey={onTakeSurvey}
             onDismissJtbdPopup={onDismissJtbdPopup}
           />

--- a/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
+++ b/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
@@ -16,6 +16,7 @@ const COLLAPSE_DELAY = 150
 export const SidebarLayout: FC = () => {
   const location = useLocation()
   const isMobile = useIsMobile()
+  const isHomeRoute = location.pathname === '/home'
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [mobileOpen, setMobileOpen] = useState(false)
   const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false)
@@ -104,7 +105,13 @@ export const SidebarLayout: FC = () => {
 
         {/* Main content - full width, centered */}
         <main className="min-h-screen overflow-y-auto">
-          <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+          <div
+            className={
+              isHomeRoute
+                ? 'mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8 lg:pl-16'
+                : 'mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8'
+            }
+          >
             <Outlet />
           </div>
         </main>

--- a/apps/agent/entrypoints/newtab/history/NewTabChatHistoryPanel.tsx
+++ b/apps/agent/entrypoints/newtab/history/NewTabChatHistoryPanel.tsx
@@ -1,0 +1,67 @@
+import { MessageSquareText, Plus } from 'lucide-react'
+import type { FC } from 'react'
+import { useNavigate } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { ChatHistory } from '@/entrypoints/sidepanel/history/ChatHistory'
+import { useChatSessionContext } from '@/entrypoints/sidepanel/layout/ChatSessionContext'
+import { cn } from '@/lib/utils'
+
+const getNewTabConversationHref = (conversationId: string) =>
+  `/home?conversationId=${conversationId}`
+
+interface NewTabChatHistoryPanelProps {
+  className?: string
+}
+
+export const NewTabChatHistoryPanel: FC<NewTabChatHistoryPanelProps> = ({
+  className,
+}) => {
+  const navigate = useNavigate()
+  const { resetConversation } = useChatSessionContext()
+
+  const handleNewConversation = () => {
+    resetConversation()
+    navigate('/home')
+  }
+
+  return (
+    <section
+      className={cn(
+        'flex min-h-0 flex-col overflow-hidden rounded-[1.75rem] border border-border/70 bg-card/90 shadow-[0_18px_60px_-42px_rgba(15,23,42,0.35)] backdrop-blur-sm',
+        className,
+      )}
+    >
+      <div className="border-border/70 border-b bg-gradient-to-b from-background via-card to-card px-5 py-5">
+        <div className="flex items-start gap-3">
+          <div className="flex size-11 items-center justify-center rounded-2xl border border-primary/20 bg-primary/10 text-primary">
+            <MessageSquareText className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <h2 className="font-semibold text-base">Conversations</h2>
+            <p className="mt-1 text-muted-foreground text-sm leading-5">
+              Pick up where you left off or clear the slate for a new BrowserOS
+              run.
+            </p>
+          </div>
+        </div>
+
+        <Button
+          variant="outline"
+          onClick={handleNewConversation}
+          className="mt-4 w-full justify-between rounded-xl border-border/70 bg-background/70 px-4"
+        >
+          Start new chat
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 px-2 pb-2">
+        <ChatHistory
+          variant="page"
+          newConversationHref="/home"
+          getConversationHref={getNewTabConversationHref}
+        />
+      </div>
+    </section>
+  )
+}

--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -50,6 +50,7 @@ import { openSidePanelWithSearch } from '@/lib/messaging/sidepanel/openSidepanel
 import { track } from '@/lib/metrics/track'
 import { cn } from '@/lib/utils'
 import { useWorkspace } from '@/lib/workspace/use-workspace'
+import { NewTabChatHistoryPanel } from '../history/NewTabChatHistoryPanel'
 import { ImportDataHint } from './ImportDataHint'
 import type { SuggestionItem } from './lib/suggestions/types'
 import {
@@ -94,8 +95,13 @@ export const NewTab = () => {
   const { servers: mcpServers } = useMcpServers()
   const { data: userMCPIntegrations } = useGetUserMCPIntegrations()
 
-  const { messages, sendMessage, setMode, resetConversation } =
-    useChatSessionContext()
+  const {
+    messages,
+    sendMessage,
+    setMode,
+    resetConversation,
+    isRestoringConversation,
+  } = useChatSessionContext()
 
   const connectedManagedServers = mcpServers.filter((s) => {
     if (s.type !== 'managed' || !s.managedServerName) return false
@@ -366,219 +372,271 @@ export const NewTab = () => {
     track(NEWTAB_OPENED_EVENT)
   }, [])
 
-  if (chatActive) {
-    return <NewTabChat onBackToSearch={handleBackToSearch} />
+  const showChat = chatActive || messages.length > 0 || isRestoringConversation
+
+  if (showChat) {
+    return (
+      <div className="grid min-h-[calc(100vh-2rem)] gap-6 xl:grid-cols-[20rem_minmax(0,1fr)]">
+        <aside className="hidden xl:block">
+          <NewTabChatHistoryPanel className="sticky top-8 h-[calc(100vh-4rem)]" />
+        </aside>
+        <div className="min-w-0">
+          <NewTabChat onBackToSearch={handleBackToSearch} />
+        </div>
+      </div>
+    )
   }
 
   return (
-    <div className="pt-[max(25vh,16px)]">
-      {/* Main content */}
-      <div className={'relative w-full space-y-8 md:w-3xl'}>
-        {/* Logo and branding */}
-        <NewTabBranding />
-        {/* Search bar with context */}
-        <div
-          className={cn(
-            'relative overflow-hidden bg-border/50 p-[2px]',
-            isSuggestionsVisible ||
-              mentionState.isOpen ||
-              selectedTabs.length > 0
-              ? 'bg-[var(--accent-orange)]/30 shadow-[var(--accent-orange)]/10'
-              : 'bg-border/50 hover:border-border',
-          )}
-          style={{ borderRadius: '1.5rem' }}
-        >
-          {mounted && (
+    <div className="grid gap-6 xl:grid-cols-[20rem_minmax(0,1fr)]">
+      <aside className="hidden xl:block">
+        <NewTabChatHistoryPanel className="sticky top-8 h-[calc(100vh-4rem)]" />
+      </aside>
+
+      <div className="min-w-0">
+        <div className="xl:hidden">
+          <NewTabChatHistoryPanel className="mb-6 max-h-[26rem]" />
+        </div>
+
+        <div className="pt-6 md:pt-10 xl:pt-[max(25vh,16px)]">
+          <div className="relative mx-auto w-full max-w-3xl space-y-8">
+            <NewTabBranding />
             <div
-              className="absolute inset-0"
+              className={cn(
+                'relative overflow-hidden bg-border/50 p-[2px]',
+                isSuggestionsVisible ||
+                  mentionState.isOpen ||
+                  selectedTabs.length > 0
+                  ? 'bg-[var(--accent-orange)]/30 shadow-[var(--accent-orange)]/10'
+                  : 'bg-border/50 hover:border-border',
+              )}
               style={{ borderRadius: '1.5rem' }}
             >
-              <GlowingBorder duration={2000} delay={0} rx="1.5rem" ry="1.5rem">
-                <GlowingElement />
-              </GlowingBorder>
-            </div>
-          )}
-          <div
-            className={cn(
-              'relative bg-card shadow-lg',
-              isSuggestionsVisible ||
-                mentionState.isOpen ||
-                selectedTabs.length > 0
-                ? 'border-[var(--accent-orange)]/30 shadow-[var(--accent-orange)]/10'
-                : 'border-border/50 hover:border-border',
-            )}
-            style={{ borderRadius: 'calc(1.5rem - 2px)' }}
-          >
-            {/* Main search input */}
-            <div className="flex items-center gap-3 px-5 py-4">
-              <Search className="h-5 w-5 flex-shrink-0 text-muted-foreground" />
-
-              <TabPickerPopover
-                variant="mention"
-                isOpen={mentionState.isOpen}
-                filterText={mentionState.filterText}
-                selectedTabs={selectedTabs}
-                onToggleTab={toggleTab}
-                onClose={closeMention}
-                anchorRef={inputRef}
-                side="bottom"
-              />
-              <input
-                type="text"
-                placeholder={searchPlaceholder}
-                className="flex-1 border-none bg-transparent text-base text-foreground outline-none placeholder:text-muted-foreground"
-                {...getInputProps({
-                  ref: inputRef,
-                  onChange: (e) => handleInputChange(e.currentTarget.value),
-                  onKeyDown: (e) => {
-                    if (!mentionStateRef.current.isOpen) return
-                    if (e.key === 'Tab') {
-                      e.preventDefault()
-                      closeMention()
-                    }
-                  },
-                })}
-              />
-
-              <Button
-                onClick={handleSend}
-                size="icon"
-                className="h-10 w-10 flex-shrink-0 rounded-xl bg-primary text-primary-foreground hover:bg-primary/90"
-              >
-                <ArrowRight className="h-5 w-5" />
-              </Button>
-            </div>
-
-            <AnimatePresence>
-              {selectedTabs.length > 0 && (
-                <motion.div
-                  className="overflow-clip px-5 pb-4"
-                  transition={{ duration: 0.2 }}
-                  initial={{ opacity: 0, height: 0 }}
-                  animate={{ opacity: 1, height: 'auto' }}
-                  exit={{ opacity: 0, height: 0 }}
+              {mounted && (
+                <div
+                  className="absolute inset-0"
+                  style={{ borderRadius: '1.5rem' }}
                 >
-                  <div className="styled-scrollbar flex gap-3 overflow-x-auto pb-2">
-                    <AnimatePresence>
-                      {selectedTabs.map((selectedTab) => {
-                        if (!selectedTab) return null
-                        return (
-                          <motion.div
-                            key={selectedTab.id}
-                            className="group w-48 flex-shrink-0 overflow-clip rounded-lg border border-border bg-accent/50 p-3 transition-colors hover:bg-accent"
-                            transition={{ duration: 0.2 }}
-                            initial={{ opacity: 0, height: 0 }}
-                            animate={{ opacity: 1, height: 'auto' }}
-                            exit={{ opacity: 0, height: 0 }}
-                          >
-                            <div className="flex items-start gap-3">
-                              <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border border-border bg-background">
-                                {selectedTab.favIconUrl ? (
-                                  <img
-                                    src={selectedTab.favIconUrl}
-                                    alt={selectedTab.title}
-                                    className="h-6 w-6"
-                                  />
-                                ) : (
-                                  <Globe className="h-6 w-6" />
-                                )}
-                              </div>
-                              <div className="min-w-0 flex-1">
-                                <div className="mb-1 truncate font-medium text-foreground text-sm">
-                                  {selectedTab.title}
-                                </div>
-                                <div className="text-muted-foreground text-xs">
-                                  Tab
-                                </div>
-                              </div>
-                              <button
-                                type="button"
-                                onClick={() => removeTab(selectedTab.id)}
-                                className="cursor-pointer rounded p-1 opacity-0 transition-opacity hover:bg-background group-hover:opacity-100"
-                              >
-                                <X className="h-3 w-3" />
-                              </button>
-                            </div>
-                          </motion.div>
-                        )
-                      })}
-                    </AnimatePresence>
-                  </div>
-                </motion.div>
+                  <GlowingBorder
+                    duration={2000}
+                    delay={0}
+                    rx="1.5rem"
+                    ry="1.5rem"
+                  >
+                    <GlowingElement />
+                  </GlowingBorder>
+                </div>
               )}
-            </AnimatePresence>
+              <div
+                className={cn(
+                  'relative bg-card shadow-lg',
+                  isSuggestionsVisible ||
+                    mentionState.isOpen ||
+                    selectedTabs.length > 0
+                    ? 'border-[var(--accent-orange)]/30 shadow-[var(--accent-orange)]/10'
+                    : 'border-border/50 hover:border-border',
+                )}
+                style={{ borderRadius: 'calc(1.5rem - 2px)' }}
+              >
+                <div className="flex items-center gap-3 px-5 py-4">
+                  <Search className="h-5 w-5 flex-shrink-0 text-muted-foreground" />
 
-            <AnimatePresence>
-              {isSuggestionsVisible && (
-                <SearchSuggestions
-                  getItemProps={getItemProps}
-                  getMenuProps={getMenuProps}
-                  highlightedIndex={highlightedIndex}
-                  sections={sections}
-                />
-              )}
-            </AnimatePresence>
+                  <TabPickerPopover
+                    variant="mention"
+                    isOpen={mentionState.isOpen}
+                    filterText={mentionState.filterText}
+                    selectedTabs={selectedTabs}
+                    onToggleTab={toggleTab}
+                    onClose={closeMention}
+                    anchorRef={inputRef}
+                    side="bottom"
+                  />
+                  <input
+                    type="text"
+                    placeholder={searchPlaceholder}
+                    className="flex-1 border-none bg-transparent text-base text-foreground outline-none placeholder:text-muted-foreground"
+                    {...getInputProps({
+                      ref: inputRef,
+                      onChange: (e) => handleInputChange(e.currentTarget.value),
+                      onKeyDown: (e) => {
+                        if (!mentionStateRef.current.isOpen) return
+                        if (e.key === 'Tab') {
+                          e.preventDefault()
+                          closeMention()
+                        }
+                      },
+                    })}
+                  />
 
-            {mounted && (
-              <div className="flex items-center justify-between border-border/50 border-t px-5 py-3">
-                <div className="flex items-center gap-1">
-                  {supports(Feature.WORKSPACE_FOLDER_SUPPORT) && (
-                    <WorkspaceSelector>
-                      <Button
-                        variant="ghost"
-                        onClick={() => track(NEWTAB_WORKSPACE_OPENED_EVENT)}
-                        className={cn(
-                          'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
-                          'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                          'data-[state=open]:bg-accent',
-                        )}
-                      >
-                        <Folder className="h-4 w-4" />
-                        <span>{selectedFolder?.name || 'Add workspace'}</span>
-                        <ChevronDown className="h-3 w-3" />
-                      </Button>
-                    </WorkspaceSelector>
-                  )}
-
-                  <div className="relative" ref={tabsDropdownRef}>
-                    <TabPickerPopover
-                      variant="selector"
-                      selectedTabs={selectedTabs}
-                      onToggleTab={toggleTab}
-                    >
-                      <Button
-                        onClick={() => track(NEWTAB_TABS_OPENED_EVENT)}
-                        className={cn(
-                          'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
-                          selectedTabs.length > 0
-                            ? 'bg-[var(--accent-orange)]! text-white shadow-sm'
-                            : 'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                          'data-[state=open]:bg-accent',
-                        )}
-                      >
-                        <Layers className="h-4 w-4" />
-                        <span>Tabs</span>
-                      </Button>
-                    </TabPickerPopover>
-                  </div>
+                  <Button
+                    onClick={handleSend}
+                    size="icon"
+                    className="h-10 w-10 flex-shrink-0 rounded-xl bg-primary text-primary-foreground hover:bg-primary/90"
+                  >
+                    <ArrowRight className="h-5 w-5" />
+                  </Button>
                 </div>
 
-                {supports(Feature.MANAGED_MCP_SUPPORT) && (
-                  <div className="ml-auto flex items-center gap-1.5">
-                    {connectedManagedServers.length === 0 && (
-                      <span className="flex items-center gap-1 font-semibold text-[var(--accent-orange)] text-sm">
-                        New!
-                      </span>
-                    )}
-                    {connectedManagedServers.length === 0 ? (
-                      <Tooltip>
-                        <AppSelector side="bottom">
-                          <TooltipTrigger asChild>
+                <AnimatePresence>
+                  {selectedTabs.length > 0 && (
+                    <motion.div
+                      className="overflow-clip px-5 pb-4"
+                      transition={{ duration: 0.2 }}
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                    >
+                      <div className="styled-scrollbar flex gap-3 overflow-x-auto pb-2">
+                        <AnimatePresence>
+                          {selectedTabs.map((selectedTab) => {
+                            if (!selectedTab) return null
+                            return (
+                              <motion.div
+                                key={selectedTab.id}
+                                className="group w-48 flex-shrink-0 overflow-clip rounded-lg border border-border bg-accent/50 p-3 transition-colors hover:bg-accent"
+                                transition={{ duration: 0.2 }}
+                                initial={{ opacity: 0, height: 0 }}
+                                animate={{ opacity: 1, height: 'auto' }}
+                                exit={{ opacity: 0, height: 0 }}
+                              >
+                                <div className="flex items-start gap-3">
+                                  <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border border-border bg-background">
+                                    {selectedTab.favIconUrl ? (
+                                      <img
+                                        src={selectedTab.favIconUrl}
+                                        alt={selectedTab.title}
+                                        className="h-6 w-6"
+                                      />
+                                    ) : (
+                                      <Globe className="h-6 w-6" />
+                                    )}
+                                  </div>
+                                  <div className="min-w-0 flex-1">
+                                    <div className="mb-1 truncate font-medium text-foreground text-sm">
+                                      {selectedTab.title}
+                                    </div>
+                                    <div className="text-muted-foreground text-xs">
+                                      Tab
+                                    </div>
+                                  </div>
+                                  <button
+                                    type="button"
+                                    onClick={() => removeTab(selectedTab.id)}
+                                    className="cursor-pointer rounded p-1 opacity-0 transition-opacity hover:bg-background group-hover:opacity-100"
+                                  >
+                                    <X className="h-3 w-3" />
+                                  </button>
+                                </div>
+                              </motion.div>
+                            )
+                          })}
+                        </AnimatePresence>
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+
+                <AnimatePresence>
+                  {isSuggestionsVisible && (
+                    <SearchSuggestions
+                      getItemProps={getItemProps}
+                      getMenuProps={getMenuProps}
+                      highlightedIndex={highlightedIndex}
+                      sections={sections}
+                    />
+                  )}
+                </AnimatePresence>
+
+                {mounted && (
+                  <div className="flex items-center justify-between border-border/50 border-t px-5 py-3">
+                    <div className="flex items-center gap-1">
+                      {supports(Feature.WORKSPACE_FOLDER_SUPPORT) && (
+                        <WorkspaceSelector>
+                          <Button
+                            variant="ghost"
+                            onClick={() => track(NEWTAB_WORKSPACE_OPENED_EVENT)}
+                            className={cn(
+                              'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
+                              'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                              'data-[state=open]:bg-accent',
+                            )}
+                          >
+                            <Folder className="h-4 w-4" />
+                            <span>
+                              {selectedFolder?.name || 'Add workspace'}
+                            </span>
+                            <ChevronDown className="h-3 w-3" />
+                          </Button>
+                        </WorkspaceSelector>
+                      )}
+
+                      <div className="relative" ref={tabsDropdownRef}>
+                        <TabPickerPopover
+                          variant="selector"
+                          selectedTabs={selectedTabs}
+                          onToggleTab={toggleTab}
+                        >
+                          <Button
+                            onClick={() => track(NEWTAB_TABS_OPENED_EVENT)}
+                            className={cn(
+                              'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
+                              selectedTabs.length > 0
+                                ? 'bg-[var(--accent-orange)]! text-white shadow-sm'
+                                : 'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                              'data-[state=open]:bg-accent',
+                            )}
+                          >
+                            <Layers className="h-4 w-4" />
+                            <span>Tabs</span>
+                          </Button>
+                        </TabPickerPopover>
+                      </div>
+                    </div>
+
+                    {supports(Feature.MANAGED_MCP_SUPPORT) && (
+                      <div className="ml-auto flex items-center gap-1.5">
+                        {connectedManagedServers.length === 0 && (
+                          <span className="flex items-center gap-1 font-semibold text-[var(--accent-orange)] text-sm">
+                            New!
+                          </span>
+                        )}
+                        {connectedManagedServers.length === 0 ? (
+                          <Tooltip>
+                            <AppSelector side="bottom">
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  onClick={() =>
+                                    track(NEWTAB_APPS_OPENED_EVENT, {
+                                      has_connected_apps: false,
+                                    })
+                                  }
+                                  className={cn(
+                                    'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
+                                    'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                                    'data-[state=open]:bg-accent',
+                                  )}
+                                >
+                                  <PlugZap className="h-4 w-4" />
+                                  <span>Apps</span>
+                                  <ChevronDown className="h-3 w-3" />
+                                </Button>
+                              </TooltipTrigger>
+                            </AppSelector>
+                            <TooltipContent side="left" className="max-w-56">
+                              Apps directly connected will have more accurate
+                              and faster responses for your queries!
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <AppSelector side="bottom">
                             <Button
                               variant="ghost"
                               onClick={() =>
                                 track(NEWTAB_APPS_OPENED_EVENT, {
-                                  has_connected_apps: false,
+                                  has_connected_apps: true,
+                                  connected_count:
+                                    connectedManagedServers.length,
                                 })
                               }
                               className={cn(
@@ -587,69 +645,43 @@ export const NewTab = () => {
                                 'data-[state=open]:bg-accent',
                               )}
                             >
-                              <PlugZap className="h-4 w-4" />
+                              <div className="flex items-center -space-x-1.5">
+                                {connectedManagedServers
+                                  .slice(0, 4)
+                                  .map((s) => (
+                                    <div
+                                      key={s.id}
+                                      className="rounded-full ring-2 ring-card"
+                                    >
+                                      <McpServerIcon
+                                        serverName={s.managedServerName ?? ''}
+                                        size={16}
+                                      />
+                                    </div>
+                                  ))}
+                              </div>
+                              {connectedManagedServers.length > 4 && (
+                                <span className="text-xs">
+                                  +{connectedManagedServers.length - 4}
+                                </span>
+                              )}
                               <span>Apps</span>
                               <ChevronDown className="h-3 w-3" />
                             </Button>
-                          </TooltipTrigger>
-                        </AppSelector>
-                        <TooltipContent side="left" className="max-w-56">
-                          Apps directly connected will have more accurate and
-                          faster responses for your queries!
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : (
-                      <AppSelector side="bottom">
-                        <Button
-                          variant="ghost"
-                          onClick={() =>
-                            track(NEWTAB_APPS_OPENED_EVENT, {
-                              has_connected_apps: true,
-                              connected_count: connectedManagedServers.length,
-                            })
-                          }
-                          className={cn(
-                            'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
-                            'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                            'data-[state=open]:bg-accent',
-                          )}
-                        >
-                          <div className="flex items-center -space-x-1.5">
-                            {connectedManagedServers.slice(0, 4).map((s) => (
-                              <div
-                                key={s.id}
-                                className="rounded-full ring-2 ring-card"
-                              >
-                                <McpServerIcon
-                                  serverName={s.managedServerName ?? ''}
-                                  size={16}
-                                />
-                              </div>
-                            ))}
-                          </div>
-                          {connectedManagedServers.length > 4 && (
-                            <span className="text-xs">
-                              +{connectedManagedServers.length - 4}
-                            </span>
-                          )}
-                          <span>Apps</span>
-                          <ChevronDown className="h-3 w-3" />
-                        </Button>
-                      </AppSelector>
+                          </AppSelector>
+                        )}
+                      </div>
                     )}
                   </div>
                 )}
               </div>
-            )}
+            </div>
+
+            {mounted && !isSuggestionsVisible && <NewTabTip />}
+            {!isSuggestionsVisible && <TopSites />}
+            {mounted && !isSuggestionsVisible && <ScheduleResults />}
           </div>
         </div>
-
-        {mounted && !isSuggestionsVisible && <NewTabTip />}
-
-        {/* Top sites */}
-        {!isSuggestionsVisible && <TopSites />}
-
-        {mounted && !isSuggestionsVisible && <ScheduleResults />}
       </div>
       {mounted && (
         <ShortcutsDialog

--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -389,15 +389,11 @@ export const NewTab = () => {
 
   return (
     <div className="grid gap-6 xl:grid-cols-[20rem_minmax(0,1fr)]">
-      <aside className="hidden xl:block">
-        <NewTabChatHistoryPanel className="sticky top-8 h-[calc(100vh-4rem)]" />
+      <aside>
+        <NewTabChatHistoryPanel className="mb-6 max-h-[26rem] xl:sticky xl:top-8 xl:mb-0 xl:h-[calc(100vh-4rem)]" />
       </aside>
 
       <div className="min-w-0">
-        <div className="xl:hidden">
-          <NewTabChatHistoryPanel className="mb-6 max-h-[26rem]" />
-        </div>
-
         <div className="pt-6 md:pt-10 xl:pt-[max(25vh,16px)]">
           <div className="relative mx-auto w-full max-w-3xl space-y-8">
             <NewTabBranding />

--- a/apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx
+++ b/apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx
@@ -3,6 +3,7 @@ import type { UIMessage } from 'ai'
 import { Loader2 } from 'lucide-react'
 import type { FC } from 'react'
 import { useMemo } from 'react'
+import { useNavigate } from 'react-router'
 import { useSessionInfo } from '@/lib/auth/sessionStorage'
 import { useConversations } from '@/lib/conversations/conversationStorage'
 import { GetProfileIdByUserIdDocument } from '@/lib/conversations/graphql/uploadConversationDocument'
@@ -12,7 +13,10 @@ import { useGraphqlMutation } from '@/lib/graphql/useGraphqlMutation'
 import { useGraphqlQuery } from '@/lib/graphql/useGraphqlQuery'
 import { useChatSessionContext } from '../layout/ChatSessionContext'
 import { ConversationList } from './components/ConversationList'
-import type { HistoryConversation } from './components/types'
+import type {
+  HistoryConversation,
+  HistoryListVariant,
+} from './components/types'
 import { extractLastUserMessage, groupConversations } from './components/utils'
 import {
   DeleteConversationDocument,
@@ -20,8 +24,26 @@ import {
 } from './graphql/chatHistoryDocument'
 import { LocalChatHistory } from './local/LocalChatHistory'
 
-const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
-  const { conversationId: activeConversationId } = useChatSessionContext()
+const DEFAULT_HISTORY_HREF = (conversationId: string) =>
+  `/?conversationId=${conversationId}`
+
+interface RemoteChatHistoryProps {
+  userId: string
+  activeConversationId: string
+  getConversationHref: (conversationId: string) => string
+  onNewConversation: () => void
+  onNavigate?: () => void
+  variant?: HistoryListVariant
+}
+
+const RemoteChatHistory: FC<RemoteChatHistoryProps> = ({
+  userId,
+  activeConversationId,
+  getConversationHref,
+  onNewConversation,
+  onNavigate,
+  variant = 'sidepanel',
+}) => {
   const queryClient = useQueryClient()
 
   const { data: profileData } = useGraphqlQuery(GetProfileIdByUserIdDocument, {
@@ -112,19 +134,61 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
       hasNextPage={hasNextPage}
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={fetchNextPage}
+      getConversationHref={getConversationHref}
+      onNewConversation={onNewConversation}
+      onNavigate={onNavigate}
+      variant={variant}
     />
   )
 }
 
-export const ChatHistory: FC = () => {
+interface ChatHistoryProps {
+  getConversationHref?: (conversationId: string) => string
+  newConversationHref?: string
+  onNavigate?: () => void
+  variant?: HistoryListVariant
+}
+
+export const ChatHistory: FC<ChatHistoryProps> = ({
+  getConversationHref = DEFAULT_HISTORY_HREF,
+  newConversationHref = '/',
+  onNavigate,
+  variant = 'sidepanel',
+}) => {
   const { sessionInfo } = useSessionInfo()
+  const navigate = useNavigate()
+  const { conversationId: activeConversationId, resetConversation } =
+    useChatSessionContext()
   const userId = sessionInfo.user?.id
   // needed to initiate remote-sync
   useConversations()
 
-  if (userId) {
-    return <RemoteChatHistory userId={userId} />
+  const handleNewConversation = () => {
+    resetConversation()
+    navigate(newConversationHref)
+    onNavigate?.()
   }
 
-  return <LocalChatHistory />
+  if (userId) {
+    return (
+      <RemoteChatHistory
+        userId={userId}
+        activeConversationId={activeConversationId}
+        getConversationHref={getConversationHref}
+        onNewConversation={handleNewConversation}
+        onNavigate={onNavigate}
+        variant={variant}
+      />
+    )
+  }
+
+  return (
+    <LocalChatHistory
+      activeConversationId={activeConversationId}
+      getConversationHref={getConversationHref}
+      onNewConversation={handleNewConversation}
+      onNavigate={onNavigate}
+      variant={variant}
+    />
+  )
 }

--- a/apps/agent/entrypoints/sidepanel/history/components/ConversationGroup.tsx
+++ b/apps/agent/entrypoints/sidepanel/history/components/ConversationGroup.tsx
@@ -1,12 +1,16 @@
 import type { FC } from 'react'
+import { cn } from '@/lib/utils'
 import { ConversationItem } from './ConversationItem'
-import type { HistoryConversation } from './types'
+import type { HistoryConversation, HistoryListVariant } from './types'
 
 interface ConversationGroupProps {
   label: string
   conversations: HistoryConversation[]
   onDelete?: (id: string) => void
   activeConversationId: string
+  getConversationHref: (conversationId: string) => string
+  onNavigate?: () => void
+  variant?: HistoryListVariant
 }
 
 export const ConversationGroup: FC<ConversationGroupProps> = ({
@@ -14,12 +18,20 @@ export const ConversationGroup: FC<ConversationGroupProps> = ({
   conversations,
   onDelete,
   activeConversationId,
+  getConversationHref,
+  onNavigate,
+  variant = 'sidepanel',
 }) => {
   if (conversations.length === 0) return null
 
   return (
-    <div className="mb-4">
-      <h3 className="mb-2 px-3 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+    <div className={cn(variant === 'page' ? 'mb-6' : 'mb-4')}>
+      <h3
+        className={cn(
+          'font-semibold text-muted-foreground uppercase tracking-wider',
+          variant === 'page' ? 'mb-3 px-2 text-[11px]' : 'mb-2 px-3 text-xs',
+        )}
+      >
         {label}
       </h3>
       <div className="space-y-1">
@@ -29,6 +41,9 @@ export const ConversationGroup: FC<ConversationGroupProps> = ({
             conversation={conversation}
             onDelete={onDelete}
             isActive={conversation.id === activeConversationId}
+            href={getConversationHref(conversation.id)}
+            onNavigate={onNavigate}
+            variant={variant}
           />
         ))}
       </div>

--- a/apps/agent/entrypoints/sidepanel/history/components/ConversationItem.tsx
+++ b/apps/agent/entrypoints/sidepanel/history/components/ConversationItem.tsx
@@ -104,9 +104,7 @@ export const ConversationItem: FC<ConversationItemProps> = ({
             onClick={handleDeleteClick}
             className={cn(
               'shrink-0 rounded p-1 text-muted-foreground transition-opacity hover:bg-destructive/10 hover:text-destructive',
-              variant === 'page'
-                ? 'opacity-0 group-hover:opacity-100'
-                : 'opacity-0 group-hover:opacity-100',
+              'opacity-0 group-hover:opacity-100',
             )}
             title="Delete conversation"
           >

--- a/apps/agent/entrypoints/sidepanel/history/components/ConversationItem.tsx
+++ b/apps/agent/entrypoints/sidepanel/history/components/ConversationItem.tsx
@@ -13,7 +13,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import type { HistoryConversation } from './types'
+import { cn } from '@/lib/utils'
+import type { HistoryConversation, HistoryListVariant } from './types'
 
 dayjs.extend(relativeTime)
 
@@ -21,12 +22,18 @@ interface ConversationItemProps {
   conversation: HistoryConversation
   onDelete?: (id: string) => void
   isActive: boolean
+  href: string
+  onNavigate?: () => void
+  variant?: HistoryListVariant
 }
 
 export const ConversationItem: FC<ConversationItemProps> = ({
   conversation,
   onDelete,
   isActive,
+  href,
+  onNavigate,
+  variant = 'sidepanel',
 }) => {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const label = conversation.lastUserMessage
@@ -46,27 +53,61 @@ export const ConversationItem: FC<ConversationItemProps> = ({
   return (
     <>
       <Link
-        to={`/?conversationId=${conversation.id}`}
-        className={`group flex w-full items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/50 ${
-          isActive ? 'bg-muted/70' : ''
-        }`}
+        to={href}
+        onClick={onNavigate}
+        className={cn(
+          'group flex w-full items-start gap-3 transition-all',
+          variant === 'page'
+            ? 'rounded-2xl border border-border/70 bg-background/80 px-4 py-3 shadow-sm hover:-translate-y-px hover:border-primary/20 hover:bg-card hover:shadow-md'
+            : 'rounded-lg px-3 py-2.5 hover:bg-muted/50',
+          isActive &&
+            (variant === 'page'
+              ? 'border-primary/25 bg-primary/5 shadow-md'
+              : 'bg-muted/70'),
+        )}
       >
         <div
-          className={`mt-0.5 shrink-0 ${isActive ? 'text-primary' : 'text-muted-foreground'}`}
+          className={cn(
+            'shrink-0',
+            variant === 'page' &&
+              'flex size-10 items-center justify-center rounded-xl border border-border/70 bg-muted/60',
+            isActive ? 'text-primary' : 'text-muted-foreground',
+          )}
         >
-          <MessageSquare className="h-4 w-4" />
+          <MessageSquare
+            className={cn(variant === 'page' ? 'h-4 w-4' : 'mt-0.5 h-4 w-4')}
+          />
         </div>
         <div className="min-w-0 flex-1 overflow-hidden">
-          <p className="truncate font-medium text-foreground text-sm">
+          <p
+            className={cn(
+              'truncate font-medium text-foreground',
+              variant === 'page' ? 'text-sm leading-5' : 'text-sm',
+            )}
+          >
             {label}
           </p>
-          <p className="text-muted-foreground text-xs">{relativeTimeAgo}</p>
+          <p
+            className={cn(
+              'text-muted-foreground',
+              variant === 'page'
+                ? 'mt-1 text-[11px] uppercase tracking-[0.14em]'
+                : 'text-xs',
+            )}
+          >
+            {relativeTimeAgo}
+          </p>
         </div>
         {onDelete && (
           <button
             type="button"
             onClick={handleDeleteClick}
-            className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+            className={cn(
+              'shrink-0 rounded p-1 text-muted-foreground transition-opacity hover:bg-destructive/10 hover:text-destructive',
+              variant === 'page'
+                ? 'opacity-0 group-hover:opacity-100'
+                : 'opacity-0 group-hover:opacity-100',
+            )}
             title="Delete conversation"
           >
             <Trash2 className="h-3.5 w-3.5" />

--- a/apps/agent/entrypoints/sidepanel/history/components/ConversationList.tsx
+++ b/apps/agent/entrypoints/sidepanel/history/components/ConversationList.tsx
@@ -1,8 +1,9 @@
 import { Loader2, MessageSquare } from 'lucide-react'
 import { type FC, useEffect, useRef } from 'react'
-import { Link } from 'react-router'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { ConversationGroup } from './ConversationGroup'
-import type { GroupedConversations } from './types'
+import type { GroupedConversations, HistoryListVariant } from './types'
 import { TIME_GROUP_LABELS } from './utils'
 
 interface ConversationListProps {
@@ -12,6 +13,10 @@ interface ConversationListProps {
   hasNextPage?: boolean
   isFetchingNextPage?: boolean
   onLoadMore?: () => void
+  getConversationHref: (conversationId: string) => string
+  onNewConversation: () => void
+  onNavigate?: () => void
+  variant?: HistoryListVariant
 }
 
 export const ConversationList: FC<ConversationListProps> = ({
@@ -21,6 +26,10 @@ export const ConversationList: FC<ConversationListProps> = ({
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
+  getConversationHref,
+  onNewConversation,
+  onNavigate,
+  variant = 'sidepanel',
 }) => {
   const loadMoreRef = useRef<HTMLDivElement>(null)
 
@@ -55,17 +64,51 @@ export const ConversationList: FC<ConversationListProps> = ({
     groupedConversations.older.length > 0
 
   return (
-    <main className="mt-4 flex h-full flex-1 flex-col space-y-4 overflow-y-auto">
-      <div className="w-full p-3">
+    <main
+      className={cn(
+        'flex min-h-0 flex-1 flex-col',
+        variant === 'page'
+          ? 'h-full overflow-hidden'
+          : 'mt-4 h-full overflow-y-auto',
+      )}
+    >
+      <div
+        className={cn(
+          'w-full',
+          variant === 'page'
+            ? 'styled-scrollbar flex-1 overflow-y-auto px-3 pb-4'
+            : 'p-3',
+        )}
+      >
         {!hasConversations ? (
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <MessageSquare className="mb-3 h-10 w-10 text-muted-foreground/50" />
+          <div
+            className={cn(
+              'flex flex-col items-center justify-center py-12 text-center',
+              variant === 'page' &&
+                'rounded-2xl border border-border/80 border-dashed bg-muted/20 px-6',
+            )}
+          >
+            <MessageSquare
+              className={cn(
+                'mb-3 text-muted-foreground/50',
+                variant === 'page' ? 'h-11 w-11' : 'h-10 w-10',
+              )}
+            />
             <p className="text-muted-foreground text-sm">
               No conversations yet
             </p>
-            <Link to="/" className="mt-2 text-primary text-sm hover:underline">
+            <Button
+              variant={variant === 'page' ? 'default' : 'link'}
+              size={variant === 'page' ? 'sm' : 'default'}
+              onClick={onNewConversation}
+              className={cn(
+                'mt-3',
+                variant === 'page' &&
+                  'rounded-xl bg-primary px-4 text-primary-foreground shadow-sm hover:bg-primary/90',
+              )}
+            >
               Start a new chat
-            </Link>
+            </Button>
           </div>
         ) : (
           <>
@@ -74,24 +117,36 @@ export const ConversationList: FC<ConversationListProps> = ({
               conversations={groupedConversations.today}
               onDelete={onDelete}
               activeConversationId={activeConversationId}
+              getConversationHref={getConversationHref}
+              onNavigate={onNavigate}
+              variant={variant}
             />
             <ConversationGroup
               label={TIME_GROUP_LABELS.thisWeek}
               conversations={groupedConversations.thisWeek}
               onDelete={onDelete}
               activeConversationId={activeConversationId}
+              getConversationHref={getConversationHref}
+              onNavigate={onNavigate}
+              variant={variant}
             />
             <ConversationGroup
               label={TIME_GROUP_LABELS.thisMonth}
               conversations={groupedConversations.thisMonth}
               onDelete={onDelete}
               activeConversationId={activeConversationId}
+              getConversationHref={getConversationHref}
+              onNavigate={onNavigate}
+              variant={variant}
             />
             <ConversationGroup
               label={TIME_GROUP_LABELS.older}
               conversations={groupedConversations.older}
               onDelete={onDelete}
               activeConversationId={activeConversationId}
+              getConversationHref={getConversationHref}
+              onNavigate={onNavigate}
+              variant={variant}
             />
 
             {hasNextPage && (

--- a/apps/agent/entrypoints/sidepanel/history/components/types.ts
+++ b/apps/agent/entrypoints/sidepanel/history/components/types.ts
@@ -4,6 +4,8 @@ export interface HistoryConversation {
   lastUserMessage: string
 }
 
+export type HistoryListVariant = 'sidepanel' | 'page'
+
 export type TimeGroup = 'today' | 'thisWeek' | 'thisMonth' | 'older'
 
 export interface GroupedConversations {

--- a/apps/agent/entrypoints/sidepanel/history/components/utils.ts
+++ b/apps/agent/entrypoints/sidepanel/history/components/utils.ts
@@ -45,7 +45,11 @@ export const groupConversations = (
     older: [],
   }
 
-  for (const conversation of conversations) {
+  const sortedConversations = [...conversations].sort(
+    (a, b) => b.lastMessagedAt - a.lastMessagedAt,
+  )
+
+  for (const conversation of sortedConversations) {
     const group = getTimeGroup(conversation.lastMessagedAt)
     groups[group].push(conversation)
   }

--- a/apps/agent/entrypoints/sidepanel/history/local/LocalChatHistory.tsx
+++ b/apps/agent/entrypoints/sidepanel/history/local/LocalChatHistory.tsx
@@ -1,15 +1,30 @@
 import type { FC } from 'react'
 import { useMemo } from 'react'
 import { useConversations } from '@/lib/conversations/conversationStorage'
-import { useChatSessionContext } from '../../layout/ChatSessionContext'
 import { ConversationList } from '../components/ConversationList'
-import type { HistoryConversation } from '../components/types'
+import type {
+  HistoryConversation,
+  HistoryListVariant,
+} from '../components/types'
 import { extractLastUserMessage, groupConversations } from '../components/utils'
 
-export const LocalChatHistory: FC = () => {
+interface LocalChatHistoryProps {
+  activeConversationId: string
+  getConversationHref: (conversationId: string) => string
+  onNewConversation: () => void
+  onNavigate?: () => void
+  variant?: HistoryListVariant
+}
+
+export const LocalChatHistory: FC<LocalChatHistoryProps> = ({
+  activeConversationId,
+  getConversationHref,
+  onNewConversation,
+  onNavigate,
+  variant = 'sidepanel',
+}) => {
   const { conversations: localConversations, removeConversation } =
     useConversations()
-  const { conversationId: activeConversationId } = useChatSessionContext()
 
   const conversations = useMemo<HistoryConversation[]>(() => {
     return localConversations.map((conv) => ({
@@ -29,6 +44,10 @@ export const LocalChatHistory: FC = () => {
       groupedConversations={groupedConversations}
       activeConversationId={activeConversationId}
       onDelete={removeConversation}
+      getConversationHref={getConversationHref}
+      onNewConversation={onNewConversation}
+      onNavigate={onNavigate}
+      variant={variant}
     />
   )
 }


### PR DESCRIPTION
## Summary
- add a full-page conversation history rail to the `/home` agent experience
- reuse the existing sidepanel conversation history data, grouping, and delete flows across sidepanel and full-page surfaces
- ensure selecting a saved conversation restores it directly into the full-page chat experience

## Design
This keeps the existing sidepanel history pipeline as the source of truth, then makes the shared history list route-aware so it can serve both the sidepanel and the full-page `/home` experience. The full-page agent now renders a desktop history rail beside the main chat/search surface, while the full-page chat state derives visibility from restored conversations so `conversationId` links actually surface the saved thread.

## Test plan
- `bun run --filter @browseros/agent lint`
- `NODE_OPTIONS=--max-old-space-size=12288 bun run --filter @browseros/agent typecheck`
- `bun --env-file=apps/agent/.env.development run --filter @browseros/agent codegen`
- `bun run --filter @browseros/agent build:dev`
