### PR TITLE
fix: fix compaction tool output truncation and token estimation

### DIFF
--- a/apps/server/src/agent/compaction.ts
+++ b/apps/server/src/agent/compaction.ts
@@ -117,6 +117,7 @@ function estimateContentPart(part: Record<string, unknown>): {
   if ('type' in part && part.type === 'image') {
     return { chars: 0, images: 1 }
   }
+  // Tool output with {type, value} wrapper (AI SDK standard)
   if (
     'output' in part &&
     part.output &&
@@ -129,8 +130,23 @@ function estimateContentPart(part: Record<string, unknown>): {
       images: 0,
     }
   }
+  // Tool result field (may be string or object)
+  if ('result' in part) {
+    const result = part.result
+    if (typeof result === 'string') {
+      return { chars: result.length, images: 0 }
+    }
+    if (result != null) {
+      return { chars: JSON.stringify(result).length, images: 0 }
+    }
+  }
   if ('input' in part) {
     return { chars: JSON.stringify(part.input).length, images: 0 }
+  }
+  // Fallback: serialize the whole part to catch any unknown structure
+  const serialized = JSON.stringify(part)
+  if (serialized.length > 100) {
+    return { chars: serialized.length, images: 0 }
   }
   return { chars: 0, images: 0 }
 }
@@ -154,7 +170,7 @@ export function estimateTokens(
     }
   }
 
-  return Math.ceil(chars / 4) + imageCount * imageTokenEstimate
+  return Math.ceil(chars / 3) + imageCount * imageTokenEstimate
 }
 
 export interface StepWithUsage {
@@ -370,7 +386,7 @@ async function summarizeTurnPrefix(
 }
 
 // ---------------------------------------------------------------------------
-// Tool output truncation (unchanged from original)
+// Tool output truncation
 // ---------------------------------------------------------------------------
 
 export function truncateToolOutputs(
@@ -384,30 +400,23 @@ export function truncateToolOutputs(
       if (!('output' in part)) return part
 
       const output = part.output
-      if (output.type === 'text' && output.value.length > maxChars) {
-        return {
-          ...part,
-          output: {
-            ...output,
-            value: `${output.value.slice(0, maxChars)}\n\n[... truncated ${output.value.length - maxChars} characters]`,
-          },
-        }
-      }
+      if (!('value' in output)) return part
 
-      if (output.type === 'json') {
-        const serialized = JSON.stringify(output.value)
-        if (serialized.length > maxChars) {
-          return {
-            ...part,
-            output: {
-              type: 'text' as const,
-              value: `${serialized.slice(0, maxChars)}\n\n[... truncated ${serialized.length - maxChars} characters]`,
-            },
-          }
-        }
-      }
+      // Stringify value regardless of output.type (text, json, content, etc.)
+      const valStr =
+        typeof output.value === 'string'
+          ? output.value
+          : JSON.stringify(output.value)
 
-      return part
+      if (valStr.length <= maxChars) return part
+
+      return {
+        ...part,
+        output: {
+          type: 'text' as const,
+          value: `${valStr.slice(0, maxChars)}\n\n[... truncated ${valStr.length - maxChars} characters]`,
+        },
+      }
     })
 
     return { ...msg, content }
@@ -706,22 +715,25 @@ export function createCompactionPrepareStep(
       ? experimental_context
       : { existingSummary: null, compactionCount: 0 }
 
+    // Stage 0: Cap oversized tool outputs before any estimation or compaction.
+    const capped = truncateToolOutputs(messages, config.toolOutputMaxChars)
+
     // Stage 1: Check if compaction is needed using the current prompt as-is.
-    const currentTokens = getCurrentTokenCount(steps, messages, config)
+    const currentTokens = getCurrentTokenCount(steps, capped, config)
     const triggerThreshold = config.triggerThreshold
 
     if (currentTokens <= triggerThreshold) {
-      return { messages, experimental_context: state }
+      return { messages: capped, experimental_context: state }
     }
 
     logger.warn('Context approaching limit, attempting compaction', {
       currentTokens,
       triggerThreshold: Math.floor(triggerThreshold),
-      messageCount: messages.length,
+      messageCount: capped.length,
     })
 
     // Stage 2: LLM-based compaction with sliding window fallback
-    const compacted = await compactMessages(model, messages, config, state)
+    const compacted = await compactMessages(model, capped, config, state)
     return { messages: compacted, experimental_context: state }
   }
 }

