### PR TITLE
feat: add generated file open pills for chat

### DIFF
--- a/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
@@ -38,6 +38,7 @@ export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
     disliked,
     onClickDislike,
     isRestoringConversation,
+    conversationId,
     providers,
     selectedProvider,
     handleSelectProvider,
@@ -148,6 +149,7 @@ export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
             messages={messages}
             status={status}
             messagesEndRef={messagesEndRef}
+            conversationId={conversationId}
             getActionForMessage={getActionForMessage}
             liked={liked}
             onClickLike={onClickLike}

--- a/apps/agent/entrypoints/sidepanel/index/Chat.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/Chat.tsx
@@ -37,6 +37,7 @@ export const Chat = () => {
     disliked,
     onClickDislike,
     isRestoringConversation,
+    conversationId,
   } = useChatSessionContext()
 
   const {
@@ -175,6 +176,7 @@ export const Chat = () => {
             messages={messages}
             status={status}
             messagesEndRef={messagesEndRef}
+            conversationId={conversationId}
             getActionForMessage={getActionForMessage}
             liked={liked}
             onClickLike={onClickLike}

--- a/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ai-elements/reasoning'
 import type { ChatAction } from '@/lib/chat-actions/types'
 import { ChatMessageActions } from './ChatMessageActions'
+import { GeneratedFileCards } from './GeneratedFileCards'
 import { getMessageSegments } from './getMessageSegments'
 import { JtbdPopup } from './JtbdPopup'
 import { ToolBatch } from './ToolBatch'
@@ -27,6 +28,7 @@ interface ChatMessagesProps {
   messages: UIMessage[]
   status: 'streaming' | 'submitted' | 'ready' | 'error'
   messagesEndRef: RefObject<HTMLDivElement | null>
+  conversationId?: string
   getActionForMessage?: (message: UIMessage) => ChatAction | undefined
   liked: Record<string, boolean>
   onClickLike: (messageId: string) => void
@@ -42,6 +44,7 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
   messages,
   status,
   messagesEndRef,
+  conversationId,
   getActionForMessage,
   liked,
   disliked,
@@ -121,6 +124,10 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
                         }
                       })
                     )}
