### PR TITLE
feat: add Tweeks — AI-powered web modifications

### DIFF
--- a/apps/server/src/api/routes/tweeks.ts
+++ b/apps/server/src/api/routes/tweeks.ts
@@ -1,0 +1,79 @@
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { TweeksService } from '../services/tweeks-service'
+
+const CreateTweekSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  domain: z.string().min(1),
+  url_pattern: z.string().min(1),
+  script: z.string().min(1),
+  script_type: z.enum(['js', 'css']).optional().default('js'),
+})
+
+const UpdateTweekSchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().optional(),
+  script: z.string().min(1).optional(),
+  url_pattern: z.string().min(1).optional(),
+  enabled: z.boolean().optional(),
+})
+
+const IdParamSchema = z.object({
+  id: z.string().uuid(),
+})
+
+export function createTweeksRoutes() {
+  const service = new TweeksService()
+
+  return new Hono()
+    .get('/', async (c) => {
+      const domain = c.req.query('domain')
+      const tweeks = service.list(domain)
+      return c.json({ tweeks })
+    })
+    .get('/match', async (c) => {
+      const url = c.req.query('url')
+      if (!url) {
+        return c.json({ error: 'url query parameter is required' }, 400)
+      }
+      const tweeks = service.getMatchingTweeks(url)
+      return c.json({ tweeks })
+    })
+    .get('/:id', zValidator('param', IdParamSchema), async (c) => {
+      const { id } = c.req.valid('param')
+      const tweek = service.getById(id)
+      if (!tweek) {
+        return c.json({ error: 'Tweek not found' }, 404)
+      }
+      return c.json({ tweek })
+    })
+    .post('/', zValidator('json', CreateTweekSchema), async (c) => {
+      const input = c.req.valid('json')
+      const tweek = service.create(input)
+      return c.json({ tweek }, 201)
+    })
+    .put(
+      '/:id',
+      zValidator('param', IdParamSchema),
+      zValidator('json', UpdateTweekSchema),
+      async (c) => {
+        const { id } = c.req.valid('param')
+        const input = c.req.valid('json')
+        const tweek = service.update(id, input)
+        if (!tweek) {
+          return c.json({ error: 'Tweek not found' }, 404)
+        }
+        return c.json({ tweek })
+      },
+    )
+    .delete('/:id', zValidator('param', IdParamSchema), async (c) => {
+      const { id } = c.req.valid('param')
+      const deleted = service.delete(id)
+      if (!deleted) {
+        return c.json({ error: 'Tweek not found' }, 404)
+      }
+      return c.json({ success: true })
+    })
+}

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -26,6 +26,7 @@ import { createSdkRoutes } from './routes/sdk'
 import { createShutdownRoute } from './routes/shutdown'
 import { createSoulRoutes } from './routes/soul'
 import { createStatusRoute } from './routes/status'
+import { createTweeksRoutes } from './routes/tweeks'
 import {
   connectKlavisProxy,
   type KlavisProxyHandle,
@@ -144,6 +145,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         codegenServiceUrl: config.codegenServiceUrl,
       }),
     )
