### PR TITLE
fix: replace stale browser_open_tab tool name in prompt

### DIFF
--- a/apps/server/src/agent/prompt.ts
+++ b/apps/server/src/agent/prompt.ts
@@ -259,7 +259,7 @@ If \`execute_action\` fails with an authentication error for a connected app:
 2. **STOP and wait.** Your response must contain ONLY the \`suggest_app_connection\` tool call with zero additional text.
 3. After the user re-connects, they will send a follow-up message. Only then retry.
 
-**Do NOT** open auth URLs directly with \`browser_open_tab\`. Always use the connection card.
+**Do NOT** open auth URLs directly with \`new_page\`. Always use the connection card.
 </authentication_flow>
 
 ## All Available Services


### PR DESCRIPTION
## Summary

- Replaces stale `browser_open_tab` reference in system prompt with `new_page`
- The old tool name caused models to infer a `browser_*` naming convention and call non-existent tools like `browser_navigate`

## Root Cause

The system prompt's authentication flow section referenced `browser_open_tab(url)` — a tool name from before the rename to `new_page`. Models saw this pattern and generalized it, calling `browser_navigate` instead of `navigate_page`, resulting in MCP error `-32602: Tool not found`.

Fixes TKT-540