### PR TITLE
feat: Claude Agent SDK integration for Gartner demo

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.62",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.71",
     "@ai-sdk/anthropic": "^3.0.46",
     "@ai-sdk/azure": "^3.0.31",
     "@ai-sdk/google": "^3.0.30",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/apps/server/src/agent/agent-interface.ts
+++ b/apps/server/src/agent/agent-interface.ts
@@ -1,0 +1,8 @@
+import type { UIMessage } from 'ai'
+
+export interface AgentInterface {
+  get messages(): UIMessage[]
+  set messages(msgs: UIMessage[])
+  appendUserMessage(content: string): void
+  dispose(): Promise<void>
+}

--- a/apps/server/src/agent/ai-sdk-agent.ts
+++ b/apps/server/src/agent/ai-sdk-agent.ts
@@ -14,6 +14,7 @@ import { isSoulBootstrap, readSoul } from '../lib/soul'
 import { buildFilesystemToolSet } from '../tools/filesystem/build-toolset'
 import { buildMemoryToolSet } from '../tools/memory/build-toolset'
 import type { ToolRegistry } from '../tools/tool-registry'
+import type { AgentInterface } from './agent-interface'
 import { CHAT_MODE_ALLOWED_TOOLS } from './chat-mode'
 import { createCompactionPrepareStep } from './compaction'
 import { createContextOverflowMiddleware } from './context-overflow-middleware'
@@ -32,7 +33,7 @@ export interface AiSdkAgentConfig {
   browserosId?: string
 }
 