+    .route('/tweeks', createTweeksRoutes())
 
   // Error handler
   app.onError((err, c) => {

--- a/apps/server/src/api/services/tweeks-service.ts
+++ b/apps/server/src/api/services/tweeks-service.ts
@@ -1,0 +1,150 @@
+import { getDb } from '../../lib/db'
+import { logger } from '../../lib/logger'
+
+export interface Tweek {
+  id: string
+  name: string
+  description: string | null
+  domain: string
+  url_pattern: string
+  script: string
+  script_type: 'js' | 'css'
+  enabled: number
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateTweekInput {
+  name: string
+  description?: string
+  domain: string
+  url_pattern: string
+  script: string
+  script_type?: 'js' | 'css'
+}
+
+export interface UpdateTweekInput {
+  name?: string
+  description?: string
+  script?: string
+  url_pattern?: string
+  enabled?: boolean
+}
+
+export class TweeksService {
+  list(domain?: string): Tweek[] {
+    const db = getDb()
+    if (domain) {
+      return db
+        .query<Tweek, [string]>(
+          'SELECT * FROM tweeks WHERE domain = ? ORDER BY created_at DESC',
+        )
+        .all(domain)
+    }
+    return db
+      .query<Tweek, []>('SELECT * FROM tweeks ORDER BY created_at DESC')
+      .all()
+  }
+
+  getById(id: string): Tweek | null {
+    const db = getDb()
+    return db
+      .query<Tweek, [string]>('SELECT * FROM tweeks WHERE id = ?')
+      .get(id)
+  }
+
+  create(input: CreateTweekInput): Tweek {
+    const db = getDb()
+    const id = crypto.randomUUID()
+    const now = new Date().toISOString()
+
+    db.query(
+      `INSERT INTO tweeks (id, name, description, domain, url_pattern, script, script_type, enabled, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
+    ).run(
+      id,
+      input.name,
+      input.description ?? null,
+      input.domain,
+      input.url_pattern,
+      input.script,
+      input.script_type ?? 'js',
+      now,
+      now,
+    )
+
+    logger.info('Tweek created', { id, name: input.name, domain: input.domain })
+    // biome-ignore lint/style/noNonNullAssertion: row was just inserted
+    return this.getById(id)!
+  }
+
+  update(id: string, input: UpdateTweekInput): Tweek | null {
+    const existing = this.getById(id)
+    if (!existing) return null
+
+    const db = getDb()
+    const now = new Date().toISOString()
+
+    const fields: string[] = ['updated_at = ?']
+    const values: (string | number)[] = [now]
+
+    if (input.name !== undefined) {
+      fields.push('name = ?')
+      values.push(input.name)
+    }
+    if (input.description !== undefined) {
+      fields.push('description = ?')
+      values.push(input.description)
+    }
+    if (input.script !== undefined) {
+      fields.push('script = ?')
+      values.push(input.script)
+    }
+    if (input.url_pattern !== undefined) {
+      fields.push('url_pattern = ?')
+      values.push(input.url_pattern)
+    }
+    if (input.enabled !== undefined) {
+      fields.push('enabled = ?')
+      values.push(input.enabled ? 1 : 0)
+    }
+
+    values.push(id)
+    db.query(`UPDATE tweeks SET ${fields.join(', ')} WHERE id = ?`).run(
+      ...values,
+    )
+
+    logger.info('Tweek updated', { id })
+    return this.getById(id)
+  }
+
+  delete(id: string): boolean {
+    const db = getDb()
+    const result = db.query('DELETE FROM tweeks WHERE id = ?').run(id)
+    if (result.changes > 0) {
+      logger.info('Tweek deleted', { id })
+      return true
+    }
+    return false
+  }
+
+  getMatchingTweeks(url: string): Tweek[] {
+    const db = getDb()
+    const allEnabled = db
+      .query<Tweek, []>('SELECT * FROM tweeks WHERE enabled = 1')
+      .all()
+
+    return allEnabled.filter((tweek) => this.matchesUrl(tweek.url_pattern, url))
+  }
+
+  private matchesUrl(pattern: string, url: string): boolean {
+    try {
+      const regexStr = pattern
+        .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+        .replace(/\*/g, '.*')
+      return new RegExp(`^${regexStr}$`).test(url)
+    } catch {
+      return false
+    }
+  }
+}

--- a/apps/server/src/lib/db/schema.ts
+++ b/apps/server/src/lib/db/schema.ts
@@ -21,7 +21,22 @@ CREATE TABLE IF NOT EXISTS identity (
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 )`
 
+const TWEEKS_TABLE = `
+CREATE TABLE IF NOT EXISTS tweeks (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  domain TEXT NOT NULL,
+  url_pattern TEXT NOT NULL,
+  script TEXT NOT NULL,
+  script_type TEXT NOT NULL DEFAULT 'js',
+  enabled INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)`
+
 export function initSchema(db: Database): void {
   db.exec(RATE_LIMITER_TABLE)
   db.exec(IDENTITY_TABLE)
+  db.exec(TWEEKS_TABLE)
 }

--- a/apps/server/src/tools/registry.ts
+++ b/apps/server/src/tools/registry.ts
@@ -60,6 +60,13 @@ import {
 } from './tab-groups'
 import { createRegistry } from './tool-registry'
 import {
+  apply_tweek,
+  create_tweek,
+  delete_tweek,
+  list_tweeks,
+  toggle_tweek,
+} from './tweeks'
+import {
   activate_window,
   close_window,
   create_hidden_window,
@@ -140,4 +147,11 @@ export const registry = createRegistry([
 
   // Info (1)
   browseros_info,
+
+  // Tweeks (5)
+  create_tweek,
+  list_tweeks,
+  apply_tweek,
+  toggle_tweek,
+  delete_tweek,
 ])

--- a/apps/server/src/tools/tweeks.ts
+++ b/apps/server/src/tools/tweeks.ts
@@ -1,0 +1,208 @@
+import { z } from 'zod'
+import { TweeksService } from '../api/services/tweeks-service'
+import { defineTool } from './framework'
+
+const tweeksService = new TweeksService()
+
+const pageParam = z.number().describe('Page ID (from list_pages)')
+
+export const create_tweek = defineTool({
+  name: 'create_tweek',
+  description:
+    'Save a new website modification (tweek). Provide a name, the target domain, URL pattern, and the JavaScript or CSS script to inject. The tweek will auto-apply on matching pages.',
+  input: z.object({
+    name: z.string().min(1).describe('Short name for the tweek'),
+    description: z.string().optional().describe('What this tweek does'),
+    domain: z.string().min(1).describe('Target domain (e.g. "youtube.com")'),
+    url_pattern: z
+      .string()
+      .min(1)
+      .describe(
+        'URL pattern with wildcards (e.g. "https://www.youtube.com/*")',
+      ),
+    script: z.string().min(1).describe('JavaScript or CSS code to inject'),
+    script_type: z.enum(['js', 'css']).default('js').describe('Type of script'),
+  }),
+  output: z.object({
+    id: z.string(),
+    name: z.string(),
+    domain: z.string(),
+  }),
+  handler: async (args, _ctx, response) => {
+    const tweek = tweeksService.create({
+      name: args.name,
+      description: args.description,
+      domain: args.domain,
+      url_pattern: args.url_pattern,
+      script: args.script,
+      script_type: args.script_type,
+    })
+    response.text(
+      `Created tweek "${tweek.name}" (${tweek.id}) for ${tweek.domain}`,
+    )
+    response.data({
+      id: tweek.id,
+      name: tweek.name,
+      domain: tweek.domain,
+    })
+  },
+})
+
+export const list_tweeks = defineTool({
+  name: 'list_tweeks',
+  description:
+    'List all saved tweeks (website modifications). Optionally filter by domain.',
+  input: z.object({
+    domain: z
+      .string()
+      .optional()
+      .describe('Filter by domain (e.g. "youtube.com")'),
+  }),
+  output: z.object({
+    tweeks: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        domain: z.string(),
+        enabled: z.boolean(),
+      }),
+    ),
+    count: z.number(),
+  }),
+  handler: async (args, _ctx, response) => {
+    const tweeks = tweeksService.list(args.domain)
+
+    if (tweeks.length === 0) {
+      response.text(
+        args.domain
+          ? `No tweeks found for ${args.domain}.`
+          : 'No tweeks found.',
+      )
+      response.data({ tweeks: [], count: 0 })
+      return
+    }
+
+    const lines = tweeks.map(
+      (t) =>
+        `- ${t.name} (${t.id}) — ${t.domain} [${t.enabled ? 'ON' : 'OFF'}]`,
+    )
+    response.text(`Found ${tweeks.length} tweek(s):\n${lines.join('\n')}`)
+    response.data({
+      tweeks: tweeks.map((t) => ({
+        id: t.id,
+        name: t.name,
+        domain: t.domain,
+        enabled: Boolean(t.enabled),
+      })),
+      count: tweeks.length,
+    })
+  },
+})
+
+export const apply_tweek = defineTool({
+  name: 'apply_tweek',
+  description:
+    'Apply a saved tweek to the current page by injecting its script. The tweek must exist and be enabled.',
+  input: z.object({
+    page: pageParam,
+    tweek_id: z.string().describe('ID of the tweek to apply'),
+  }),
+  output: z.object({
+    applied: z.boolean(),
+    tweek_name: z.string().optional(),
+  }),
+  handler: async (args, ctx, response) => {
+    const tweek = tweeksService.getById(args.tweek_id)
+
+    if (!tweek) {
+      response.error(`Tweek not found: ${args.tweek_id}`)
+      return
+    }
+
+    if (!tweek.enabled) {
+      response.error(`Tweek "${tweek.name}" is disabled.`)
+      return
+    }
+
+    let expression: string
+    if (tweek.script_type === 'css') {
+      const escaped = tweek.script.replace(/`/g, '\\`').replace(/\$/g, '\\$')
+      expression = `(() => {
+        const style = document.createElement('style');
+        style.dataset.tweekId = '${tweek.id}';
+        style.textContent = \`${escaped}\`;
+        document.head.appendChild(style);
+        return 'CSS injected';
+      })()`
+    } else {
+      expression = tweek.script
+    }
+
+    const result = await ctx.browser.evaluate(args.page, expression)
+
+    if (result.error) {
+      response.error(`Script error: ${result.error}`)
+      response.data({ applied: false })
+      return
+    }
+
+    response.text(`Applied tweek "${tweek.name}" to page ${args.page}`)
+    response.data({ applied: true, tweek_name: tweek.name })
+  },
+})
+
+export const toggle_tweek = defineTool({
+  name: 'toggle_tweek',
+  description: 'Enable or disable a saved tweek.',
+  input: z.object({
+    tweek_id: z.string().describe('ID of the tweek to toggle'),
+    enabled: z
+      .boolean()
+      .describe('Whether to enable (true) or disable (false)'),
+  }),
+  output: z.object({
+    id: z.string(),
+    name: z.string(),
+    enabled: z.boolean(),
+  }),
+  handler: async (args, _ctx, response) => {
+    const tweek = tweeksService.update(args.tweek_id, {
+      enabled: args.enabled,
+    })
+
+    if (!tweek) {
+      response.error(`Tweek not found: ${args.tweek_id}`)
+      return
+    }
+
+    const state = args.enabled ? 'enabled' : 'disabled'
+    response.text(`Tweek "${tweek.name}" is now ${state}.`)
+    response.data({
+      id: tweek.id,
+      name: tweek.name,
+      enabled: Boolean(tweek.enabled),
+    })
+  },
+})
+
+export const delete_tweek = defineTool({
+  name: 'delete_tweek',
+  description: 'Permanently delete a saved tweek.',
+  input: z.object({
+    tweek_id: z.string().describe('ID of the tweek to delete'),
+  }),
+  output: z.object({
+    deleted: z.boolean(),
+  }),
+  handler: async (args, _ctx, response) => {
+    const deleted = tweeksService.delete(args.tweek_id)
+
+    if (!deleted) {
+      response.error(`Tweek not found: ${args.tweek_id}`)
+      return
+    }
+
+    response.text(`Tweek ${args.tweek_id} deleted.`)
+    response.data({ deleted: true })
+  },
+})

--- a/apps/tweeks/.gitignore
+++ b/apps/tweeks/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.output
+.wxt

--- a/apps/tweeks/biome.json
+++ b/apps/tweeks/biome.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
+  "root": false,
+  "extends": "//",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error"
+      },
+      "nursery": {
+        "useSortedClasses": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded"
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  }
+}

--- a/apps/tweeks/entrypoints/background/index.ts
+++ b/apps/tweeks/entrypoints/background/index.ts
@@ -1,0 +1,5 @@
+export default defineBackground(() => {
+  chrome.action.onClicked.addListener((_tab) => {
+    // Popup is configured in manifest, this is a fallback
+  })
+})

--- a/apps/tweeks/entrypoints/content.ts
+++ b/apps/tweeks/entrypoints/content.ts
@@ -1,0 +1,43 @@
+export default defineContentScript({
+  matches: ['<all_urls>'],
+  runAt: 'document_idle',
+  async main() {
+    const SERVER_URL = 'http://127.0.0.1:9222'
+    const currentUrl = window.location.href
+
+    try {
+      const res = await fetch(
+        `${SERVER_URL}/tweeks/match?url=${encodeURIComponent(currentUrl)}`,
+      )
+      if (!res.ok) return
+
+      const data = await res.json()
+      const tweeks = data.tweeks as Array<{
+        id: string
+        script: string
+        script_type: 'js' | 'css'
+        name: string
+      }>
+
+      for (const tweek of tweeks) {
+        try {
+          if (tweek.script_type === 'css') {
+            const style = document.createElement('style')
+            style.dataset.tweekId = tweek.id
+            style.textContent = tweek.script
+            document.head.appendChild(style)
+          } else {
+            const script = document.createElement('script')
+            script.dataset.tweekId = tweek.id
+            script.textContent = tweek.script
+            document.head.appendChild(script)
+          }
+        } catch {
+          // Individual tweek failure shouldn't block others
+        }
+      }
+    } catch {
+      // Server not available — silently skip
+    }
+  },
+})

--- a/apps/tweeks/entrypoints/popup/App.tsx
+++ b/apps/tweeks/entrypoints/popup/App.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useState } from 'react'
+import {
+  createTweek,
+  deleteTweek,
+  fetchTweeks,
+  type Tweek,
+  updateTweek,
+} from '../../lib/api'
+import { extractDomain } from '../../lib/utils'
+import { CreateTweekForm } from './CreateTweekForm'
+import { TweekCard } from './TweekCard'
+
+type View = 'list' | 'create'
+
+export function App() {
+  const [tweeks, setTweeks] = useState<Tweek[]>([])
+  const [currentDomain, setCurrentDomain] = useState('')
+  const [currentUrl, setCurrentUrl] = useState('')
+  const [view, setView] = useState<View>('list')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  useEffect(() => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const tab = tabs[0]
+      if (tab?.url) {
+        const domain = extractDomain(tab.url)
+        setCurrentDomain(domain)
+        setCurrentUrl(tab.url)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!currentDomain) return
+    setLoading(true)
+    setError(null)
+    fetchTweeks()
+      .then((all) => setTweeks(all))
+      .catch(() => setError('Could not connect to BrowserOS server'))
+      .finally(() => setLoading(false))
+  }, [currentDomain])
+
+  async function refreshTweeks() {
+    setLoading(true)
+    setError(null)
+    try {
+      const all = await fetchTweeks()
+      setTweeks(all)
+    } catch {
+      setError('Could not connect to BrowserOS server')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleToggle(id: string, enabled: boolean) {
+    await updateTweek(id, { enabled })
+    await refreshTweeks()
+  }
+
+  async function handleDelete(id: string) {
+    await deleteTweek(id)
+    await refreshTweeks()
+  }
+
+  async function handleCreate(input: {
+    name: string
+    description: string
+    script: string
+    script_type: 'js' | 'css'
+  }) {
+    await createTweek({
+      ...input,
+      domain: currentDomain,
+      url_pattern: `https://*${currentDomain}/*`,
+    })
+    await refreshTweeks()
+    setView('list')
+  }
+
+  const domainTweeks = tweeks.filter((t) => t.domain === currentDomain)
+  const otherTweeks = tweeks.filter((t) => t.domain !== currentDomain)
+
+  return (
+    <div className="flex max-h-[560px] min-h-[400px] w-[380px] flex-col overflow-hidden">
+      <header className="flex items-center justify-between border-border border-b px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="flex h-7 w-7 items-center justify-center rounded-md bg-primary font-bold text-primary-foreground text-xs">
+            T
+          </div>
+          <h1 className="font-semibold text-sm">Tweeks</h1>
+        </div>
+        {view === 'list' ? (
+          <button
+            type="button"
+            onClick={() => setView('create')}
+            className="rounded-md bg-primary px-3 py-1.5 font-medium text-primary-foreground text-xs transition-colors hover:bg-primary/90"
+          >
+            + New Tweek
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setView('list')}
+            className="rounded-md border border-border px-3 py-1.5 font-medium text-xs transition-colors hover:bg-muted"
+          >
+            Back
+          </button>
+        )}
+      </header>
+
+      <div className="flex-1 overflow-y-auto">
+        {view === 'create' ? (
+          <CreateTweekForm
+            domain={currentDomain}
+            url={currentUrl}
+            onSubmit={handleCreate}
+          />
+        ) : (
+          <div className="flex flex-col">
+            {loading && (
+              <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
+                Loading...
+              </div>
+            )}
+
+            {error && (
+              <div className="mx-4 mt-3 rounded-md bg-destructive/10 px-3 py-2 text-destructive text-xs">
+                {error}
+              </div>
+            )}
+
+            {!loading && !error && tweeks.length === 0 && (
+              <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+                <p className="text-muted-foreground text-sm">No tweeks yet</p>
+                <p className="text-muted-foreground text-xs">
+                  Create your first tweek to customize this site
+                </p>
+              </div>
+            )}
+
+            {!loading && domainTweeks.length > 0 && (
+              <section>
+                <h2 className="px-4 pt-3 pb-1 font-semibold text-[11px] text-muted-foreground uppercase tracking-wider">
+                  {currentDomain}
+                </h2>
+                {domainTweeks.map((tweek) => (
+                  <TweekCard
+                    key={tweek.id}
+                    tweek={tweek}
+                    onToggle={handleToggle}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </section>
+            )}
+
+            {!loading && otherTweeks.length > 0 && (
+              <section>
+                <h2 className="px-4 pt-3 pb-1 font-semibold text-[11px] text-muted-foreground uppercase tracking-wider">
+                  Other Sites
+                </h2>
+                {otherTweeks.map((tweek) => (
+                  <TweekCard
+                    key={tweek.id}
+                    tweek={tweek}
+                    onToggle={handleToggle}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </section>
+            )}
+          </div>
+        )}
+      </div>
+
+      <footer className="border-border border-t px-4 py-2 text-center text-[10px] text-muted-foreground">
+        BrowserOS Tweeks v0.0.1
+      </footer>
+    </div>
+  )
+}

--- a/apps/tweeks/entrypoints/popup/CreateTweekForm.tsx
+++ b/apps/tweeks/entrypoints/popup/CreateTweekForm.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react'
+
+interface CreateTweekFormProps {
+  domain: string
+  url: string
+  onSubmit: (input: {
+    name: string
+    description: string
+    script: string
+    script_type: 'js' | 'css'
+  }) => void
+}
+
+export function CreateTweekForm({ domain, onSubmit }: CreateTweekFormProps) {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [script, setScript] = useState('')
+  const [scriptType, setScriptType] = useState<'js' | 'css'>('js')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim() || !script.trim()) return
+    setSubmitting(true)
+    try {
+      await onSubmit({
+        name: name.trim(),
+        description: description.trim(),
+        script: script.trim(),
+        script_type: scriptType,
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3 p-4">
+      <div className="rounded-md bg-accent px-3 py-2 text-accent-foreground text-xs">
+        Creating tweek for <strong>{domain}</strong>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="tweek-name" className="font-medium text-xs">
+          Name
+        </label>
+        <input
+          id="tweek-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Hide Sidebar"
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+          required
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label htmlFor="tweek-description" className="font-medium text-xs">
+          Description
+        </label>
+        <input
+          id="tweek-description"
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What does this tweek do?"
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <label htmlFor="tweek-script" className="font-medium text-xs">
+            Script
+          </label>
+          <div className="flex gap-1">
+            <button
+              type="button"
+              onClick={() => setScriptType('js')}
+              className={`rounded px-2 py-0.5 font-medium text-[10px] transition-colors ${
+                scriptType === 'js'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80'
+              }`}
+            >
+              JS
+            </button>
+            <button
+              type="button"
+              onClick={() => setScriptType('css')}
+              className={`rounded px-2 py-0.5 font-medium text-[10px] transition-colors ${
+                scriptType === 'css'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80'
+              }`}
+            >
+              CSS
+            </button>
+          </div>
+        </div>
+        <textarea
+          id="tweek-script"
+          value={script}
+          onChange={(e) => setScript(e.target.value)}
+          placeholder={
+            scriptType === 'css'
+              ? '.sidebar { display: none !important; }'
+              : "document.querySelector('.sidebar')?.remove();"
+          }
+          rows={6}
+          className="resize-none rounded-md border border-border bg-background px-3 py-2 font-mono text-xs outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+          required
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={submitting || !name.trim() || !script.trim()}
+        className="rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground text-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {submitting ? 'Creating...' : 'Create Tweek'}
+      </button>
+    </form>
+  )
+}

--- a/apps/tweeks/entrypoints/popup/TweekCard.tsx
+++ b/apps/tweeks/entrypoints/popup/TweekCard.tsx
@@ -1,0 +1,68 @@
+import { Trash2 } from 'lucide-react'
+import type { Tweek } from '../../lib/api'
+import { cn } from '../../lib/utils'
+
+interface TweekCardProps {
+  tweek: Tweek
+  onToggle: (id: string, enabled: boolean) => void
+  onDelete: (id: string) => void
+}
+
+export function TweekCard({ tweek, onToggle, onDelete }: TweekCardProps) {
+  const isEnabled = Boolean(tweek.enabled)
+
+  return (
+    <div className="flex items-center gap-3 border-border border-b px-4 py-3 last:border-b-0">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              'truncate font-medium text-sm',
+              !isEnabled && 'text-muted-foreground',
+            )}
+          >
+            {tweek.name}
+          </span>
+          <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            {tweek.script_type.toUpperCase()}
+          </span>
+        </div>
+        {tweek.description && (
+          <p className="mt-0.5 truncate text-muted-foreground text-xs">
+            {tweek.description}
+          </p>
+        )}
+        <p className="mt-0.5 text-[10px] text-muted-foreground">
+          {tweek.domain}
+        </p>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onToggle(tweek.id, !isEnabled)}
+          className={cn(
+            'relative h-5 w-9 rounded-full transition-colors',
+            isEnabled ? 'bg-primary' : 'bg-muted',
+          )}
+          title={isEnabled ? 'Disable' : 'Enable'}
+        >
+          <span
+            className={cn(
+              'absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform',
+              isEnabled && 'translate-x-4',
+            )}
+          />
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(tweek.id)}
+          className="rounded p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+          title="Delete"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/tweeks/entrypoints/popup/index.html
+++ b/apps/tweeks/entrypoints/popup/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tweeks</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/tweeks/entrypoints/popup/main.tsx
+++ b/apps/tweeks/entrypoints/popup/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import '../../styles/global.css'
+import { App } from './App'
+
+const root = document.getElementById('root')
+if (root) {
+  ReactDOM.createRoot(root).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  )
+}

--- a/apps/tweeks/lib/api.ts
+++ b/apps/tweeks/lib/api.ts
@@ -1,0 +1,68 @@
+const SERVER_URL = 'http://127.0.0.1:9222'
+
+export interface Tweek {
+  id: string
+  name: string
+  description: string | null
+  domain: string
+  url_pattern: string
+  script: string
+  script_type: 'js' | 'css'
+  enabled: number
+  created_at: string
+  updated_at: string
+}
+
+export async function fetchTweeks(domain?: string): Promise<Tweek[]> {
+  const params = domain ? `?domain=${encodeURIComponent(domain)}` : ''
+  const res = await fetch(`${SERVER_URL}/tweeks${params}`)
+  const data = await res.json()
+  return data.tweeks
+}
+
+export async function fetchMatchingTweeks(url: string): Promise<Tweek[]> {
+  const res = await fetch(
+    `${SERVER_URL}/tweeks/match?url=${encodeURIComponent(url)}`,
+  )
+  const data = await res.json()
+  return data.tweeks
+}
+
+export async function createTweek(input: {
+  name: string
+  description?: string
+  domain: string
+  url_pattern: string
+  script: string
+  script_type?: 'js' | 'css'
+}): Promise<Tweek> {
+  const res = await fetch(`${SERVER_URL}/tweeks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  const data = await res.json()
+  return data.tweek
+}
+
+export async function updateTweek(
+  id: string,
+  input: {
+    name?: string
+    description?: string
+    script?: string
+    enabled?: boolean
+  },
+): Promise<Tweek> {
+  const res = await fetch(`${SERVER_URL}/tweeks/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  })
+  const data = await res.json()
+  return data.tweek
+}
+
+export async function deleteTweek(id: string): Promise<void> {
+  await fetch(`${SERVER_URL}/tweeks/${id}`, { method: 'DELETE' })
+}

--- a/apps/tweeks/lib/utils.ts
+++ b/apps/tweeks/lib/utils.ts
@@ -1,0 +1,14 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+export function extractDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return ''
+  }
+}

--- a/apps/tweeks/package.json
+++ b/apps/tweeks/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@browseros/tweeks",
+  "description": "BrowserOS Tweeks - AI-powered web modifications",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "bun --env-file=.env.development wxt",
+    "build": "wxt build",
+    "build:dev": "bun --env-file=.env.development wxt build --mode development",
+    "zip": "wxt zip",
+    "typecheck": "tsc --noEmit",
+    "lint": "bunx biome check",
+    "lint:fix": "bunx biome check --write --unsafe"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.562.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "tailwind-merge": "^3.4.0",
+    "tw-animate-css": "^1.4.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.17",
+    "@types/bun": "^1.3.5",
+    "@types/chrome": "^0.1.28",
+    "@types/react": "^19.1.12",
+    "@types/react-dom": "^19.1.9",
+    "@wxt-dev/module-react": "^1.1.5",
+    "tailwindcss": "^4.1.17",
+    "typescript": "^5.9.2",
+    "wxt": "^0.20.18"
+  }
+}

--- a/apps/tweeks/styles/global.css
+++ b/apps/tweeks/styles/global.css
@@ -1,0 +1,27 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@theme {
+  --color-background: #ffffff;
+  --color-foreground: #0a0a0a;
+  --color-muted: #f5f5f5;
+  --color-muted-foreground: #737373;
+  --color-border: #e5e5e5;
+  --color-primary: #6d28d9;
+  --color-primary-foreground: #ffffff;
+  --color-destructive: #ef4444;
+  --color-destructive-foreground: #ffffff;
+  --color-accent: #f5f3ff;
+  --color-accent-foreground: #6d28d9;
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  margin: 0;
+  padding: 0;
+}

--- a/apps/tweeks/tsconfig.json
+++ b/apps/tweeks/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./.wxt/tsconfig.json",
+  "compilerOptions": {
+    "types": ["chrome", "bun"],
+    "allowImportingTsExtensions": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/apps/tweeks/wxt.config.ts
+++ b/apps/tweeks/wxt.config.ts
@@ -1,0 +1,20 @@
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'wxt'
+
+export default defineConfig({
+  outDir: 'dist',
+  modules: ['@wxt-dev/module-react'],
+  manifest: {
+    name: 'BrowserOS Tweeks',
+    description: 'AI-powered web modifications for BrowserOS',
+    action: {
+      default_title: 'Tweeks',
+      default_popup: 'popup.html',
+    },
+    permissions: ['activeTab', 'storage', 'scripting', 'tabs'],
+    host_permissions: ['http://127.0.0.1/*', '<all_urls>'],
+  },
+  vite: () => ({
+    plugins: [tailwindcss()],
+  }),
+})

--- a/bun.lock
+++ b/bun.lock
@@ -199,6 +199,30 @@
         "chrome-devtools-mcp": "latest",
       },
     },