--- a/apps/server/tests/agent/compaction.test.ts
+++ b/apps/server/tests/agent/compaction.test.ts
@@ -239,13 +239,13 @@ describe('computeConfig — summarization budgets', () => {
 // ---------------------------------------------------------------------------
 
 describe('estimateTokens', () => {
-  it('estimates text messages as chars/4', () => {
-    const msgs = [userMsg('a'.repeat(400))]
+  it('estimates text messages as chars/3', () => {
+    const msgs = [userMsg('a'.repeat(300))]
     expect(estimateTokens(msgs)).toBe(100)
   })
 
   it('estimates tool result text', () => {
-    const msgs = [toolResult('test', 'a'.repeat(800))]
+    const msgs = [toolResult('test', 'a'.repeat(600))]
     expect(estimateTokens(msgs)).toBe(200)
   })
 
@@ -253,12 +253,12 @@ describe('estimateTokens', () => {
     const obj = { key: 'a'.repeat(100) }
     const msgs = [toolResultJson('test', obj)]
     const serialized = JSON.stringify(obj)
-    expect(estimateTokens(msgs)).toBe(Math.ceil(serialized.length / 4))
+    expect(estimateTokens(msgs)).toBe(Math.ceil(serialized.length / 3))
   })
 
   it('counts images as 1000 tokens each', () => {
     const msgs = [userMsgWithImage('hello')]
-    const textTokens = Math.ceil('hello'.length / 4)
+    const textTokens = Math.ceil('hello'.length / 3)
     expect(estimateTokens(msgs)).toBe(textTokens + 1000)
   })
 
@@ -271,14 +271,14 @@ describe('estimateTokens', () => {
         { type: 'image', image: new Uint8Array([2]) },
       ],
     }
-    const textTokens = Math.ceil('compare these'.length / 4)
+    const textTokens = Math.ceil('compare these'.length / 3)
     expect(estimateTokens([msg])).toBe(textTokens + 2000)
   })
 
   it('handles tool call input', () => {
     const msgs = [assistantToolCall('navigate', { url: 'https://example.com' })]
     const expected = Math.ceil(
-      JSON.stringify({ url: 'https://example.com' }).length / 4,
+      JSON.stringify({ url: 'https://example.com' }).length / 3,
     )
     expect(estimateTokens(msgs)).toBe(expected)
   })

--- a/packages/shared/src/constants/limits.ts
+++ b/packages/shared/src/constants/limits.ts
@@ -39,7 +39,8 @@ export const AGENT_LIMITS = {
   COMPACTION_SUMMARIZER_OUTPUT_RATIO: 0.8,
 
   // Compaction — estimation (step 0 / no real usage)
-  COMPACTION_FIXED_OVERHEAD: 5_000,
+  // Covers system prompt (~2.5K tokens) + tool definitions as JSON Schema (~8-9K tokens)
+  COMPACTION_FIXED_OVERHEAD: 12_000,
   COMPACTION_SAFETY_MULTIPLIER: 1.3,
   COMPACTION_IMAGE_TOKEN_ESTIMATE: 1_000,
 


### PR DESCRIPTION
- truncateToolOutputs: handle all output.type variants (text, json, content) by checking output.value directly instead of branching on type. The old code missed type 'content' (array of content parts), causing 1M+ char tool results to pass through untouched.

- estimateTokens: change chars/4 to chars/3 — HTML/Markdown content tokenizes at ~3.14 chars/token empirically, not 4.

- COMPACTION_FIXED_OVERHEAD: 5K → 12K to account for system prompt (~2.5K tokens) + tool definitions as JSON Schema (~8-9K tokens).

- Apply truncateToolOutputs in prepareStep (Stage 0) before token estimation, not just during summarization.