-export class AiSdkAgent {
+export class AiSdkAgent implements AgentInterface {
   private constructor(
     private _agent: ToolLoopAgent,
     private _messages: UIMessage[],

--- a/apps/server/src/agent/claude-agent.ts
+++ b/apps/server/src/agent/claude-agent.ts
@@ -1,0 +1,269 @@
+import { type McpServerConfig, query } from '@anthropic-ai/claude-agent-sdk'
+import { AGENT_LIMITS } from '@browseros/shared/constants/limits'
+import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
+import type { UIMessage } from 'ai'
+import type { Browser } from '../browser/browser'
+import type { KlavisClient } from '../lib/clients/klavis/klavis-client'
+import { logger } from '../lib/logger'
+import { isSoulBootstrap, readSoul } from '../lib/soul'
+import { buildFilesystemToolSet } from '../tools/filesystem/build-toolset'
+import { buildMemoryToolSet } from '../tools/memory/build-toolset'
+import type { ToolRegistry } from '../tools/tool-registry'
+import type { AgentInterface } from './agent-interface'
+import { CHAT_MODE_ALLOWED_TOOLS } from './chat-mode'
+import { createClaudeStreamResponse } from './claude-stream-adapter'
+import {
+  createBrowserMcpServer,
+  createToolSetMcpServer,
+} from './claude-tool-adapter'
+import { buildMcpServerSpecs } from './mcp-builder'
+import { buildSystemPrompt } from './prompt'
+import type { ResolvedAgentConfig } from './types'
+
+export interface ClaudeAgentConfig {
+  resolvedConfig: ResolvedAgentConfig
+  browser: Browser
+  registry: ToolRegistry
+  browserContext?: BrowserContext
+  klavisClient?: KlavisClient
+  browserosId?: string
+}
+
+export class ClaudeAgent implements AgentInterface {
+  private _messages: UIMessage[] = []
+
+  private constructor(
+    private mcpServers: Record<string, McpServerConfig>,
+    private externalMcpClients: Array<{ close(): Promise<void> }>,
+    private instructions: string,
+    private model: string,
+    private apiKey: string | undefined,
+    private conversationId: string,
+    private chatMode: boolean,
+    private allowedToolNames: string[],
+  ) {}
+
+  static async create(cfg: ClaudeAgentConfig): Promise<ClaudeAgent> {
+    const { resolvedConfig, browser, registry } = cfg
+
+    // Build in-process MCP servers for browser tools
+    const allBrowserTools = registry.all()
+    const filteredRegistry = resolvedConfig.chatMode
+      ? {
+          all: () =>
+            allBrowserTools.filter((t) => CHAT_MODE_ALLOWED_TOOLS.has(t.name)),
+          get: (name: string) =>
+            allBrowserTools.find(
+              (t) => t.name === name && CHAT_MODE_ALLOWED_TOOLS.has(name),
+            ),
+          names: () =>
+            allBrowserTools
+              .filter((t) => CHAT_MODE_ALLOWED_TOOLS.has(t.name))
+              .map((t) => t.name),
+        }
+      : registry
+
+    const browserMcp = createBrowserMcpServer(
+      filteredRegistry as ToolRegistry,
+      browser,
+    )
+
+    // Filesystem & memory tools (skip in chat mode)
+    const mcpServers: Record<string, McpServerConfig> = {
+      'browser-tools': browserMcp,
+    }
+    const allowedToolNames: string[] = [...filteredRegistry.names()]
+
+    if (!resolvedConfig.chatMode) {
+      const fsMcp = createToolSetMcpServer(
+        buildFilesystemToolSet(resolvedConfig.sessionExecutionDir),
+        'filesystem-tools',
+      )
+      mcpServers['filesystem-tools'] = fsMcp
+      allowedToolNames.push(
+        'filesystem_read',
+        'filesystem_write',
+        'filesystem_edit',
+        'filesystem_bash',
+        'filesystem_grep',
+        'filesystem_find',
+        'filesystem_ls',
+      )
+
+      const memMcp = createToolSetMcpServer(
+        buildMemoryToolSet(),
+        'memory-tools',
+      )
+      mcpServers['memory-tools'] = memMcp
+      allowedToolNames.push(
+        'memory_search',
+        'memory_write',
+        'memory_read_core',
+        'memory_save_core',
+        'soul_read',
+        'soul_update',
+      )
+    }
+
+    // External MCP servers (Klavis, custom) — pass as remote servers
+    const externalMcpClients: Array<{ close(): Promise<void> }> = []
+    const specs = await buildMcpServerSpecs({
+      browserContext: cfg.browserContext,
+      klavisClient: cfg.klavisClient,
+      browserosId: cfg.browserosId,
+    })
+    for (const spec of specs) {
+      mcpServers[spec.name] = {
+        type: spec.transport === 'sse' ? 'sse' : 'http',
+        url: spec.url,
+        ...(spec.headers && { headers: spec.headers }),
+      } as McpServerConfig
+    }
+
+    // Build system prompt
+    const excludeSections: string[] = ['tool-reference']
+    if (resolvedConfig.isScheduledTask) {
+      excludeSections.push('tab-grouping')
+    }
+    const soulContent = await readSoul()
+    const isBootstrap = await isSoulBootstrap()
+    const instructions = buildSystemPrompt({
+      userSystemPrompt: resolvedConfig.userSystemPrompt,
+      exclude: excludeSections,
+      isScheduledTask: resolvedConfig.isScheduledTask,
+      scheduledTaskWindowId: cfg.browserContext?.windowId,
+      workspaceDir: resolvedConfig.sessionExecutionDir,
+      soulContent,
+      isSoulBootstrap: isBootstrap,
+      chatMode: resolvedConfig.chatMode,
+    })
+
+    if (resolvedConfig.chatMode) {
+      logger.info('Chat mode enabled, restricting to read-only browser tools', {
+        allowedTools: Array.from(CHAT_MODE_ALLOWED_TOOLS),
+      })
+    }
+
+    logger.info('Claude Agent session created', {
+      conversationId: resolvedConfig.conversationId,
+      model: resolvedConfig.model,
+      toolCount: allowedToolNames.length,
+      mcpServerCount: Object.keys(mcpServers).length,
+    })
+
+    return new ClaudeAgent(
+      mcpServers,
+      externalMcpClients,
+      instructions,
+      resolvedConfig.model,
+      resolvedConfig.apiKey,
+      resolvedConfig.conversationId,
+      resolvedConfig.chatMode ?? false,
+      allowedToolNames,
+    )
+  }
+
+  get messages(): UIMessage[] {
+    return this._messages
+  }
+
+  set messages(msgs: UIMessage[]) {
+    this._messages = msgs
+  }
+
+  appendUserMessage(content: string): void {
+    this._messages.push({
+      id: crypto.randomUUID(),
+      role: 'user',
+      parts: [{ type: 'text', text: content }],
+    })
+  }
+
+  processMessage(
+    abortSignal: AbortSignal,
+    onComplete?: () => Promise<void>,
+  ): Response {
+    const lastMessage = this._messages[this._messages.length - 1]
+    const userText =
+      lastMessage?.role === 'user'
+        ? lastMessage.parts
+            .filter(
+              (p): p is { type: 'text'; text: string } => p.type === 'text',
+            )
+            .map((p) => p.text)
+            .join('\n')
+        : ''
+
+    // Build conversation context from previous messages
+    const contextLines: string[] = []
+    for (const msg of this._messages.slice(0, -1)) {
+      const text = msg.parts
+        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+        .map((p) => p.text)
+        .join('\n')
+      if (text) {
+        contextLines.push(`[${msg.role}]: ${text}`)
+      }
+    }
+
+    const prompt =
+      contextLines.length > 0
+        ? `Previous conversation:\n${contextLines.join('\n')}\n\nCurrent message:\n${userText}`
+        : userText
+
+    const env: Record<string, string | undefined> = { ...process.env }
+    if (this.apiKey) {
+      env.ANTHROPIC_API_KEY = this.apiKey
+    }
+
+    const abortController = new AbortController()
+    abortSignal.addEventListener('abort', () => abortController.abort(), {
+      once: true,
+    })
+
+    const queryStream = query({
+      prompt,
+      options: {
+        abortController,
+        model: this.model,
+        systemPrompt: this.instructions,
+        tools: [],
+        mcpServers: this.mcpServers,
+        allowedTools: this.allowedToolNames,
+        maxTurns: AGENT_LIMITS.MAX_TURNS,
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        includePartialMessages: true,
+        persistSession: false,
+        env,
+        settingSources: [],
+      },
+    })
+
+    const onFinish = async (responseText: string) => {
+      if (responseText) {
+        this._messages.push({
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          parts: [{ type: 'text', text: responseText }],
+        })
+      }
+      logger.info('Claude Agent execution complete', {
+        conversationId: this.conversationId,
+        totalMessages: this._messages.length,
+      })
+      await onComplete?.()
+    }
+
+    return createClaudeStreamResponse(queryStream, abortSignal, onFinish)
+  }
+
+  async dispose(): Promise<void> {
+    for (const client of this.externalMcpClients) {
+      await client.close().catch(() => {})
+    }
+    logger.info('Claude Agent disposed', {
+      conversationId: this.conversationId,
+    })
+  }
+}

--- a/apps/server/src/agent/claude-stream-adapter.ts
+++ b/apps/server/src/agent/claude-stream-adapter.ts
@@ -1,0 +1,149 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk'
+import { createUIMessageStream, createUIMessageStreamResponse } from 'ai'
+import { logger } from '../lib/logger'
+
+// biome-ignore lint/suspicious/noExplicitAny: SDK event types are complex union types
+type Writer = any
+
+function ensureStarted(writer: Writer, messageId: string, started: boolean) {
+  if (!started) writer.write({ type: 'start', messageId })
+  return true
+}
+
+function handleStreamEvent(
+  writer: Writer,
+  msg: SDKMessage,
+): string | undefined {
+  // biome-ignore lint/suspicious/noExplicitAny: SDK nested event type
+  const event = (msg as any).event
+  if (!event) return undefined
+
+  if (event.type === 'content_block_delta') {
+    const delta = event.delta
+    if (delta?.type === 'text_delta' && delta.text) {
+      writer.write({ type: 'text', text: delta.text })
+      return delta.text
+    }
+  } else if (event.type === 'content_block_start') {
+    const block = event.content_block
+    if (block?.type === 'tool_use') {
+      writer.write({
+        type: 'tool-call',
+        toolCallId: block.id,
+        toolName: block.name,
+        args: block.input ?? {},
+      })
+    }
+  }
+  return undefined
+}
+
+function handleAssistantMessage(
+  writer: Writer,
+  msg: SDKMessage,
+): string | undefined {
+  // biome-ignore lint/suspicious/noExplicitAny: SDK nested message type
+  const message = (msg as any).message
+  if (!message?.content) return undefined
+
+  const texts: string[] = []
+  for (const block of message.content) {
+    if (block.type === 'text' && block.text) {
+      writer.write({ type: 'text', text: block.text })
+      texts.push(block.text)
+    }
+    if (block.type === 'tool_use') {
+      writer.write({
+        type: 'tool-call',
+        toolCallId: block.id,
+        toolName: block.name,
+        args: block.input ?? {},
+      })
+      writer.write({
+        type: 'tool-result',
+        toolCallId: block.id,
+        result: 'Executed',
+      })
+    }
+  }
+  return texts.length > 0 ? texts.join('') : undefined
+}
+
+function dispatchMessage(
+  writer: Writer,
+  msg: SDKMessage,
+  textChunks: string[],
+): void {
+  if (msg.type === 'stream_event') {
+    const text = handleStreamEvent(writer, msg)
+    if (text) textChunks.push(text)
+  } else {
+    const text = handleAssistantMessage(writer, msg)
+    if (text) textChunks.push(text)
+  }
+}
+
+async function processStream(
+  writer: Writer,
+  queryStream: AsyncGenerator<SDKMessage, void>,
+  abortSignal: AbortSignal,
+  onFinish?: (responseText: string) => Promise<void>,
+): Promise<void> {
+  const messageId = crypto.randomUUID()
+  let started = false
+  const textChunks: string[] = []
+
+  try {
+    for await (const msg of queryStream) {
+      if (abortSignal.aborted) break
+
+      if (msg.type === 'stream_event' || msg.type === 'assistant') {
+        started = ensureStarted(writer, messageId, started)
+        dispatchMessage(writer, msg, textChunks)
+      } else if (msg.type === 'result') {
+        started = ensureStarted(writer, messageId, started)
+        writer.write({
+          type: 'finish',
+          finishReason: msg.subtype === 'success' ? 'stop' : 'error',
+        })
+      } else {
+        logger.debug('Unhandled SDK message type', {
+          type: msg.type,
+          subtype: 'subtype' in msg ? msg.subtype : undefined,
+        })
+      }
+    }
+
+    if (!started) {
+      writer.write({ type: 'start', messageId })
+      writer.write({ type: 'finish', finishReason: 'stop' })
+    }
+  } catch (error) {
+    logger.error('Claude stream error', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    ensureStarted(writer, messageId, started)
+    writer.write({
+      type: 'error',
+      errorText: error instanceof Error ? error.message : 'Unknown error',
+    })
+    writer.write({ type: 'finish', finishReason: 'error' })
+  } finally {
+    await onFinish?.(textChunks.join(''))
+  }
+}
+
+export function createClaudeStreamResponse(
+  queryStream: AsyncGenerator<SDKMessage, void>,
+  abortSignal: AbortSignal,
+  onFinish?: (responseText: string) => Promise<void>,
+): Response {
+  return createUIMessageStreamResponse({
+    status: 200,
+    stream: createUIMessageStream({
+      execute: async ({ writer }) => {
+        await processStream(writer, queryStream, abortSignal, onFinish)
+      },
+    }),
+  })
+}

--- a/apps/server/src/agent/claude-tool-adapter.ts
+++ b/apps/server/src/agent/claude-tool-adapter.ts
@@ -1,0 +1,144 @@
+import {
+  createSdkMcpServer,
+  tool as sdkTool,
+} from '@anthropic-ai/claude-agent-sdk'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import type { ToolSet } from 'ai'
+import type { z } from 'zod'
+import type { Browser } from '../browser/browser'
+import { logger } from '../lib/logger'
+import { metrics } from '../lib/metrics'
+import { executeTool } from '../tools/framework'
+import type { ContentItem } from '../tools/response'
+import type { ToolRegistry } from '../tools/tool-registry'
+
+function contentToCallToolResult(
+  content: ContentItem[],
+  isError?: boolean,
+): CallToolResult {
+  return {
+    content: content.map((c) => {
+      if (c.type === 'text') return { type: 'text' as const, text: c.text }
+      return {
+        type: 'image' as const,
+        data: c.data,
+        mimeType: c.mimeType,
+      }
+    }),
+    isError,
+  }
+}
+
+function extractShape(schema: z.ZodType): Record<string, z.ZodType> {
+  if ('shape' in schema && typeof schema.shape === 'object') {
+    return schema.shape as Record<string, z.ZodType>
+  }
+  // ZodEffects, ZodTransformed, etc. don't expose .shape — tool will have no parameters
+  logger.warn(
+    'Schema has no .shape property, tool will have empty parameters',
+    {
+      schemaType: schema.constructor?.name,
+    },
+  )
+  return {}
+}
+
+export function createBrowserMcpServer(
+  registry: ToolRegistry,
+  browser: Browser,
+) {
+  const ctx = { browser }
+  const tools = registry.all().map((def) => {
+    const shape = extractShape(def.input)
+    return sdkTool(
+      def.name,
+      def.description,
+      shape,
+      async (args: Record<string, unknown>) => {
+        const startTime = performance.now()
+        try {
+          const result = await executeTool(
+            def,
+            args,
+            ctx,
+            AbortSignal.timeout(120_000),
+          )
+          metrics.log('tool_executed', {
+            tool_name: def.name,
+            duration_ms: Math.round(performance.now() - startTime),
+            success: !result.isError,
+          })
+          return contentToCallToolResult(result.content, result.isError)
+        } catch (error) {
+          const errorText =
+            error instanceof Error ? error.message : String(error)
+          logger.error('Tool execution failed', {
+            tool: def.name,
+            error: errorText,
+          })
+          metrics.log('tool_executed', {
+            tool_name: def.name,
+            duration_ms: Math.round(performance.now() - startTime),
+            success: false,
+          })
+          return { content: [{ type: 'text', text: errorText }], isError: true }
+        }
+      },
+    )
+  })
+
+  return createSdkMcpServer({ name: 'browser-tools', version: '1.0.0', tools })
+}
+
+export function createToolSetMcpServer(toolSet: ToolSet, name: string) {
+  const tools = Object.entries(toolSet).map(([toolName, def]) => {
+    const shape = extractShape(def.inputSchema as z.ZodType)
+    return sdkTool(
+      toolName,
+      def.description ?? toolName,
+      shape,
+      async (args: Record<string, unknown>) => {
+        const startTime = performance.now()
+        try {
+          const raw = await def.execute?.(args, {
+            toolCallId: crypto.randomUUID(),
+            messages: [],
+          })
+          metrics.log('tool_executed', {
+            tool_name: toolName,
+            duration_ms: Math.round(performance.now() - startTime),
+            success: true,
+          })
+          if (typeof raw === 'string') {
+            return { content: [{ type: 'text', text: raw }] }
+          }
+          if (raw && typeof raw === 'object' && 'content' in raw) {
+            const result = raw as {
+              content: ContentItem[]
+              isError?: boolean
+            }
+            return contentToCallToolResult(result.content, result.isError)
+          }
+          return {
+            content: [{ type: 'text', text: JSON.stringify(raw) ?? 'Success' }],
+          }
+        } catch (error) {
+          const errorText =
+            error instanceof Error ? error.message : String(error)
+          logger.error('ToolSet tool execution failed', {
+            tool: toolName,
+            error: errorText,
+          })
+          metrics.log('tool_executed', {
+            tool_name: toolName,
+            duration_ms: Math.round(performance.now() - startTime),
+            success: false,
+          })
+          return { content: [{ type: 'text', text: errorText }], isError: true }
+        }
+      },
+    )
+  })
+
+  return createSdkMcpServer({ name, version: '1.0.0', tools })
+}

--- a/apps/server/src/agent/session-store.ts
+++ b/apps/server/src/agent/session-store.ts
@@ -1,9 +1,9 @@
 import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
 import { logger } from '../lib/logger'
-import type { AiSdkAgent } from './ai-sdk-agent'
+import type { AgentInterface } from './agent-interface'
 
 export interface AgentSession {
-  agent: AiSdkAgent
+  agent: AgentInterface
   hiddenWindowId?: number
   /** Browser context scoped to the hidden window (scheduled tasks only) */
   browserContext?: BrowserContext

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -6,8 +6,10 @@
 
 import { mkdir } from 'node:fs/promises'
 import path from 'node:path'
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createAgentUIStreamResponse, type UIMessage } from 'ai'
 import { AiSdkAgent } from '../../agent/ai-sdk-agent'
+import { ClaudeAgent } from '../../agent/claude-agent'
 import { formatUserMessage } from '../../agent/format-message'
 import type { SessionStore } from '../../agent/session-store'
 import type { ResolvedAgentConfig } from '../../agent/types'
@@ -96,14 +98,24 @@ export class ChatService {
         }
       }
 
-      const agent = await AiSdkAgent.create({
-        resolvedConfig: agentConfig,
-        browser: this.deps.browser,
-        registry: this.deps.registry,
-        browserContext,
-        klavisClient: this.deps.klavisClient,
-        browserosId: this.deps.browserosId,
-      })
+      const useClaudeAgent = agentConfig.provider === LLM_PROVIDERS.ANTHROPIC
+      const agent = useClaudeAgent
+        ? await ClaudeAgent.create({
+            resolvedConfig: agentConfig,
+            browser: this.deps.browser,
+            registry: this.deps.registry,
+            browserContext,
+            klavisClient: this.deps.klavisClient,
+            browserosId: this.deps.browserosId,
+          })
+        : await AiSdkAgent.create({
+            resolvedConfig: agentConfig,
+            browser: this.deps.browser,
+            registry: this.deps.registry,
+            browserContext,
+            klavisClient: this.deps.klavisClient,
+            browserosId: this.deps.browserosId,
+          })
       session = { agent, hiddenWindowId, browserContext }
       sessionStore.set(request.conversationId, session)
     }
@@ -137,9 +149,23 @@ export class ChatService {
     )
     session.agent.appendUserMessage(userContent)
 
+    if (session.agent instanceof ClaudeAgent) {
+      const onComplete = session.hiddenWindowId
+        ? async () => {
+            const windowId = session.hiddenWindowId
+            if (windowId) {
+              session.hiddenWindowId = undefined
+              this.closeHiddenWindow(windowId, request.conversationId)
+            }
+          }
+        : undefined
+      return session.agent.processMessage(abortSignal, onComplete)
+    }
+
+    const aiSdkAgent = session.agent as AiSdkAgent
     return createAgentUIStreamResponse({
-      agent: session.agent.toolLoopAgent,
-      uiMessages: session.agent.messages,
+      agent: aiSdkAgent.toolLoopAgent,
+      uiMessages: aiSdkAgent.messages,
       abortSignal,
       onFinish: async ({ messages }: { messages: UIMessage[] }) => {
         session.agent.messages = messages

--- a/bun.lock
+++ b/bun.lock
@@ -143,7 +143,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "bin": {
         "browseros-server": "./src/index.ts",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -156,6 +156,7 @@
         "@ai-sdk/openai": "^3.0.30",
         "@ai-sdk/openai-compatible": "^2.0.30",
         "@ai-sdk/provider": "^3.0.8",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.71",
         "@browseros-ai/agent-sdk": "workspace:*",
         "@browseros/cdp-protocol": "workspace:*",
         "@browseros/shared": "workspace:*",
@@ -281,6 +282,8 @@
     "@ant-design/react-slick": ["@ant-design/react-slick@1.1.2", "", { "dependencies": { "@babel/runtime": "^7.10.4", "classnames": "^2.2.5", "json2mq": "^0.2.0", "resize-observer-polyfill": "^1.5.1", "throttle-debounce": "^5.0.0" }, "peerDependencies": { "react": ">=16.9.0" } }, "sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.71", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pIsQJnM7Y+cJHL7aFY6SCCW3FIni218gVEpPqG8XGowfYxboFNBbNssWiUNRwthT8bp9jypcX7q5kx0Xsw14xg=="],
 
     "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.8.2", "", {}, "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA=="],
 
@@ -707,6 +710,38 @@
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
     "@iconify/utils": ["@iconify/utils@3.1.0", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.0" } }, "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
 
@@ -4057,6 +4092,8 @@
     "@aklinker1/rollup-plugin-visualizer/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "@ant-design/cssinjs-utils/@ant-design/cssinjs": ["@ant-design/cssinjs@1.24.0", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "classnames": "^2.3.1", "csstype": "^3.1.3", "rc-util": "^5.35.0", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-K4cYrJBsgvL+IoozUXYjbT6LHHNt+19a9zkvpBPxLjFHas1UpPM2A5MlhROb0BT8N8WoavM5VsP9MeSeNK/3mg=="],
+
+    "@anthropic-ai/claude-agent-sdk/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "@aws-crypto/crc32/@aws-sdk/types": ["@aws-sdk/types@3.972.0", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug=="],
 


### PR DESCRIPTION
## Summary
- Adds `ClaudeAgent` as a drop-in alternative to `AiSdkAgent` when the LLM provider is Anthropic, using the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`)
- Routes Anthropic provider requests through the Claude Agent SDK's `query()` API which spawns a managed Claude Code subprocess with full tool support via in-process MCP servers
- Maintains full parity with existing agent: browser tools, filesystem tools, memory tools, external MCP servers, chat mode, scheduled tasks, and multi-turn conversation persistence

## Key Files
- `apps/server/src/agent/claude-agent.ts` — Main agent class wrapping the SDK
- `apps/server/src/agent/claude-stream-adapter.ts` — Converts SDK AsyncGenerator→SSE Response
- `apps/server/src/agent/claude-tool-adapter.ts` — Bridges ToolRegistry/ToolSet→SDK MCP format
- `apps/server/src/agent/agent-interface.ts` — Shared interface for SessionStore polymorphism
- `apps/server/src/api/services/chat-service.ts` — Provider-based routing

## Test plan
- [ ] Verify Anthropic provider requests route to ClaudeAgent (check server logs for "Claude Agent session created")
- [ ] Verify non-Anthropic providers still use AiSdkAgent
- [ ] Test multi-turn conversation with Anthropic provider
- [ ] Test scheduled task with Anthropic provider (hidden window cleanup)
- [ ] Test chat mode restricts tools correctly
- [ ] Run `bun run typecheck` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)