+                    <GeneratedFileCards
+                      conversationId={conversationId}
+                      message={message}
+                    />
                   </MessageContent>
                 </Message>
                 {message.role === 'assistant' &&

--- a/apps/agent/entrypoints/sidepanel/index/GeneratedFileCards.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/GeneratedFileCards.tsx
@@ -1,0 +1,135 @@
+import type { UIMessage } from 'ai'
+import {
+  FileIcon,
+  FileTextIcon,
+  GlobeIcon,
+  ImageIcon,
+  Loader2Icon,
+} from 'lucide-react'
+import { type FC, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { getAgentServerUrl } from '@/lib/browseros/helpers'
+import { cn } from '@/lib/utils'
+import {
+  getGeneratedFilesFromMessage,
+  type MessageGeneratedFile,
+} from './generated-files'
+
+interface GeneratedFileCardsProps {
+  message: UIMessage
+  conversationId?: string
+}
+
+function getFileIcon(file: MessageGeneratedFile) {
+  if (file.mediaType?.startsWith('image/')) return ImageIcon
+  if (file.mediaType === 'text/html') return GlobeIcon
+  if (
+    file.mediaType?.startsWith('text/') ||
+    file.mediaType === 'application/pdf'
+  ) {
+    return FileTextIcon
+  }
+  return FileIcon
+}
+
+function getOpenLabel(file: MessageGeneratedFile): string {
+  return file.openMode === 'browser' ? 'Open' : 'Open in App'
+}
+
+function getOpenDescription(file: MessageGeneratedFile): string {
+  return file.openMode === 'browser'
+    ? `${file.typeLabel} - opens in browser`
+    : `${file.typeLabel} - opens in default app`
+}
+
+export const GeneratedFileCards: FC<GeneratedFileCardsProps> = ({
+  message,
+  conversationId,
+}) => {
+  const [pendingPath, setPendingPath] = useState<string | null>(null)
+  const files = getGeneratedFilesFromMessage(message)
+
+  if (!conversationId || files.length === 0) {
+    return null
+  }
+
+  const openFile = async (file: MessageGeneratedFile) => {
+    setPendingPath(file.path)
+
+    try {
+      const baseUrl = await getAgentServerUrl()
+
+      if (file.openMode === 'browser') {
+        const url = new URL(`/chat/${conversationId}/files`, baseUrl)
+        url.searchParams.set('path', file.path)
+        await chrome.tabs.create({ url: url.toString() })
+        return
+      }
+
+      const url = new URL(`/chat/${conversationId}/files/open`, baseUrl)
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ path: file.path }),
+      })
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as {
+          error?: string
+        } | null
+        throw new Error(payload?.error || `Failed to open ${file.fileName}`)
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : `Failed to open ${file.fileName}`,
+      )
+    } finally {
+      setPendingPath(null)
+    }
+  }
+
+  return (
+    <div className="mt-2 flex flex-col gap-2">
+      {files.map((file) => {
+        const Icon = getFileIcon(file)
+        const isPending = pendingPath === file.path
+
+        return (
+          <div
+            key={file.path}
+            className={cn(
+              'flex items-center gap-3 rounded-xl border border-border/60 bg-card/80 px-3 py-2.5 shadow-sm',
+            )}
+          >
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+              <Icon className="h-4 w-4" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-medium text-foreground text-sm">
+                {file.fileName}
+              </p>
+              <p className="truncate text-muted-foreground text-xs">
+                {getOpenDescription(file)}
+              </p>
+            </div>
+            <Button
+              disabled={isPending}
+              onClick={() => openFile(file)}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              {isPending ? <Loader2Icon className="animate-spin" /> : null}
+              {getOpenLabel(file)}
+            </Button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/sidepanel/index/generated-files.ts
+++ b/apps/agent/entrypoints/sidepanel/index/generated-files.ts
@@ -1,0 +1,102 @@
+import {
+  type GeneratedFile,
+  type GeneratedFileOpenMode,
+  GeneratedFileSchema,
+  getGeneratedFileMediaType,
+  getGeneratedFileName,
+  getGeneratedFileOpenMode,
+  getGeneratedFileTypeLabel,
+} from '@browseros/shared/generated-files'
+import type { DynamicToolUIPart, ToolUIPart, UIMessage } from 'ai'
+
+export interface MessageGeneratedFile extends GeneratedFile {
+  fileName: string
+  openMode: GeneratedFileOpenMode
+  typeLabel: string
+}
+
+type ToolLikePart = DynamicToolUIPart | ToolUIPart
+
+function extractGeneratedFilesFromOutput(output: unknown): GeneratedFile[] {
+  if (!output || typeof output !== 'object') return []
+
+  const record = output as {
+    generatedFiles?: unknown
+    structuredContent?: { generatedFiles?: unknown }
+  }
+  const candidates: unknown[] = []
+
+  if (Array.isArray(record.generatedFiles)) {
+    candidates.push(...record.generatedFiles)
+  }
+
+  if (
+    record.structuredContent &&
+    typeof record.structuredContent === 'object' &&
+    Array.isArray(record.structuredContent.generatedFiles)
+  ) {
+    candidates.push(...record.structuredContent.generatedFiles)
+  }
+
+  return candidates.flatMap((candidate) => {
+    const parsed = GeneratedFileSchema.safeParse(candidate)
+    return parsed.success ? [parsed.data] : []
+  })
+}
+
+function extractGeneratedFilesFromPart(part: ToolLikePart): GeneratedFile[] {
+  if (part.state !== 'output-available' || part.preliminary) {
+    return []
+  }
+
+  return extractGeneratedFilesFromOutput(part.output)
+}
+
+function dedupeGeneratedFiles(
+  files: MessageGeneratedFile[],
+): MessageGeneratedFile[] {
+  const seen = new Set<string>()
+  const deduped: MessageGeneratedFile[] = []
+
+  for (let index = files.length - 1; index >= 0; index--) {
+    const file = files[index]
+    if (seen.has(file.path)) continue
+    seen.add(file.path)
+    deduped.unshift(file)
+  }
+
+  return deduped
+}
+
+export function getGeneratedFilesFromMessage(
+  message: UIMessage,
+): MessageGeneratedFile[] {
+  if (message.role !== 'assistant') return []
+
+  const files: MessageGeneratedFile[] = []
+
+  for (const part of message.parts) {
+    if (!(part.type === 'dynamic-tool' || part.type.startsWith('tool-'))) {
+      continue
+    }
+
+    const toolPart = part as ToolLikePart
+    const generatedFiles = extractGeneratedFilesFromPart(toolPart)
+
+    for (const generatedFile of generatedFiles) {
+      const mediaType = getGeneratedFileMediaType(
+        generatedFile.path,
+        generatedFile.mediaType,
+      )
+      files.push({
+        ...generatedFile,
+        mediaType,
+        fileName: getGeneratedFileName(generatedFile.path),
+        openMode: getGeneratedFileOpenMode(generatedFile.path, mediaType),
+        typeLabel: getGeneratedFileTypeLabel(generatedFile.path, mediaType),
+      })
+    }
+  }
+
+  return dedupeGeneratedFiles(files)
+}

--- a/apps/server/src/agent/session-store.ts
+++ b/apps/server/src/agent/session-store.ts
@@ -4,6 +4,7 @@ import type { AiSdkAgent } from './ai-sdk-agent'
 
 export interface AgentSession {
   agent: AiSdkAgent
+  executionDir: string
   hiddenWindowId?: number
   /** Browser context scoped to the hidden window (scheduled tasks only) */
   browserContext?: BrowserContext

--- a/apps/server/src/agent/tool-adapter.ts
+++ b/apps/server/src/agent/tool-adapter.ts
@@ -66,6 +66,7 @@ export function buildBrowserToolSet(
             content: result.content,
             isError: result.isError ?? false,
             metadata: result.metadata,
+            structuredContent: result.structuredContent,
           }
         } catch (error) {
           const errorText =
@@ -93,6 +94,7 @@ export function buildBrowserToolSet(
         const result = output as {
           content: ContentItem[]
           isError: boolean
+          structuredContent?: Record<string, unknown>
         }
         if (result.isError) {
           const text = result.content

--- a/apps/server/src/api/routes/chat-files.ts
+++ b/apps/server/src/api/routes/chat-files.ts
@@ -1,0 +1,115 @@
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { logger } from '../../lib/logger'
+import {
+  type ChatFileService,
+  ChatFileServiceError,
+} from '../services/chat-file-service'
+import type { Env } from '../types'
+import { isTrustedLocalBrowserRequest } from '../utils/security'
+import { ConversationIdParamSchema } from '../utils/validation'
+
+interface ChatFileRouteDeps {
+  fileService: ChatFileService
+}
+
+const ChatFilePathSchema = z.object({
+  path: z.string().min(1, 'path is required'),
+})
+
+const SANDBOXED_INLINE_MEDIA_TYPES = new Set(['image/svg+xml', 'text/html'])
+
+function buildFileHeaders(result: {
+  filename: string
+  mediaType: string
+}): Headers {
+  const headers = new Headers({
+    'Cache-Control': 'no-store',
+    'Content-Disposition': `inline; filename="${result.filename.replaceAll('"', '')}"`,
+    'Content-Type': result.mediaType,
+    'X-Content-Type-Options': 'nosniff',
+  })
+
+  if (SANDBOXED_INLINE_MEDIA_TYPES.has(result.mediaType)) {
+    headers.set(
+      'Content-Security-Policy',
+      [
+        'sandbox',
+        "default-src 'none'",
+        "style-src 'unsafe-inline'",
+        'img-src data: blob: http: https:',
+        'font-src data: http: https:',
+        'media-src data: blob: http: https:',
+      ].join('; '),
+    )
+  }
+
+  return headers
+}
+
+export function createChatFileRoutes(deps: ChatFileRouteDeps) {
+  const { fileService } = deps
+
+  return new Hono<Env>()
+    .get(
+      '/',
+      zValidator('param', ConversationIdParamSchema),
+      zValidator('query', ChatFilePathSchema),
+      async (c) => {
+        if (!isTrustedLocalBrowserRequest(c)) {
+          return c.json({ error: 'Forbidden' }, 403)
+        }
+
+        const { conversationId } = c.req.valid('param')
+        const { path } = c.req.valid('query')
+
+        try {
+          const result = await fileService.readFile(conversationId, path)
+          return new Response(result.file, {
+            headers: buildFileHeaders(result),
+          })
+        } catch (error) {
+          if (error instanceof ChatFileServiceError) {
+            return c.json({ error: error.message }, error.statusCode)
+          }
+
+          logger.error('Failed to render chat file', {
+            conversationId,
+            path,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return c.json({ error: 'Failed to render file' }, 500)
+        }
+      },
+    )
+    .post(
+      '/open',
+      zValidator('param', ConversationIdParamSchema),
+      zValidator('json', ChatFilePathSchema),
+      async (c) => {
+        if (!isTrustedLocalBrowserRequest(c)) {
+          return c.json({ error: 'Forbidden' }, 403)
+        }
+
+        const { conversationId } = c.req.valid('param')
+        const { path } = c.req.valid('json')
+
+        try {
+          const result = await fileService.openFile(conversationId, path)
+          return c.json({ success: true, path: result.filePath })
+        } catch (error) {
+          if (error instanceof ChatFileServiceError) {
+            return c.json({ error: error.message }, error.statusCode)
+          }
+
+          logger.error('Failed to open chat file', {
+            conversationId,
+            path,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          return c.json({ error: 'Failed to open file' }, 500)
+        }
+      },
+    )
+}

--- a/apps/server/src/api/routes/chat-files.ts
+++ b/apps/server/src/api/routes/chat-files.ts
@@ -20,13 +20,27 @@ const ChatFilePathSchema = z.object({
 
 const SANDBOXED_INLINE_MEDIA_TYPES = new Set(['image/svg+xml', 'text/html'])
 
+function sanitizeInlineFilename(filename: string): string {
+  return Array.from(filename)
+    .filter((character) => {
+      const codePoint = character.codePointAt(0)
+      return (
+        codePoint !== undefined &&
+        codePoint >= 0x20 &&
+        codePoint !== 0x7f &&
+        character !== '"'
+      )
+    })
+    .join('')
+}
+
 function buildFileHeaders(result: {
   filename: string
   mediaType: string
 }): Headers {
   const headers = new Headers({
     'Cache-Control': 'no-store',
-    'Content-Disposition': `inline; filename="${result.filename.replaceAll('"', '')}"`,
+    'Content-Disposition': `inline; filename="${sanitizeInlineFilename(result.filename)}"`,
     'Content-Type': result.mediaType,
     'X-Content-Type-Options': 'nosniff',
   })

--- a/apps/server/src/api/routes/chat.ts
+++ b/apps/server/src/api/routes/chat.ts
@@ -10,9 +10,11 @@ import type { RateLimiter } from '../../lib/rate-limiter/rate-limiter'
 import { Sentry } from '../../lib/sentry'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import { createBrowserosRateLimitMiddleware } from '../middleware/rate-limit'
+import { ChatFileService } from '../services/chat-file-service'
 import { ChatService } from '../services/chat-service'
 import { ChatRequestSchema } from '../types'
 import { ConversationIdParamSchema } from '../utils/validation'
+import { createChatFileRoutes } from './chat-files'
 
 interface ChatRouteDeps {
   browser: Browser
@@ -35,6 +37,10 @@ export function createChatRoutes(deps: ChatRouteDeps) {
     browser: deps.browser,
     registry: deps.registry,
     browserosId,
+  })
+  const fileService = new ChatFileService({
+    sessionStore,
+    executionDir,
   })
 
   return new Hono()
@@ -69,6 +75,12 @@ export function createChatRoutes(deps: ChatRouteDeps) {
 
         return service.processMessage(request, c.req.raw.signal)
       },
+    )
+    .route(
+      '/:conversationId/files',
+      createChatFileRoutes({
+        fileService,
+      }),
     )
     .delete(
       '/:conversationId',

--- a/apps/server/src/api/services/chat-file-service.ts
+++ b/apps/server/src/api/services/chat-file-service.ts
@@ -1,0 +1,137 @@
+import { spawn } from 'node:child_process'
+import { realpath, stat } from 'node:fs/promises'
+import { basename, isAbsolute, join, relative, resolve } from 'node:path'
+import type { SessionStore } from '../../agent/session-store'
+
+interface ChatFileServiceDeps {
+  sessionStore: SessionStore
+  executionDir: string
+}
+
+export class ChatFileServiceError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode: 400 | 404 | 500,
+  ) {
+    super(message)
+    this.name = 'ChatFileServiceError'
+  }
+}
+
+export class ChatFileService {
+  constructor(private deps: ChatFileServiceDeps) {}
+
+  async readFile(
+    conversationId: string,
+    requestedPath: string,
+  ): Promise<{
+    file: Blob
+    filePath: string
+    filename: string
+    mediaType: string
+  }> {
+    const filePath = await this.resolveFilePath(conversationId, requestedPath)
+    const file = Bun.file(filePath)
+    const exists = await file.exists()
+    if (!exists) {
+      throw new ChatFileServiceError('File not found', 404)
+    }
+
+    return {
+      file,
+      filePath,
+      filename: basename(filePath),
+      mediaType: file.type || 'application/octet-stream',
+    }
+  }
+
+  async openFile(
+    conversationId: string,
+    requestedPath: string,
+  ): Promise<{ filePath: string }> {
+    const filePath = await this.resolveFilePath(conversationId, requestedPath)
+    await openFileWithDefaultApp(filePath)
+    return { filePath }
+  }
+
+  async resolveFilePath(
+    conversationId: string,
+    requestedPath: string,
+  ): Promise<string> {
+    if (!requestedPath.trim()) {
+      throw new ChatFileServiceError('File path is required', 400)
+    }
+
+    const roots = [
+      this.deps.sessionStore.get(conversationId)?.executionDir,
+      join(this.deps.executionDir, 'sessions', conversationId),
+    ].filter(
+      (root, index, values): root is string =>
+        Boolean(root) && values.indexOf(root) === index,
+    )
+
+    for (const root of roots) {
+      const resolvedPath = await resolveFileWithinRoot(root, requestedPath)
+      if (resolvedPath) return resolvedPath
+    }
+
+    throw new ChatFileServiceError('File not found', 404)
+  }
+}
+
+async function resolveFileWithinRoot(
+  rootPath: string,
+  requestedPath: string,
+): Promise<string | null> {
+  const realRoot = await realpath(rootPath).catch(() => null)
+  if (!realRoot) return null
+
+  const candidatePath = isAbsolute(requestedPath)
+    ? requestedPath
+    : resolve(realRoot, requestedPath)
+  const realCandidate = await realpath(candidatePath).catch(() => null)
+  if (!realCandidate) return null
+
+  const relativePath = relative(realRoot, realCandidate)
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    return null
+  }
+
+  const fileStat = await stat(realCandidate).catch(() => null)
+  if (!fileStat?.isFile()) return null
+
+  return realCandidate
+}
+
+async function openFileWithDefaultApp(filePath: string): Promise<void> {
+  const [command, ...args] = getOpenCommand(filePath)
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn(command, args, {
+      detached: true,
+      stdio: 'ignore',
+    })
+    child.once('error', rejectPromise)
+    child.once('spawn', () => {
+      child.unref()
+      resolvePromise()
+    })
+  }).catch((error) => {
+    throw new ChatFileServiceError(
+      error instanceof Error ? error.message : 'Failed to open file',
+      500,
+    )
+  })
+}
+
+function getOpenCommand(filePath: string): string[] {
+  if (process.platform === 'darwin') {
+    return ['open', filePath]
+  }
+
+  if (process.platform === 'win32') {
+    return ['cmd', '/c', 'start', '', filePath]
+  }
+
+  return ['xdg-open', filePath]
+}

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -104,8 +104,15 @@ export class ChatService {
         klavisClient: this.deps.klavisClient,
         browserosId: this.deps.browserosId,
       })
-      session = { agent, hiddenWindowId, browserContext }
+      session = {
+        agent,
+        executionDir: sessionExecutionDir,
+        hiddenWindowId,
+        browserContext,
+      }
       sessionStore.set(request.conversationId, session)
+    } else {
+      session.executionDir = sessionExecutionDir
     }
 
     if (isNewSession && request.previousConversation?.length) {

--- a/apps/server/src/api/utils/security.ts
+++ b/apps/server/src/api/utils/security.ts
@@ -8,6 +8,11 @@ import type { Context } from 'hono'
 import type { Env } from '../types'
 
 const LOCALHOST_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
+const LOCALHOST_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '::1'])
+const TRUSTED_EXTENSION_PROTOCOLS = new Set([
+  'chrome-extension:',
+  'moz-extension:',
+])
 
 /**
  * Check if request originates from localhost.
@@ -50,4 +55,37 @@ export function isLocalhostRequest(c: Context<Env>): boolean {
   }
 
   return true
+}
+
+function isTrustedRequestUrl(urlValue: string | undefined): boolean {
+  if (!urlValue) return true
+
+  try {
+    const url = new URL(urlValue)
+    return (
+      LOCALHOST_HOSTNAMES.has(url.hostname) ||
+      TRUSTED_EXTENSION_PROTOCOLS.has(url.protocol)
+    )
+  } catch {
+    return false
+  }
+}
+
+export function isTrustedLocalBrowserRequest(c: Context<Env>): boolean {
+  const server = c.env.server
+  const request = c.req.raw
+  const socketAddr = server.requestIP(request)
+  if (!socketAddr || !LOCALHOST_ADDRESSES.has(socketAddr.address)) {
+    return false
+  }
+
+  const host = c.req.header('host')
+  if (!host) return false
+  const hostname = host.split(':')[0]
+  if (!LOCALHOST_HOSTNAMES.has(hostname)) return false
+
+  return (
+    isTrustedRequestUrl(c.req.header('origin')) &&
+    isTrustedRequestUrl(c.req.header('referer'))
+  )
 }

--- a/apps/server/src/tools/filesystem/edit.ts
+++ b/apps/server/src/tools/filesystem/edit.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import type { GeneratedFile } from '@browseros/shared/generated-files'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
@@ -127,7 +128,17 @@ export function createEditTool(cwd: string) {
         await writeFile(resolved, finalContent, 'utf-8')
 
         const diff = generateDiff(params.old_string, params.new_string)
-        return { text: `Applied edit to ${params.path}\n\n${diff}` }
+        const generatedFiles: GeneratedFile[] = [
+          {
+            path: resolved,
+            sourceTool: TOOL_NAME,
+            operation: 'updated',
+          },
+        ]
+        return {
+          text: `Applied edit to ${params.path}\n\n${diff}`,
+          generatedFiles,
+        }
       }),
     toModelOutput,
   })

--- a/apps/server/src/tools/filesystem/utils.ts
+++ b/apps/server/src/tools/filesystem/utils.ts
@@ -1,6 +1,7 @@
 import type { Dirent } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { join, relative } from 'node:path'
+import type { GeneratedFile } from '@browseros/shared/generated-files'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 
@@ -17,6 +18,7 @@ export interface FilesystemToolResult {
   text: string
   isError?: boolean
   images?: Array<{ data: string; mimeType: string }>
+  generatedFiles?: GeneratedFile[]
 }
 
 export interface TruncationResult {

--- a/apps/server/src/tools/filesystem/write.ts
+++ b/apps/server/src/tools/filesystem/write.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, stat, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import type { GeneratedFile } from '@browseros/shared/generated-files'
 import { tool } from 'ai'
@@ -20,6 +20,9 @@ export function createWriteTool(cwd: string) {
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
         const resolved = resolve(cwd, params.path)
+        const operation = (await stat(resolved).catch(() => null))
+          ? 'updated'
+          : 'created'
         await mkdir(dirname(resolved), { recursive: true })
         await writeFile(resolved, params.content, 'utf-8')
         const bytes = Buffer.byteLength(params.content, 'utf-8')
@@ -27,7 +30,7 @@ export function createWriteTool(cwd: string) {
           {
             path: resolved,
             sourceTool: TOOL_NAME,
-            operation: 'created',
+            operation,
           },
         ]
         return {

--- a/apps/server/src/tools/filesystem/write.ts
+++ b/apps/server/src/tools/filesystem/write.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
+import type { GeneratedFile } from '@browseros/shared/generated-files'
 import { tool } from 'ai'
 import { z } from 'zod'
 import { executeWithMetrics, toModelOutput } from './utils'
@@ -22,7 +23,17 @@ export function createWriteTool(cwd: string) {
         await mkdir(dirname(resolved), { recursive: true })
         await writeFile(resolved, params.content, 'utf-8')
         const bytes = Buffer.byteLength(params.content, 'utf-8')
-        return { text: `Wrote ${bytes} bytes to ${params.path}` }
+        const generatedFiles: GeneratedFile[] = [
+          {
+            path: resolved,
+            sourceTool: TOOL_NAME,
+            operation: 'created',
+          },
+        ]
+        return {
+          text: `Wrote ${bytes} bytes to ${params.path}`,
+          generatedFiles,
+        }
       }),
     toModelOutput,
   })

--- a/apps/server/src/tools/page-actions.ts
+++ b/apps/server/src/tools/page-actions.ts
@@ -1,6 +1,10 @@
 import { mkdtemp, rename, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import {
+  type GeneratedFile,
+  GeneratedFilesSchema,
+} from '@browseros/shared/generated-files'
 import { z } from 'zod'
 import { defineTool } from './framework'
 
@@ -22,6 +26,7 @@ export const save_pdf = defineTool({
   }),
   output: z.object({
     action: z.literal('save_pdf'),
+    generatedFiles: GeneratedFilesSchema,
     page: z.number(),
     path: z.string(),
   }),
@@ -29,9 +34,18 @@ export const save_pdf = defineTool({
     const resolvedPath = resolve(args.cwd ?? process.cwd(), args.path)
     const { data } = await ctx.browser.printToPDF(args.page)
     await Bun.write(resolvedPath, Buffer.from(data, 'base64'))
+    const generatedFiles: GeneratedFile[] = [
+      {
+        path: resolvedPath,
+        mediaType: 'application/pdf',
+        sourceTool: 'save_pdf',
+        operation: 'saved',
+      },
+    ]
     response.text(`Saved PDF to ${resolvedPath}`)
     response.data({
       action: 'save_pdf',
+      generatedFiles,
       page: args.page,
       path: resolvedPath,
     })
@@ -67,6 +81,7 @@ export const save_screenshot = defineTool({
   }),
   output: z.object({
     action: z.literal('save_screenshot'),
+    generatedFiles: GeneratedFilesSchema,
     page: z.number(),
     path: z.string(),
     format: z.enum(['png', 'jpeg', 'webp']),
@@ -81,10 +96,19 @@ export const save_screenshot = defineTool({
       fullPage: args.fullPage,
     })
     await Bun.write(resolvedPath, Buffer.from(data, 'base64'))
+    const generatedFiles: GeneratedFile[] = [
+      {
+        path: resolvedPath,
+        mediaType: `image/${args.format}`,
+        sourceTool: 'save_screenshot',
+        operation: 'saved',
+      },
+    ]
     response.text(`Saved screenshot to ${resolvedPath}`)
     response.data({
       action: 'save_screenshot',
       page: args.page,
+      generatedFiles,
       path: resolvedPath,
       format: args.format,
       quality: args.quality,
@@ -111,6 +135,7 @@ export const download_file = defineTool({
     page: z.number(),
     element: z.number(),
     directory: z.string(),
+    generatedFiles: GeneratedFilesSchema,
     suggestedFilename: z.string(),
     destinationPath: z.string(),
   }),
@@ -124,6 +149,13 @@ export const download_file = defineTool({
 
       const destPath = join(resolvedDir, suggestedFilename)
       await rename(filePath, destPath)
+      const generatedFiles: GeneratedFile[] = [
+        {
+          path: destPath,
+          sourceTool: 'download_file',
+          operation: 'downloaded',
+        },
+      ]
 
       response.text(`Downloaded "${suggestedFilename}" to ${destPath}`)
       response.data({
@@ -131,6 +163,7 @@ export const download_file = defineTool({
         page: args.page,
         element: args.element,
         directory: resolvedDir,
+        generatedFiles,
         suggestedFilename,
         destinationPath: destPath,
       })

--- a/apps/server/tests/agent/tool-adapter.test.ts
+++ b/apps/server/tests/agent/tool-adapter.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+import { z } from 'zod'
+import { buildBrowserToolSet } from '../../src/agent/tool-adapter'
+import type { Browser } from '../../src/browser/browser'
+import { defineTool } from '../../src/tools/framework'
+import { ToolRegistry } from '../../src/tools/tool-registry'
+
+describe('buildBrowserToolSet', () => {
+  it('preserves structured content from browser tools', async () => {
+    const registry = new ToolRegistry([
+      defineTool({
+        name: 'save_report',
+        description: 'Save a report',
+        input: z.object({}),
+        output: z.object({
+          generatedFiles: z.array(
+            z.object({
+              path: z.string(),
+            }),
+          ),
+        }),
+        async handler(_args, _ctx, response) {
+          response.text('Saved report')
+          response.data({
+            generatedFiles: [{ path: '/tmp/report.html' }],
+          })
+        },
+      }),
+    ])
+
+    const toolSet = buildBrowserToolSet(registry, {} as Browser)
+    const result = await toolSet.save_report.execute?.({})
+
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Saved report' }],
+      isError: false,
+      structuredContent: {
+        generatedFiles: [{ path: '/tmp/report.html' }],
+      },
+    })
+  })
+})

--- a/apps/server/tests/api/chat-file-service.test.ts
+++ b/apps/server/tests/api/chat-file-service.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { SessionStore } from '../../src/agent/session-store'
+import {
+  ChatFileService,
+  ChatFileServiceError,
+} from '../../src/api/services/chat-file-service'
+
+const CONVERSATION_ID = '8ad89eca-e9f9-495a-80a8-a15d7c354181'
+
+let tempRoot: string
+let workspaceDir: string
+let outsideDir: string
+
+beforeEach(async () => {
+  tempRoot = join(
+    tmpdir(),
+    `chat-file-service-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  )
+  workspaceDir = join(tempRoot, 'workspace')
+  outsideDir = join(tempRoot, 'outside')
+
+  await mkdir(workspaceDir, { recursive: true })
+  await mkdir(outsideDir, { recursive: true })
+})
+
+afterEach(async () => {
+  await rm(tempRoot, { recursive: true, force: true })
+})
+
+describe('ChatFileService', () => {
+  it('resolves a relative path inside the session execution dir', async () => {
+    const filePath = join(workspaceDir, 'report.html')
+    await writeFile(filePath, '<html>report</html>')
+
+    const sessionStore = new SessionStore()
+    sessionStore.set(CONVERSATION_ID, {
+      agent: {} as never,
+      executionDir: workspaceDir,
+    })
+
+    const service = new ChatFileService({
+      sessionStore,
+      executionDir: tempRoot,
+    })
+
+    const resolvedPath = await service.resolveFilePath(
+      CONVERSATION_ID,
+      'report.html',
+    )
+
+    expect(resolvedPath).toBe(await realpath(filePath))
+  })
+
+  it('rejects a path outside the session execution dir', async () => {
+    const insidePath = join(workspaceDir, 'report.html')
+    const outsidePath = join(outsideDir, 'secret.html')
+    await writeFile(insidePath, '<html>report</html>')
+    await writeFile(outsidePath, '<html>secret</html>')
+
+    const sessionStore = new SessionStore()
+    sessionStore.set(CONVERSATION_ID, {
+      agent: {} as never,
+      executionDir: workspaceDir,
+    })
+
+    const service = new ChatFileService({
+      sessionStore,
+      executionDir: tempRoot,
+    })
+
+    await expect(
+      service.resolveFilePath(CONVERSATION_ID, outsidePath),
+    ).rejects.toBeInstanceOf(ChatFileServiceError)
+  })
+
+  it('falls back to the default per-session directory', async () => {
+    const sessionDir = join(tempRoot, 'sessions', CONVERSATION_ID)
+    const filePath = join(sessionDir, 'report.pdf')
+    await mkdir(sessionDir, { recursive: true })
+    await writeFile(filePath, 'pdf')
+
+    const service = new ChatFileService({
+      sessionStore: new SessionStore(),
+      executionDir: tempRoot,
+    })
+
+    const resolvedPath = await service.resolveFilePath(
+      CONVERSATION_ID,
+      'report.pdf',
+    )
+
+    expect(resolvedPath).toBe(await realpath(filePath))
+  })
+})

--- a/apps/server/tests/api/routes/chat-files.test.ts
+++ b/apps/server/tests/api/routes/chat-files.test.ts
@@ -14,7 +14,9 @@ const LOCAL_ENV = {
   },
 } as Env['Bindings']
 
-function createRoute(fileService: Pick<ChatFileService, 'readFile'>) {
+function createRoute(
+  fileService: Partial<Pick<ChatFileService, 'readFile' | 'openFile'>>,
+) {
   return new Hono<Env>().route(
     '/chat/:conversationId/files',
     createChatFileRoutes({
@@ -53,6 +55,36 @@ describe('createChatFileRoutes', () => {
     expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
   })
 
+  it('strips control characters from inline filenames', async () => {
+    const route = createRoute({
+      async readFile() {
+        return {
+          file: new Blob(['<html><body>report</body></html>'], {
+            type: 'text/html',
+          }),
+          filePath: '/tmp/report.html',
+          filename: 'report.html\r\nX-Injected: value',
+          mediaType: 'text/html',
+        }
+      },
+    })
+
+    const response = await route.request(
+      `http://localhost/chat/${CONVERSATION_ID}/files?path=report.html`,
+      {
+        headers: {
+          host: 'localhost',
+        },
+      },
+      LOCAL_ENV,
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Disposition')).toBe(
+      'inline; filename="report.htmlX-Injected: value"',
+    )
+  })
+
   it('does not sandbox PDF files', async () => {
     const route = createRoute({
       async readFile() {
@@ -80,5 +112,35 @@ describe('createChatFileRoutes', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('Content-Security-Policy')).toBeNull()
     expect(response.headers.get('Content-Type')).toBe('application/pdf')
+  })
+
+  it('opens files with the native app route', async () => {
+    let openedPath: string | undefined
+    const route = createRoute({
+      async openFile(_conversationId, path) {
+        openedPath = path
+        return { filePath: '/tmp/report.docx' }
+      },
+    })
+
+    const response = await route.request(
+      `http://localhost/chat/${CONVERSATION_ID}/files/open`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          host: 'localhost',
+        },
+        body: JSON.stringify({ path: 'report.docx' }),
+      },
+      LOCAL_ENV,
+    )
+
+    expect(response.status).toBe(200)
+    expect(openedPath).toBe('report.docx')
+    expect(await response.json()).toEqual({
+      success: true,
+      path: '/tmp/report.docx',
+    })
   })
 })

--- a/apps/server/tests/api/routes/chat-files.test.ts
+++ b/apps/server/tests/api/routes/chat-files.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'bun:test'
+import { Hono } from 'hono'
+import { createChatFileRoutes } from '../../../src/api/routes/chat-files'
+import type { ChatFileService } from '../../../src/api/services/chat-file-service'
+import type { Env } from '../../../src/api/types'
+
+const CONVERSATION_ID = '8ad89eca-e9f9-495a-80a8-a15d7c354181'
+
+const LOCAL_ENV = {
+  server: {
+    requestIP() {
+      return { address: '127.0.0.1' }
+    },
+  },
+} as Env['Bindings']
+
+function createRoute(fileService: Pick<ChatFileService, 'readFile'>) {
+  return new Hono<Env>().route(
+    '/chat/:conversationId/files',
+    createChatFileRoutes({
+      fileService: fileService as ChatFileService,
+    }),
+  )
+}
+
+describe('createChatFileRoutes', () => {
+  it('sandboxes inline HTML files', async () => {
+    const route = createRoute({
+      async readFile() {
+        return {
+          file: new Blob(['<html><body>report</body></html>'], {
+            type: 'text/html',
+          }),
+          filePath: '/tmp/report.html',
+          filename: 'report.html',
+          mediaType: 'text/html',
+        }
+      },
+    })
+
+    const response = await route.request(
+      `http://localhost/chat/${CONVERSATION_ID}/files?path=report.html`,
+      {
+        headers: {
+          host: 'localhost',
+        },
+      },
+      LOCAL_ENV,
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Security-Policy')).toContain('sandbox')
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  })
+
+  it('does not sandbox PDF files', async () => {
+    const route = createRoute({
+      async readFile() {
+        return {
+          file: new Blob(['pdf'], {
+            type: 'application/pdf',
+          }),
+          filePath: '/tmp/report.pdf',
+          filename: 'report.pdf',
+          mediaType: 'application/pdf',
+        }
+      },
+    })
+
+    const response = await route.request(
+      `http://localhost/chat/${CONVERSATION_ID}/files?path=report.pdf`,
+      {
+        headers: {
+          host: 'localhost',
+        },
+      },
+      LOCAL_ENV,
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Security-Policy')).toBeNull()
+    expect(response.headers.get('Content-Type')).toBe('application/pdf')
+  })
+})

--- a/apps/server/tests/generated-files.test.ts
+++ b/apps/server/tests/generated-files.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  getGeneratedFileOpenMode,
+  getGeneratedFileTypeLabel,
+} from '@browseros/shared/generated-files'
+
+describe('generated-files helpers', () => {
+  it('opens HTML and PDF files in the browser', () => {
+    expect(getGeneratedFileOpenMode('/tmp/report.html')).toBe('browser')
+    expect(getGeneratedFileOpenMode('/tmp/report.pdf')).toBe('browser')
+  })
+
+  it('opens DOCX files in the default native app', () => {
+    expect(getGeneratedFileOpenMode('/tmp/report.docx')).toBe('native')
+    expect(getGeneratedFileTypeLabel('/tmp/report.docx')).toBe('DOCX file')
+  })
+
+  it('uses an explicit media type when provided', () => {
+    expect(
+      getGeneratedFileOpenMode('/tmp/report.bin', 'text/html; charset=utf-8'),
+    ).toBe('browser')
+    expect(
+      getGeneratedFileTypeLabel('/tmp/report.bin', 'application/pdf'),
+    ).toBe('PDF document')
+  })
+})

--- a/apps/server/tests/tools/filesystem/write.test.ts
+++ b/apps/server/tests/tools/filesystem/write.test.ts
@@ -29,6 +29,13 @@ describe('filesystem_write', () => {
     expect(result.isError).toBeUndefined()
     expect(result.text).toContain('Wrote')
     expect(result.text).toContain('bytes')
+    expect(result.generatedFiles).toEqual([
+      {
+        path: join(tmpDir, 'new.txt'),
+        sourceTool: 'filesystem_write',
+        operation: 'created',
+      },
+    ])
 
     const content = await readFile(join(tmpDir, 'new.txt'), 'utf-8')
     expect(content).toBe('hello world')
@@ -40,6 +47,13 @@ describe('filesystem_write', () => {
 
     const result = await exec({ path: 'exists.txt', content: 'new content' })
     expect(result.isError).toBeUndefined()
+    expect(result.generatedFiles).toEqual([
+      {
+        path: filePath,
+        sourceTool: 'filesystem_write',
+        operation: 'updated',
+      },
+    ])
 
     const content = await readFile(filePath, 'utf-8')
     expect(content).toBe('new content')

--- a/apps/server/tests/tools/page-actions.test.ts
+++ b/apps/server/tests/tools/page-actions.test.ts
@@ -36,9 +36,26 @@ describe('page action tools', () => {
         })
         assert.ok(!pdfResult.isError, textOf(pdfResult))
         assert.ok(textOf(pdfResult).includes('Saved PDF'))
-        const data = structuredOf<{ action: string; path: string }>(pdfResult)
+        const data = structuredOf<{
+          action: string
+          path: string
+          generatedFiles: Array<{
+            path: string
+            mediaType: string
+            sourceTool: string
+            operation: string
+          }>
+        }>(pdfResult)
         assert.strictEqual(data.action, 'save_pdf')
         assert.strictEqual(data.path, pdfPath)
+        assert.deepStrictEqual(data.generatedFiles, [
+          {
+            path: pdfPath,
+            mediaType: 'application/pdf',
+            sourceTool: 'save_pdf',
+            operation: 'saved',
+          },
+        ])
         assert.ok(existsSync(pdfPath), 'PDF file should exist on disk')
 
         const stat = Bun.file(pdfPath)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,6 +33,10 @@
       "types": "./src/constants/paths.ts",
       "default": "./src/constants/paths.ts"
     },
+    "./generated-files": {
+      "types": "./src/generated-files.ts",
+      "default": "./src/generated-files.ts"
+    },
     "./types/logger": {
       "types": "./src/types/logger.ts",
       "default": "./src/types/logger.ts"

--- a/packages/shared/src/generated-files.ts
+++ b/packages/shared/src/generated-files.ts
@@ -1,0 +1,110 @@
+import { z } from 'zod'
+
+export const GeneratedFileOperationSchema = z.enum([
+  'created',
+  'updated',
+  'saved',
+  'downloaded',
+])
+
+export const GeneratedFileSchema = z.object({
+  path: z.string().min(1),
+  mediaType: z.string().optional(),
+  sourceTool: z.string().min(1),
+  operation: GeneratedFileOperationSchema,
+})
+
+export const GeneratedFilesSchema = z.array(GeneratedFileSchema)
+
+export type GeneratedFileOperation = z.infer<
+  typeof GeneratedFileOperationSchema
+>
+export type GeneratedFile = z.infer<typeof GeneratedFileSchema>
+export type GeneratedFileOpenMode = 'browser' | 'native'
+
+const MEDIA_TYPES_BY_EXTENSION: Record<string, string> = {
+  '.bmp': 'image/bmp',
+  '.csv': 'text/csv',
+  '.gif': 'image/gif',
+  '.htm': 'text/html',
+  '.html': 'text/html',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.json': 'application/json',
+  '.md': 'text/markdown',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain',
+  '.webp': 'image/webp',
+}
+
+const BROWSER_MEDIA_TYPES = new Set(['application/pdf', 'text/html'])
+
+export function getGeneratedFileName(filePath: string): string {
+  const normalized = filePath.replaceAll('\\', '/')
+  const segments = normalized.split('/').filter(Boolean)
+  return segments.at(-1) ?? filePath
+}
+
+export function getGeneratedFileExtension(filePath: string): string {
+  const filename = getGeneratedFileName(filePath)
+  const dotIndex = filename.lastIndexOf('.')
+  if (dotIndex === -1) return ''
+  return filename.slice(dotIndex).toLowerCase()
+}
+
+function normalizeMediaType(mediaType?: string): string | undefined {
+  return mediaType?.split(';', 1)[0]?.trim().toLowerCase() || undefined
+}
+
+export function getGeneratedFileMediaType(
+  filePath: string,
+  mediaType?: string,
+): string | undefined {
+  const normalized = normalizeMediaType(mediaType)
+  if (normalized) return normalized
+  return MEDIA_TYPES_BY_EXTENSION[getGeneratedFileExtension(filePath)]
+}
+
+export function getGeneratedFileOpenMode(
+  filePath: string,
+  mediaType?: string,
+): GeneratedFileOpenMode {
+  const resolvedMediaType = getGeneratedFileMediaType(filePath, mediaType)
+  if (!resolvedMediaType) return 'native'
+  return BROWSER_MEDIA_TYPES.has(resolvedMediaType) ? 'browser' : 'native'
+}
+
+export function getGeneratedFileTypeLabel(
+  filePath: string,
+  mediaType?: string,
+): string {
+  const resolvedMediaType = getGeneratedFileMediaType(filePath, mediaType)
+  switch (resolvedMediaType) {
+    case 'application/json':
+      return 'JSON file'
+    case 'application/pdf':
+      return 'PDF document'
+    case 'image/bmp':
+    case 'image/gif':
+    case 'image/jpeg':
+    case 'image/png':
+    case 'image/svg+xml':
+    case 'image/webp':
+      return 'Image'
+    case 'text/csv':
+      return 'CSV file'
+    case 'text/html':
+      return 'HTML document'
+    case 'text/markdown':
+      return 'Markdown document'
+    case 'text/plain':
+      return 'Text file'
+    default: {
+      const extension = getGeneratedFileExtension(filePath)
+      if (!extension) return 'File'
+      return `${extension.slice(1).toUpperCase()} file`
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Surface generated local files as attachment-style cards in assistant messages.
- Open HTML and PDF outputs in a new browser tab, and hand DOCX and other files off to the OS default app.
- Keep file access scoped to the conversation execution root or selected workspace, and dedupe repeated file cards within a single response.

## Design
This change standardizes file-producing tool outputs around a shared `generatedFiles` descriptor, preserves that metadata through the server tool adapters, and adds chat-scoped file routes for inline render and native open. On the client side, the agent UI scans assistant tool parts, derives de-duplicated generated file entries, and renders compact cards that open through the local server. Inline HTML delivery is sandboxed to avoid running reports with full localhost origin privileges.

## Test plan
- `bun run lint`
- `bun run --filter @browseros/shared typecheck`
- `bun run --filter @browseros/server typecheck`
- `bun test apps/server/tests/generated-files.test.ts apps/server/tests/api/chat-file-service.test.ts apps/server/tests/api/routes/chat-files.test.ts apps/server/tests/agent/tool-adapter.test.ts apps/server/tests/tools/page-actions.test.ts`
- `bun run test`
- Attempted `NODE_OPTIONS=--max-old-space-size=8192 bun run --filter @browseros/agent typecheck`, but the project-scale TypeScript run did not complete in this workspace.