+    "apps/tweeks": {
+      "name": "@browseros/tweeks",
+      "version": "0.0.1",
+      "dependencies": {
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.562.0",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
+        "tailwind-merge": "^3.4.0",
+        "tw-animate-css": "^1.4.0",
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.1.17",
+        "@types/bun": "^1.3.5",
+        "@types/chrome": "^0.1.28",
+        "@types/react": "^19.1.12",
+        "@types/react-dom": "^19.1.9",
+        "@wxt-dev/module-react": "^1.1.5",
+        "tailwindcss": "^4.1.17",
+        "typescript": "^5.9.2",
+        "wxt": "^0.20.18",
+      },
+    },
     "packages/agent-sdk": {
       "name": "@browseros-ai/agent-sdk",
       "version": "0.0.5",
@@ -447,6 +471,8 @@
     "@browseros/server": ["@browseros/server@workspace:apps/server"],
 
     "@browseros/shared": ["@browseros/shared@workspace:packages/shared"],
+
+    "@browseros/tweeks": ["@browseros/tweeks@workspace:apps/tweeks"],
 
     "@bunup/dts": ["@bunup/dts@0.14.49", "", { "dependencies": { "@babel/parser": "^7.28.6", "coffi": "^0.1.37", "oxc-minify": "^0.93.0", "oxc-resolver": "^11.16.2", "oxc-transform": "^0.93.0", "picocolors": "^1.1.1", "std-env": "^3.10.0", "ts-import-resolver": "^0.1.23" }, "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-mAni3Zpf1MLxFDNCNStcxjbgNaSZpygc1qqF66WHMoUs3j+NSNKZPKwex9uLGXazJdE8g9MqQ//1QQcETdwY6Q=="],
 


### PR DESCRIPTION
## Summary
- Adds a Tweeks system (inspired by [tweeks.io](https://tweeks.io)) that lets users create, manage, and auto-apply website modifications (CSS/JS scripts) to customize any site
- New server-side CRUD API (`/tweeks`) with SQLite persistence, URL pattern matching, and 5 new MCP tools (`create_tweek`, `list_tweeks`, `apply_tweek`, `toggle_tweek`, `delete_tweek`)
- New `apps/tweeks` WXT Chrome extension with popup UI (React + Tailwind), content script for auto-injection, and domain-aware tweek management

## What is Tweeks?
Tweeks are small CSS/JS scripts that modify specific websites. Users can:
1. Create tweeks manually (write CSS/JS) or via the AI agent (natural language)
2. Tweeks auto-apply when visiting matching domains
3. Toggle tweeks on/off per-site
4. Manage all tweeks from the extension popup

## Architecture
```
Extension Popup → Server API (/tweeks) → SQLite DB
Content Script → Server API (/tweeks/match?url=) → Inject matching scripts
AI Agent → MCP Tools (create_tweek, etc.) → Same API
```

## Test plan
- [ ] Create a tweek via the `/tweeks` API and verify it persists in SQLite
- [ ] Verify `GET /tweeks/match?url=` returns correct tweeks for URL patterns
- [ ] Test MCP tools work via the agent (create, list, toggle, delete)
- [ ] Build and load the `apps/tweeks` extension in BrowserOS
- [ ] Verify content script auto-applies tweeks on matching pages
- [ ] Test toggle on/off and delete from the popup UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)