### PR TITLE
feat: use execution dir for tool temp output

### DIFF
--- a/apps/server/src/tools/dom.ts
+++ b/apps/server/src/tools/dom.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { formatSearchResult } from '../browser/dom'
 import { defineTool } from './framework'
-import { writeToolOutputFile } from './output-file'
+import { writeTempToolOutputFile } from './output-file'
 
 const pageParam = z.number().describe('Page ID (from list_pages)')
 
@@ -37,7 +37,7 @@ export const get_dom = defineTool({
       return
     }
 
-    const path = await writeToolOutputFile(ctx, {
+    const path = await writeTempToolOutputFile({
       toolName: 'get-dom',
       extension: 'html',
       content: html,

--- a/apps/server/src/tools/dom.ts
+++ b/apps/server/src/tools/dom.ts
@@ -37,7 +37,7 @@ export const get_dom = defineTool({
       return
     }
 
-    const path = await writeToolOutputFile({
+    const path = await writeToolOutputFile(ctx, {
       toolName: 'get-dom',
       extension: 'html',
       content: html,

--- a/apps/server/src/tools/output-file.ts
+++ b/apps/server/src/tools/output-file.ts
@@ -2,19 +2,25 @@ import { randomUUID } from 'node:crypto'
 import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { PATHS } from '@browseros/shared/constants/paths'
-import { getBrowserosDir } from '../lib/browseros-dir'
+import type { ToolContext } from './framework'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
   return sanitized || 'tool-output'
 }
 
-export async function writeToolOutputFile(args: {
-  toolName: string
-  extension: string
-  content: string
-}): Promise<string> {
-  const outputDir = join(getBrowserosDir(), PATHS.TOOL_OUTPUT_DIR_NAME)
+export async function writeToolOutputFile(
+  ctx: ToolContext,
+  args: {
+    toolName: string
+    extension: string
+    content: string
+  },
+): Promise<string> {
+  const outputDir = join(
+    ctx.directories.executionDir,
+    PATHS.TOOL_OUTPUT_DIR_NAME,
+  )
   await mkdir(outputDir, { recursive: true })
 
   const toolName = sanitizeSegment(args.toolName)

--- a/apps/server/src/tools/output-file.ts
+++ b/apps/server/src/tools/output-file.ts
@@ -1,28 +1,19 @@
 import { randomUUID } from 'node:crypto'
-import { mkdir } from 'node:fs/promises'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { PATHS } from '@browseros/shared/constants/paths'
-import type { ToolContext } from './framework'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
   return sanitized || 'tool-output'
 }
 
-export async function writeToolOutputFile(
-  ctx: ToolContext,
-  args: {
-    toolName: string
-    extension: string
-    content: string
-  },
-): Promise<string> {
-  const outputDir = join(
-    ctx.directories.executionDir,
-    PATHS.TOOL_OUTPUT_DIR_NAME,
-  )
-  await mkdir(outputDir, { recursive: true })
-
+export async function writeTempToolOutputFile(args: {
+  toolName: string
+  extension: string
+  content: string
+}): Promise<string> {
+  const outputDir = await mkdtemp(join(tmpdir(), 'browseros-tool-output-'))
   const toolName = sanitizeSegment(args.toolName)
   const extension = sanitizeSegment(args.extension) || 'txt'
   const filePath = join(

--- a/apps/server/src/tools/page-actions.ts
+++ b/apps/server/src/tools/page-actions.ts
@@ -1,5 +1,4 @@
 import { mkdtemp, rename, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { z } from 'zod'
 import { defineTool, resolveExecutionPath } from './framework'
@@ -122,7 +121,9 @@ export const download_file = defineTool({
   }),
   handler: async (args, ctx, response) => {
     const resolvedDir = resolveExecutionPath(ctx, args.path, args.cwd)
-    const tempDir = await mkdtemp(join(tmpdir(), 'browseros-dl-'))
+    const tempDir = await mkdtemp(
+      join(ctx.directories.executionDir, 'browseros-dl-'),
+    )
 
     try {
       const { filePath, suggestedFilename } =

--- a/apps/server/src/tools/page-actions.ts
+++ b/apps/server/src/tools/page-actions.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rename, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rename, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { z } from 'zod'
 import { defineTool, resolveExecutionPath } from './framework'
@@ -121,6 +121,7 @@ export const download_file = defineTool({
   }),
   handler: async (args, ctx, response) => {
     const resolvedDir = resolveExecutionPath(ctx, args.path, args.cwd)
+    await mkdir(ctx.directories.executionDir, { recursive: true })
     const tempDir = await mkdtemp(
       join(ctx.directories.executionDir, 'browseros-dl-'),
     )

--- a/apps/server/src/tools/snapshot.ts
+++ b/apps/server/src/tools/snapshot.ts
@@ -1,7 +1,7 @@
 import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
 import { z } from 'zod'
 import { defineTool } from './framework'
-import { writeToolOutputFile } from './output-file'
+import { writeTempToolOutputFile } from './output-file'
 
 const pageParam = z.number().describe('Page ID (from list_pages)')
 
@@ -96,7 +96,7 @@ export const get_page_content = defineTool({
     }
 
     if (text.length > TOOL_LIMITS.INLINE_PAGE_CONTENT_MAX_CHARS) {
-      const path = await writeToolOutputFile(ctx, {
+      const path = await writeTempToolOutputFile({
         toolName: 'get-page-content',
         extension: 'md',
         content: text,

--- a/apps/server/src/tools/snapshot.ts
+++ b/apps/server/src/tools/snapshot.ts
@@ -96,7 +96,7 @@ export const get_page_content = defineTool({
     }
 
     if (text.length > TOOL_LIMITS.INLINE_PAGE_CONTENT_MAX_CHARS) {
-      const path = await writeToolOutputFile({
+      const path = await writeToolOutputFile(ctx, {
         toolName: 'get-page-content',
         extension: 'md',
         content: text,

--- a/apps/server/tests/tools/dom.test.ts
+++ b/apps/server/tests/tools/dom.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
 import { existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
 import { get_dom, search_dom } from '../../src/tools/dom'
 import { close_page, new_page } from '../../src/tools/navigation'
 import { evaluate_script } from '../../src/tools/snapshot'
@@ -85,6 +86,10 @@ describe('get_dom', () => {
 
         assert.ok(textOf(result).includes('Saved DOM'))
         assert.ok(existsSync(domPath), 'Saved DOM file should exist')
+        assert.ok(
+          domPath.startsWith(join(process.cwd(), 'tool-output')),
+          'Saved DOM file should be written under executionDir/tool-output',
+        )
         assert.ok(html.includes('<html'), 'Should contain <html> tag')
         assert.ok(html.includes('</html>'), 'Should contain closing </html>')
         assert.ok(html.includes('id="login-form"'), 'Should contain form ID')
@@ -236,6 +241,10 @@ describe('get_dom', () => {
         const html = readFileSync(domPath, 'utf8')
 
         assert.ok(textOf(result).includes('Saved DOM'))
+        assert.ok(
+          domPath.startsWith(join(process.cwd(), 'tool-output')),
+          'Saved DOM file should be written under executionDir/tool-output',
+        )
         assert.ok(data.totalLength > 100_000, 'Expected a large DOM payload')
         assert.strictEqual(html.length, data.totalLength)
         assert.ok(

--- a/apps/server/tests/tools/dom.test.ts
+++ b/apps/server/tests/tools/dom.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
-import { existsSync, readFileSync, unlinkSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync, rmSync, unlinkSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { get_dom, search_dom } from '../../src/tools/dom'
 import { close_page, new_page } from '../../src/tools/navigation'
 import { evaluate_script } from '../../src/tools/snapshot'
@@ -69,6 +69,13 @@ const RICH_PAGE = `data:text/html,${encodeURIComponent(`<!DOCTYPE html>
   </main>
 </body></html>`)}`
 
+function cleanupSavedDom(domPath: string): void {
+  unlinkSync(domPath)
+  try {
+    rmSync(dirname(domPath))
+  } catch {}
+}
+
 // ── get_dom ──
 
 describe('get_dom', () => {
@@ -86,8 +93,9 @@ describe('get_dom', () => {
 
         assert.ok(textOf(result).includes('Saved DOM'))
         assert.ok(existsSync(domPath), 'Saved DOM file should exist')
-        assert.ok(
-          domPath.startsWith(join(process.cwd(), 'tool-output')),
+        assert.strictEqual(
+          dirname(domPath),
+          join(process.cwd(), 'tool-output'),
           'Saved DOM file should be written under executionDir/tool-output',
         )
         assert.ok(html.includes('<html'), 'Should contain <html> tag')
@@ -105,7 +113,7 @@ describe('get_dom', () => {
         assert.strictEqual(data.path, domPath)
         assert.strictEqual(data.totalLength, html.length)
       } finally {
-        if (domPath && existsSync(domPath)) unlinkSync(domPath)
+        if (domPath && existsSync(domPath)) cleanupSavedDom(domPath)
         await execute(close_page, { page: pageId })
       }
     })
@@ -142,7 +150,7 @@ describe('get_dom', () => {
           'Scoped result should NOT contain features section',
         )
       } finally {
-        if (domPath && existsSync(domPath)) unlinkSync(domPath)
+        if (domPath && existsSync(domPath)) cleanupSavedDom(domPath)
         await execute(close_page, { page: pageId })
       }
     })
@@ -168,7 +176,7 @@ describe('get_dom', () => {
         assert.ok(html.includes('About'), 'Should contain nav links')
         assert.ok(!html.includes('<form'), 'Scoped nav should NOT contain form')
       } finally {
-        if (domPath && existsSync(domPath)) unlinkSync(domPath)
+        if (domPath && existsSync(domPath)) cleanupSavedDom(domPath)
         await execute(close_page, { page: pageId })
       }
     })
@@ -209,7 +217,7 @@ describe('get_dom', () => {
           'about:blank should still have html element',
         )
       } finally {
-        if (domPath && existsSync(domPath)) unlinkSync(domPath)
+        if (domPath && existsSync(domPath)) cleanupSavedDom(domPath)
         await execute(close_page, { page: pageId })
       }
     })
@@ -241,8 +249,9 @@ describe('get_dom', () => {
         const html = readFileSync(domPath, 'utf8')
 
         assert.ok(textOf(result).includes('Saved DOM'))
-        assert.ok(
-          domPath.startsWith(join(process.cwd(), 'tool-output')),
+        assert.strictEqual(
+          dirname(domPath),
+          join(process.cwd(), 'tool-output'),
           'Saved DOM file should be written under executionDir/tool-output',
         )
         assert.ok(data.totalLength > 100_000, 'Expected a large DOM payload')
@@ -252,7 +261,7 @@ describe('get_dom', () => {
           'Saved file should contain the full DOM',
         )
       } finally {
-        if (domPath && existsSync(domPath)) unlinkSync(domPath)
+        if (domPath && existsSync(domPath)) cleanupSavedDom(domPath)
         await execute(close_page, { page: pageId })
       }
     })
@@ -283,7 +292,7 @@ describe('get_dom', () => {
           'Should preserve data attributes',
         )
       } finally {
-        if (domPath && existsSync(domPath)) unlinkSync(domPath)
+        if (domPath && existsSync(domPath)) cleanupSavedDom(domPath)
         await execute(close_page, { page: pageId })
       }
     })

--- a/apps/server/tests/tools/dom.test.ts
+++ b/apps/server/tests/tools/dom.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
 import { existsSync, readFileSync, rmSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { get_dom, search_dom } from '../../src/tools/dom'
 import { close_page, new_page } from '../../src/tools/navigation'
@@ -93,10 +94,9 @@ describe('get_dom', () => {
 
         assert.ok(textOf(result).includes('Saved DOM'))
         assert.ok(existsSync(domPath), 'Saved DOM file should exist')
-        assert.strictEqual(
-          dirname(domPath),
-          join(process.cwd(), 'tool-output'),
-          'Saved DOM file should be written under executionDir/tool-output',
+        assert.ok(
+          dirname(domPath).startsWith(join(tmpdir(), 'browseros-tool-output-')),
+          'Saved DOM file should be written to an OS temp directory',
         )
         assert.ok(html.includes('<html'), 'Should contain <html> tag')
         assert.ok(html.includes('</html>'), 'Should contain closing </html>')
@@ -249,10 +249,9 @@ describe('get_dom', () => {
         const html = readFileSync(domPath, 'utf8')
 
         assert.ok(textOf(result).includes('Saved DOM'))
-        assert.strictEqual(
-          dirname(domPath),
-          join(process.cwd(), 'tool-output'),
-          'Saved DOM file should be written under executionDir/tool-output',
+        assert.ok(
+          dirname(domPath).startsWith(join(tmpdir(), 'browseros-tool-output-')),
+          'Saved DOM file should be written to an OS temp directory',
         )
         assert.ok(data.totalLength > 100_000, 'Expected a large DOM payload')
         assert.strictEqual(html.length, data.totalLength)

--- a/apps/server/tests/tools/observation.test.ts
+++ b/apps/server/tests/tools/observation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
 import { existsSync, readFileSync, rmSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { close_page, navigate_page, new_page } from '../../src/tools/navigation'
 import {
@@ -204,10 +205,11 @@ describe('observation tools', () => {
         assert.strictEqual(data.writtenToFile, true)
         assert.ok(textOf(contentResult).includes('Saved page content'))
         assert.ok(existsSync(savedPath), 'Saved page content file should exist')
-        assert.strictEqual(
-          dirname(savedPath),
-          join(process.cwd(), 'tool-output'),
-          'Saved page content should be written under executionDir/tool-output',
+        assert.ok(
+          dirname(savedPath).startsWith(
+            join(tmpdir(), 'browseros-tool-output-'),
+          ),
+          'Saved page content should be written to an OS temp directory',
         )
 
         const savedContent = readFileSync(savedPath, 'utf8')

--- a/apps/server/tests/tools/observation.test.ts
+++ b/apps/server/tests/tools/observation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
-import { existsSync, readFileSync, unlinkSync } from 'node:fs'
-import { join } from 'node:path'
+import { existsSync, readFileSync, rmSync, unlinkSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { close_page, navigate_page, new_page } from '../../src/tools/navigation'
 import {
   evaluate_script,
@@ -34,6 +34,13 @@ function pageIdOf(result: {
   const data = result.structuredContent as { pageId?: number } | undefined
   if (typeof data?.pageId === 'number') return data.pageId
   return Number(textOf(result).match(/Page ID:\s*(\d+)/)?.[1])
+}
+
+function cleanupSavedContent(path: string): void {
+  unlinkSync(path)
+  try {
+    rmSync(dirname(path))
+  } catch {}
 }
 
 describe('observation tools', () => {
@@ -197,8 +204,9 @@ describe('observation tools', () => {
         assert.strictEqual(data.writtenToFile, true)
         assert.ok(textOf(contentResult).includes('Saved page content'))
         assert.ok(existsSync(savedPath), 'Saved page content file should exist')
-        assert.ok(
-          savedPath.startsWith(join(process.cwd(), 'tool-output')),
+        assert.strictEqual(
+          dirname(savedPath),
+          join(process.cwd(), 'tool-output'),
           'Saved page content should be written under executionDir/tool-output',
         )
 
@@ -209,7 +217,7 @@ describe('observation tools', () => {
           'Saved file should contain the extracted content',
         )
       } finally {
-        if (savedPath && existsSync(savedPath)) unlinkSync(savedPath)
+        if (savedPath && existsSync(savedPath)) cleanupSavedContent(savedPath)
         await execute(close_page, { page: pageId })
       }
     })

--- a/apps/server/tests/tools/observation.test.ts
+++ b/apps/server/tests/tools/observation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
 import { existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
 import { close_page, navigate_page, new_page } from '../../src/tools/navigation'
 import {
   evaluate_script,
@@ -196,6 +197,10 @@ describe('observation tools', () => {
         assert.strictEqual(data.writtenToFile, true)
         assert.ok(textOf(contentResult).includes('Saved page content'))
         assert.ok(existsSync(savedPath), 'Saved page content file should exist')
+        assert.ok(
+          savedPath.startsWith(join(process.cwd(), 'tool-output')),
+          'Saved page content should be written under executionDir/tool-output',
+        )
 
         const savedContent = readFileSync(savedPath, 'utf8')
         assert.strictEqual(savedContent.length, data.contentLength)

--- a/apps/server/tests/tools/page-actions.test.ts
+++ b/apps/server/tests/tools/page-actions.test.ts
@@ -123,12 +123,14 @@ describe('page action tools', () => {
     const executionDir = await mkdtemp(
       join(tmpdir(), 'browseros-page-actions-'),
     )
+    let stagingDir: string | undefined
     const browser = createBrowserStub({
       downloadViaClick: async (
         _page: number,
         _element: number,
         tempDir: string,
       ) => {
+        stagingDir = tempDir
         const filePath = join(tempDir, 'download.txt')
         await Bun.write(filePath, 'hello')
         return {
@@ -155,6 +157,15 @@ describe('page action tools', () => {
       assert.strictEqual(structured.directory, executionDir)
       assert.strictEqual(structured.destinationPath, outputPath)
       assert.ok(existsSync(outputPath), 'Download should land in executionDir')
+      assert.ok(stagingDir, 'Download should use a staging directory')
+      assert.ok(
+        stagingDir.startsWith(join(executionDir, 'browseros-dl-')),
+        'Staging directory should be created inside executionDir',
+      )
+      assert.ok(
+        !existsSync(stagingDir),
+        'Staging directory should be removed after the download completes',
+      )
     } finally {
       await rm(executionDir, { recursive: true, force: true })
     }

--- a/apps/server/tests/tools/page-actions.test.ts
+++ b/apps/server/tests/tools/page-actions.test.ts
@@ -120,9 +120,8 @@ describe('page action tools', () => {
   })
 
   it('download_file resolves relative directories against the execution directory by default', async () => {
-    const executionDir = await mkdtemp(
-      join(tmpdir(), 'browseros-page-actions-'),
-    )
+    const baseDir = await mkdtemp(join(tmpdir(), 'browseros-page-actions-'))
+    const executionDir = join(baseDir, 'execution')
     let stagingDir: string | undefined
     const browser = createBrowserStub({
       downloadViaClick: async (
@@ -167,7 +166,7 @@ describe('page action tools', () => {
         'Staging directory should be removed after the download completes',
       )
     } finally {
-      await rm(executionDir, { recursive: true, force: true })
+      await rm(baseDir, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
## Summary
- Write generated tool artifact files under `executionDir/tool-output` instead of `~/.browseros`.
- Stage browser downloads inside `executionDir` and keep cleaning staging directories after each download.
- Keep persistent BrowserOS state such as memory, skills, and soul under `browseros-dir`.

## Design
This change routes execution-scoped tool artifacts through `ToolContext.directories.executionDir` while preserving `browseros-dir` for persistent application state. `get_dom` and large `get_page_content` responses now write into `executionDir/tool-output`, and `download_file` stages downloads in an execution-scoped temp directory that is removed in a `finally` block.

## Test plan
- `bun test apps/server/tests/tools/page-actions.test.ts apps/server/tests/tools/dom.test.ts apps/server/tests/tools/observation.test.ts`
- `bun run lint` (pre-existing unrelated warnings only)
- `bun run --filter @browseros/server typecheck`
- `bun run test`
- `bun run test:integration`
- `bun run test:sdk` (currently fails in existing SDK integration cases with `NavigationError: No active tab to navigate`)
