### PR TITLE
feat: use execution dir in browser tool context

### DIFF
--- a/apps/server/src/agent/ai-sdk-agent.ts
+++ b/apps/server/src/agent/ai-sdk-agent.ts
@@ -59,7 +59,11 @@ export class AiSdkAgent {
         : rawModel
 
     // Build browser tools from the unified tool registry
-    const allBrowserTools = buildBrowserToolSet(config.registry, config.browser)
+    const allBrowserTools = buildBrowserToolSet(
+      config.registry,
+      config.browser,
+      config.resolvedConfig.sessionExecutionDir,
+    )
     const browserTools = config.resolvedConfig.chatMode
       ? Object.fromEntries(
           Object.entries(allBrowserTools).filter(([name]) =>

--- a/apps/server/src/agent/tool-adapter.ts
+++ b/apps/server/src/agent/tool-adapter.ts
@@ -3,7 +3,7 @@ import { type ToolSet, tool } from 'ai'
 import type { Browser } from '../browser/browser'
 import { logger } from '../lib/logger'
 import { metrics } from '../lib/metrics'
-import { executeTool } from '../tools/framework'
+import { executeTool, type ToolContext } from '../tools/framework'
 import type { ContentItem } from '../tools/response'
 import type { ToolRegistry } from '../tools/tool-registry'
 
@@ -38,9 +38,13 @@ function contentToModelOutput(
 export function buildBrowserToolSet(
   registry: ToolRegistry,
   browser: Browser,
+  executionDir: string,
 ): ToolSet {
   const toolSet: ToolSet = {}
-  const ctx = { browser }
+  const ctx: ToolContext = {
+    browser,
+    directories: { executionDir },
+  }
 
   for (const def of registry.all()) {
     toolSet[def.name] = tool({

--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -19,6 +19,8 @@ interface McpRouteDeps {
   version: string
   registry: ToolRegistry
   browser: Browser
+  executionDir: string
+  resourcesDir: string
   klavisProxy?: KlavisProxyHandle | null
 }
 

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -63,6 +63,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     host = '0.0.0.0',
     browserosId,
     executionDir,
+    resourcesDir,
     rateLimiter,
     version,
     browser,
@@ -117,6 +118,8 @@ export async function createHttpServer(config: HttpServerConfig) {
         version,
         registry,
         browser,
+        executionDir,
+        resourcesDir,
         klavisProxy,
       }),
     )

--- a/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/apps/server/src/api/services/mcp/mcp-server.ts
@@ -19,6 +19,8 @@ export interface McpServiceDeps {
   version: string
   registry: ToolRegistry
   browser: Browser
+  executionDir: string
+  resourcesDir: string
   klavisProxy?: KlavisProxyHandle | null
 }
 
@@ -37,7 +39,13 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
   })
 
   // Register browser tools
-  registerTools(server, deps.registry, { browser: deps.browser })
+  registerTools(server, deps.registry, {
+    browser: deps.browser,
+    directories: {
+      executionDir: deps.executionDir,
+      resourcesDir: deps.resourcesDir,
+    },
+  })
 
   // Register Klavis proxy tools (if connected)
   if (deps.klavisProxy) {

--- a/apps/server/src/api/types.ts
+++ b/apps/server/src/api/types.ts
@@ -90,7 +90,8 @@ export interface HttpServerConfig {
   registry: ToolRegistry
 
   browserosId?: string
-  executionDir?: string
+  executionDir: string
+  resourcesDir: string
   rateLimiter?: RateLimiter
 
   codegenServiceUrl?: string

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -93,6 +93,7 @@ export class Application {
         registry,
         browserosId: identity.getBrowserOSId(),
         executionDir: this.config.executionDir,
+        resourcesDir: this.config.resourcesDir,
         rateLimiter: new RateLimiter(this.getDb(), dailyRateLimit),
         codegenServiceUrl: this.config.codegenServiceUrl,
 

--- a/apps/server/src/tools/framework.ts
+++ b/apps/server/src/tools/framework.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path'
 import type { z } from 'zod'
 import type { Browser } from '../browser/browser'
 import { ToolResponse, type ToolResult } from './response'
@@ -16,8 +17,22 @@ export type ToolHandler = (
   response: ToolResponse,
 ) => Promise<void>
 
+export interface ToolDirectories {
+  executionDir: string
+  resourcesDir?: string
+}
+
 export type ToolContext = {
   browser: Browser
+  directories: ToolDirectories
+}
+
+export function resolveExecutionPath(
+  ctx: ToolContext,
+  targetPath: string,
+  cwd?: string,
+): string {
+  return resolve(cwd ?? ctx.directories.executionDir, targetPath)
 }
 
 export function defineTool<

--- a/apps/server/src/tools/page-actions.ts
+++ b/apps/server/src/tools/page-actions.ts
@@ -1,8 +1,8 @@
 import { mkdtemp, rename, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { z } from 'zod'
-import { defineTool } from './framework'
+import { defineTool, resolveExecutionPath } from './framework'
 
 const pageParam = z.number().describe('Page ID (from list_pages)')
 const elementParam = z
@@ -18,7 +18,9 @@ export const save_pdf = defineTool({
     cwd: z
       .string()
       .optional()
-      .describe('Working directory to resolve relative paths against'),
+      .describe(
+        'Working directory to resolve relative paths against; defaults to the execution directory',
+      ),
   }),
   output: z.object({
     action: z.literal('save_pdf'),
@@ -26,7 +28,7 @@ export const save_pdf = defineTool({
     path: z.string(),
   }),
   handler: async (args, ctx, response) => {
-    const resolvedPath = resolve(args.cwd ?? process.cwd(), args.path)
+    const resolvedPath = resolveExecutionPath(ctx, args.path, args.cwd)
     const { data } = await ctx.browser.printToPDF(args.page)
     await Bun.write(resolvedPath, Buffer.from(data, 'base64'))
     response.text(`Saved PDF to ${resolvedPath}`)
@@ -49,7 +51,9 @@ export const save_screenshot = defineTool({
     cwd: z
       .string()
       .optional()
-      .describe('Working directory to resolve relative paths against'),
+      .describe(
+        'Working directory to resolve relative paths against; defaults to the execution directory',
+      ),
     format: z
       .enum(['png', 'jpeg', 'webp'])
       .default('png')
@@ -74,7 +78,7 @@ export const save_screenshot = defineTool({
     fullPage: z.boolean(),
   }),
   handler: async (args, ctx, response) => {
-    const resolvedPath = resolve(args.cwd ?? process.cwd(), args.path)
+    const resolvedPath = resolveExecutionPath(ctx, args.path, args.cwd)
     const { data } = await ctx.browser.screenshot(args.page, {
       format: args.format,
       quality: args.quality,
@@ -104,7 +108,9 @@ export const download_file = defineTool({
     cwd: z
       .string()
       .optional()
-      .describe('Working directory to resolve relative paths against'),
+      .describe(
+        'Working directory to resolve relative paths against; defaults to the execution directory',
+      ),
   }),
   output: z.object({
     action: z.literal('download_file'),
@@ -115,7 +121,7 @@ export const download_file = defineTool({
     destinationPath: z.string(),
   }),
   handler: async (args, ctx, response) => {
-    const resolvedDir = resolve(args.cwd ?? process.cwd(), args.path)
+    const resolvedDir = resolveExecutionPath(ctx, args.path, args.cwd)
     const tempDir = await mkdtemp(join(tmpdir(), 'browseros-dl-'))
 
     try {

--- a/apps/server/tests/__helpers__/with-browser.ts
+++ b/apps/server/tests/__helpers__/with-browser.ts
@@ -81,7 +81,15 @@ export async function withBrowser(
       args: unknown,
     ): Promise<ToolResult> => {
       const signal = AbortSignal.timeout(30_000)
-      return executeTool(tool, args, { browser }, signal)
+      return executeTool(
+        tool,
+        args,
+        {
+          browser,
+          directories: { executionDir: process.cwd() },
+        },
+        signal,
+      )
     }
 
     await cb({ browser, execute })

--- a/apps/server/tests/tools/page-actions.test.ts
+++ b/apps/server/tests/tools/page-actions.test.ts
@@ -1,10 +1,17 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
 import { existsSync, unlinkSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { Browser } from '../../src/browser/browser'
+import { executeTool, type ToolContext } from '../../src/tools/framework'
 import { close_page, new_page } from '../../src/tools/navigation'
-import { save_pdf } from '../../src/tools/page-actions'
+import {
+  download_file,
+  save_pdf,
+  save_screenshot,
+} from '../../src/tools/page-actions'
 import { withBrowser } from '../__helpers__/with-browser'
 
 function textOf(result: {
@@ -21,7 +28,138 @@ function structuredOf<T>(result: { structuredContent?: unknown }): T {
   return result.structuredContent as T
 }
 
+function createToolContext(
+  browser: Browser,
+  executionDir: string,
+  resourcesDir?: string,
+): ToolContext {
+  return {
+    browser,
+    directories: {
+      executionDir,
+      resourcesDir,
+    },
+  }
+}
+
+function createBrowserStub(methods: Record<string, unknown>): Browser {
+  return {
+    getTabIdForPage: () => undefined,
+    ...methods,
+  } as unknown as Browser
+}
+
 describe('page action tools', () => {
+  it('save_pdf resolves relative paths against the execution directory by default', async () => {
+    const executionDir = await mkdtemp(
+      join(tmpdir(), 'browseros-page-actions-'),
+    )
+    const browser = createBrowserStub({
+      printToPDF: async () => ({
+        data: Buffer.from('pdf-data').toString('base64'),
+      }),
+    })
+
+    try {
+      const result = await executeTool(
+        save_pdf,
+        { page: 1, path: 'report.pdf' },
+        createToolContext(browser, executionDir),
+        AbortSignal.timeout(1_000),
+      )
+
+      assert.ok(!result.isError, textOf(result))
+      const outputPath = join(executionDir, 'report.pdf')
+      assert.strictEqual(
+        structuredOf<{ path: string }>(result).path,
+        outputPath,
+      )
+      assert.ok(existsSync(outputPath), 'PDF file should exist in executionDir')
+    } finally {
+      await rm(executionDir, { recursive: true, force: true })
+    }
+  })
+
+  it('save_screenshot still honors an explicit cwd override', async () => {
+    const executionDir = await mkdtemp(
+      join(tmpdir(), 'browseros-page-actions-'),
+    )
+    const overrideDir = await mkdtemp(join(tmpdir(), 'browseros-page-actions-'))
+    const browser = createBrowserStub({
+      screenshot: async () => ({
+        data: Buffer.from('image-data').toString('base64'),
+      }),
+    })
+
+    try {
+      const result = await executeTool(
+        save_screenshot,
+        { page: 1, path: 'capture.png', cwd: overrideDir },
+        createToolContext(browser, executionDir),
+        AbortSignal.timeout(1_000),
+      )
+
+      assert.ok(!result.isError, textOf(result))
+      const outputPath = join(overrideDir, 'capture.png')
+      assert.strictEqual(
+        structuredOf<{ path: string }>(result).path,
+        outputPath,
+      )
+      assert.ok(
+        existsSync(outputPath),
+        'Screenshot should exist in overrideDir',
+      )
+      assert.ok(
+        !existsSync(join(executionDir, 'capture.png')),
+        'Execution directory should not be used when cwd is provided',
+      )
+    } finally {
+      await rm(executionDir, { recursive: true, force: true })
+      await rm(overrideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('download_file resolves relative directories against the execution directory by default', async () => {
+    const executionDir = await mkdtemp(
+      join(tmpdir(), 'browseros-page-actions-'),
+    )
+    const browser = createBrowserStub({
+      downloadViaClick: async (
+        _page: number,
+        _element: number,
+        tempDir: string,
+      ) => {
+        const filePath = join(tempDir, 'download.txt')
+        await Bun.write(filePath, 'hello')
+        return {
+          filePath,
+          suggestedFilename: 'download.txt',
+        }
+      },
+    })
+
+    try {
+      const result = await executeTool(
+        download_file,
+        { page: 1, element: 7, path: '.' },
+        createToolContext(browser, executionDir),
+        AbortSignal.timeout(1_000),
+      )
+
+      assert.ok(!result.isError, textOf(result))
+      const outputPath = join(executionDir, 'download.txt')
+      const structured = structuredOf<{
+        directory: string
+        destinationPath: string
+      }>(result)
+      assert.strictEqual(structured.directory, executionDir)
+      assert.strictEqual(structured.destinationPath, outputPath)
+      assert.ok(existsSync(outputPath), 'Download should land in executionDir')
+    } finally {
+      await rm(executionDir, { recursive: true, force: true })
+    }
+  })
+
   it('save_pdf writes a PDF file to disk', async () => {
     await withBrowser(async ({ execute }) => {
       const newResult = await execute(new_page, { url: 'https://example.com' })


### PR DESCRIPTION
## Summary
- Thread execution directory data through unified browser tool context for MCP and agent tool execution
- Default page-action relative paths to the configured execution directory while preserving explicit cwd overrides
- Add unit and integration coverage for execution-directory path resolution

## Design
Unified browser tool execution now carries directory scope instead of dropping it at the MCP and agent boundaries. MCP uses the server-configured execution and resources directories, and agent browser tools use the per-session execution directory already created by chat flow. Execution-oriented page actions resolve relative paths with that runtime context rather than `process.cwd()`.

## Test plan
- bun test apps/server/tests/tools/page-actions.test.ts
- bun run lint
- bun run typecheck
- bun run test