### PR TITLE
feat: add scoped logger keys to agent logs

### DIFF
--- a/apps/server/src/agent/ai-sdk-agent.ts
+++ b/apps/server/src/agent/ai-sdk-agent.ts
@@ -26,6 +26,8 @@ import { createLanguageModel } from './provider-factory'
 import { buildBrowserToolSet } from './tool-adapter'
 import type { ResolvedAgentConfig } from './types'
 
+const agentLogger = logger.child({ key: 'agent.ai-sdk-agent' })
+
 export interface AiSdkAgentConfig {
   resolvedConfig: ResolvedAgentConfig
   browser: Browser
@@ -72,9 +74,12 @@ export class AiSdkAgent {
         )
       : allBrowserTools
     if (config.resolvedConfig.chatMode) {
-      logger.info('Chat mode enabled, restricting to read-only browser tools', {
-        allowedTools: Array.from(CHAT_MODE_ALLOWED_TOOLS),
-      })
+      agentLogger.info(
+        'Chat mode enabled, restricting to read-only browser tools',
+        {
+          allowedTools: Array.from(CHAT_MODE_ALLOWED_TOOLS),
+        },
+      )
     }
 
     // Build external MCP server specs (Klavis, custom) and connect clients
@@ -156,7 +161,7 @@ export class AiSdkAgent {
       prepareStep,
     })
 
-    logger.info('Agent session created (v2)', {
+    agentLogger.info('Agent session created (v2)', {
       conversationId: config.resolvedConfig.conversationId,
       provider: config.resolvedConfig.provider,
       model: config.resolvedConfig.model,
@@ -195,6 +200,6 @@ export class AiSdkAgent {
     for (const client of this._mcpClients) {
       await client.close().catch(() => {})
     }
-    logger.info('Agent disposed', { conversationId: this.conversationId })
+    agentLogger.info('Agent disposed', { conversationId: this.conversationId })
   }
 }

--- a/apps/server/src/agent/compaction.ts
+++ b/apps/server/src/agent/compaction.ts
@@ -8,6 +8,8 @@ import {
   messagesToTranscript,
 } from './compaction-prompt'
 
+const compactionLogger = logger.child({ key: 'agent.compaction' })
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -345,7 +347,7 @@ async function callSummarizer(
     return text || null
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    logger.warn(`${logLabel} failed`, { error: message })
+    compactionLogger.warn(`${logLabel} failed`, { error: message })
     return null
   } finally {
     clearTimeout(timeout)
@@ -461,7 +463,7 @@ export function slidingWindow(
 
   if (startIndex === 0) return messages
 
-  logger.info('Sliding window applied', {
+  compactionLogger.info('Sliding window applied', {
     droppedMessages: startIndex,
     remainingMessages: messages.length - startIndex,
     estimatedTokens: estimateTokens(messages.slice(startIndex)),
@@ -491,7 +493,7 @@ async function compactMessages(
   )
 
   if (splitIndex === -1) {
-    logger.info('Cannot find safe split point, using sliding window')
+    compactionLogger.info('Cannot find safe split point, using sliding window')
     return slidingWindow(messages, triggerThreshold)
   }
 
@@ -504,7 +506,7 @@ async function compactMessages(
   if (isSplitTurn && turnStartIndex >= 0) {
     historyMessages = messages.slice(0, turnStartIndex)
     turnPrefixMessages = messages.slice(turnStartIndex, splitIndex)
-    logger.info('Split turn detected', {
+    compactionLogger.info('Split turn detected', {
       historyMessages: historyMessages.length,
       turnPrefixMessages: turnPrefixMessages.length,
       toKeepMessages: toKeep.length,
@@ -528,10 +530,13 @@ async function compactMessages(
     const summarizeTokens = estimateTokens(toSummarize)
     if (summarizeTokens > config.maxSummarizationInput) {
       const excess = summarizeTokens - config.maxSummarizationInput
-      logger.info('Capping summarization input, dropping oldest messages', {
-        excess,
-        maxSummarizationInput: config.maxSummarizationInput,
-      })
+      compactionLogger.info(
+        'Capping summarization input, dropping oldest messages',
+        {
+          excess,
+          maxSummarizationInput: config.maxSummarizationInput,
+        },
+      )
       toSummarize = slidingWindow(toSummarize, config.maxSummarizationInput)
     }
   }
@@ -539,10 +544,13 @@ async function compactMessages(
   if (truncatedTurnPrefix.length > 0) {
     const prefixTokens = estimateTokens(truncatedTurnPrefix)
     if (prefixTokens > config.maxSummarizationInput) {
-      logger.info('Capping turn prefix input, dropping oldest messages', {
-        excess: prefixTokens - config.maxSummarizationInput,
-        maxSummarizationInput: config.maxSummarizationInput,
-      })
+      compactionLogger.info(
+        'Capping turn prefix input, dropping oldest messages',
+        {
+          excess: prefixTokens - config.maxSummarizationInput,
+          maxSummarizationInput: config.maxSummarizationInput,
+        },
+      )
       truncatedTurnPrefix = slidingWindow(
         truncatedTurnPrefix,
         config.maxSummarizationInput,
@@ -554,7 +562,9 @@ async function compactMessages(
   const totalSummarizable =
     estimateTokens(toSummarize) + estimateTokens(truncatedTurnPrefix)
   if (totalSummarizable < config.minSummarizableTokens) {
-    logger.info('Too little content to summarize, using sliding window')
+    compactionLogger.info(
+      'Too little content to summarize, using sliding window',
+    )
     return slidingWindow(messages, triggerThreshold)
   }
 
@@ -567,7 +577,7 @@ async function compactMessages(
     ),
   )
 
-  logger.info('Attempting LLM-based compaction', {
+  compactionLogger.info('Attempting LLM-based compaction', {
     toSummarizeMessages: toSummarize.length,
     toSummarizeTokens: estimateTokens(toSummarize),
     turnPrefixMessages: truncatedTurnPrefix.length,
@@ -629,7 +639,9 @@ async function compactMessages(
 
   // 6. Validate summary
   if (!summary) {
-    logger.warn('Summarization returned empty, using sliding window fallback')
+    compactionLogger.warn(
+      'Summarization returned empty, using sliding window fallback',
+    )
     return slidingWindow(messages, triggerThreshold)
   }
 
@@ -637,7 +649,7 @@ async function compactMessages(
   const summaryTokens = Math.ceil(summary.length / 4)
   const originalTokens = estimateTokens(allSummarized)
   if (summaryTokens >= originalTokens) {
-    logger.warn(
+    compactionLogger.warn(
       'Summary is larger than original, using sliding window fallback',
       {
         summaryTokens,
@@ -651,7 +663,7 @@ async function compactMessages(
   state.existingSummary = summary
   state.compactionCount++
 
-  logger.info('LLM compaction succeeded', {
+  compactionLogger.info('LLM compaction succeeded', {
     originalMessages: messages.length,
     keptMessages: toKeep.length,
     summaryTokens,
@@ -689,7 +701,7 @@ export function createCompactionPrepareStep(
     userConfig?.contextWindow ?? AGENT_LIMITS.DEFAULT_CONTEXT_WINDOW
   const config = computeConfig(contextWindow)
 
-  logger.info('Compaction config computed', {
+  compactionLogger.info('Compaction config computed', {
     contextWindow,
     reserveTokens: config.reserveTokens,
     triggerRatio: config.triggerRatio.toFixed(3),
@@ -726,7 +738,7 @@ export function createCompactionPrepareStep(
       return { messages: capped, experimental_context: state }
     }
 
-    logger.warn('Context approaching limit, attempting compaction', {
+    compactionLogger.warn('Context approaching limit, attempting compaction', {
       currentTokens,
       triggerThreshold: Math.floor(triggerThreshold),
       messageCount: capped.length,

--- a/apps/server/src/agent/context-overflow-middleware.ts
+++ b/apps/server/src/agent/context-overflow-middleware.ts
@@ -6,6 +6,10 @@ import type {
 } from '@ai-sdk/provider'
 import { logger } from '../lib/logger'
 
+const overflowLogger = logger.child({
+  key: 'agent.context-overflow-middleware',
+})
+
 /**
  * Provider-specific regex patterns for context overflow errors.
  * Adapted from Pi coding agent's overflow detection.
@@ -69,7 +73,7 @@ function truncatePrompt(
     ...systemMessages,
     ...nonSystem.slice(keepFrom),
   ]
-  logger.warn('Emergency prompt truncation', {
+  overflowLogger.warn('Emergency prompt truncation', {
     original: prompt.length,
     kept: kept.length,
     dropped: prompt.length - kept.length,
@@ -87,7 +91,7 @@ export function createContextOverflowMiddleware(
         return await doGenerate()
       } catch (error) {
         if (!isContextOverflowError(error)) throw error
-        logger.warn(
+        overflowLogger.warn(
           'Context overflow detected in doGenerate, truncating and retrying',
         )
         ;(params as LanguageModelV3CallOptions).prompt = truncatePrompt(
@@ -102,7 +106,7 @@ export function createContextOverflowMiddleware(
         return await doStream()
       } catch (error) {
         if (!isContextOverflowError(error)) throw error
-        logger.warn(
+        overflowLogger.warn(
           'Context overflow detected in doStream, truncating and retrying',
         )
         ;(params as LanguageModelV3CallOptions).prompt = truncatePrompt(

--- a/apps/server/src/agent/mcp-builder.ts
+++ b/apps/server/src/agent/mcp-builder.ts
@@ -9,6 +9,8 @@ import {
   type McpTransportType,
 } from '../lib/mcp-transport-detect'
 
+const mcpLogger = logger.child({ key: 'agent.mcp-builder' })
+
 export interface McpServerSpec {
   name: string
   url: string
@@ -49,12 +51,12 @@ export async function buildMcpServerSpecs(
         url: result.strataServerUrl,
         transport: 'streamable-http',
       })
-      logger.info('Added Klavis Strata MCP server', {
+      mcpLogger.info('Added Klavis Strata MCP server', {
         browserosId: deps.browserosId.slice(0, 12),
         servers: deps.browserContext.enabledMcpServers,
       })
     } catch (error) {
-      logger.error('Failed to create Klavis Strata MCP server', {
+      mcpLogger.error('Failed to create Klavis Strata MCP server', {
         error: error instanceof Error ? error.message : String(error),
       })
     }
@@ -116,7 +118,7 @@ async function connectMcpClient(
     ])
     return { client, tools: clientTools }
   } catch (error) {
-    logger.warn('Failed to connect MCP client, skipping', {
+    mcpLogger.warn('Failed to connect MCP client, skipping', {
       name: spec.name,
       url: spec.url,
       error: error instanceof Error ? error.message : String(error),

--- a/apps/server/src/agent/provider-factory.ts
+++ b/apps/server/src/agent/provider-factory.ts
@@ -11,6 +11,8 @@ import { logger } from '../lib/logger'
 import { createOpenRouterCompatibleFetch } from '../lib/openrouter-fetch'
 import type { ResolvedAgentConfig } from './types'
 
+const providerLogger = logger.child({ key: 'agent.provider-factory' })
+
 type ProviderFactory = (
   config: ResolvedAgentConfig,
 ) => (modelId: string) => unknown
@@ -116,7 +118,9 @@ function createBrowserOSFactory(
   if (upstreamProvider === LLM_PROVIDERS.AZURE) {
     return createAzure({ baseURL: baseUrl, ...(apiKey && { apiKey }) })
   }
-  logger.info('creating openai-compatible')
+  providerLogger.info('Creating OpenAI-compatible BrowserOS provider', {
+    upstreamProvider: upstreamProvider ?? null,
+  })
   return createOpenAICompatible({
     name: 'browseros',
     baseURL: baseUrl,

--- a/apps/server/src/agent/session-store.ts
+++ b/apps/server/src/agent/session-store.ts
@@ -2,6 +2,8 @@ import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
 import { logger } from '../lib/logger'
 import type { AiSdkAgent } from './ai-sdk-agent'
 
+const sessionStoreLogger = logger.child({ key: 'agent.session-store' })
+
 export interface AgentSession {
   agent: AiSdkAgent
   hiddenWindowId?: number
@@ -20,7 +22,7 @@ export class SessionStore {
 
   set(conversationId: string, session: AgentSession): void {
     this.sessions.set(conversationId, session)
-    logger.info('Session added to store', {
+    sessionStoreLogger.info('Session added to store', {
       conversationId,
       totalSessions: this.sessions.size,
     })
@@ -33,7 +35,7 @@ export class SessionStore {
   remove(conversationId: string): boolean {
     const existed = this.sessions.delete(conversationId)
     if (existed) {
-      logger.info('Session removed from store (without dispose)', {
+      sessionStoreLogger.info('Session removed from store (without dispose)', {
         conversationId,
         remainingSessions: this.sessions.size,
       })
@@ -47,7 +49,7 @@ export class SessionStore {
 
     await session.agent.dispose()
     this.sessions.delete(conversationId)
-    logger.info('Session deleted', {
+    sessionStoreLogger.info('Session deleted', {
       conversationId,
       remainingSessions: this.sessions.size,
     })

--- a/apps/server/src/agent/tool-adapter.ts
+++ b/apps/server/src/agent/tool-adapter.ts
@@ -7,6 +7,8 @@ import { executeTool, type ToolContext } from '../tools/framework'
 import type { ContentItem } from '../tools/response'
 import type { ToolRegistry } from '../tools/tool-registry'
 
+const toolAdapterLogger = logger.child({ key: 'agent.tool-adapter' })
+
 function contentToModelOutput(
   content: ContentItem[],
 ): LanguageModelV2ToolResultOutput {
@@ -75,7 +77,7 @@ export function buildBrowserToolSet(
           const errorText =
             error instanceof Error ? error.message : String(error)
 
-          logger.error('Tool execution failed', {
+          toolAdapterLogger.error('Tool execution failed', {
             tool: def.name,
             error: errorText,
           })

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -18,6 +18,8 @@ import { logger } from '../../lib/logger'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import type { BrowserContext, ChatRequest } from '../types'
 
+const chatServiceLogger = logger.child({ key: 'api.chat-service' })
+
 export interface ChatServiceDeps {
   sessionStore: SessionStore
   klavisClient: KlavisClient
@@ -69,11 +71,14 @@ export class ChatService {
 
     // Detect MCP config change mid-conversation → rebuild session
     if (session && session.mcpServerKey !== mcpServerKey) {
-      logger.info('MCP servers changed mid-conversation, rebuilding session', {
-        conversationId: request.conversationId,
-        previous: session.mcpServerKey,
-        current: mcpServerKey,
-      })
+      chatServiceLogger.info(
+        'MCP servers changed mid-conversation, rebuilding session',
+        {
+          conversationId: request.conversationId,
+          previous: session.mcpServerKey,
+          current: mcpServerKey,
+        },
+      )
       const previousMessages = session.agent.messages
       await session.agent.dispose()
       sessionStore.remove(request.conversationId)
@@ -113,15 +118,18 @@ export class ChatService {
               title: 'Scheduled Task',
             },
           }
-          logger.info('Created hidden window for scheduled task', {
+          chatServiceLogger.info('Created hidden window for scheduled task', {
             conversationId: request.conversationId,
             windowId: hiddenWindowId,
             pageId,
           })
         } catch (error) {
-          logger.warn('Failed to create hidden window, using default', {
-            error: error instanceof Error ? error.message : String(error),
-          })
+          chatServiceLogger.warn(
+            'Failed to create hidden window, using default',
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          )
         }
       }
 
@@ -145,7 +153,7 @@ export class ChatService {
           parts: [{ type: 'text', text: msg.content }],
         })
       }
-      logger.info('Injected previous conversation history', {
+      chatServiceLogger.info('Injected previous conversation history', {
         conversationId: request.conversationId,
         messageCount: request.previousConversation.length,
       })
@@ -172,7 +180,7 @@ export class ChatService {
       abortSignal,
       onFinish: async ({ messages }: { messages: UIMessage[] }) => {
         session.agent.messages = messages
-        logger.info('Agent execution complete', {
+        chatServiceLogger.info('Agent execution complete', {
           conversationId: request.conversationId,
           totalMessages: messages.length,
         })
@@ -222,12 +230,14 @@ export class ChatService {
     const addPageId = (tab: { id: number; url?: string; title?: string }) => {
       const pageId = tabToPage.get(tab.id)
       if (pageId === undefined) {
-        logger.warn('Could not resolve page ID for tab', { tabId: tab.id })
+        chatServiceLogger.warn('Could not resolve page ID for tab', {
+          tabId: tab.id,
+        })
       }
       return { ...tab, pageId }
     }
 
-    logger.debug('Resolved tab IDs to page IDs', {
+    chatServiceLogger.debug('Resolved tab IDs to page IDs', {
       mapping: Object.fromEntries(tabToPage),
     })
 
@@ -243,7 +253,7 @@ export class ChatService {
 
   private closeHiddenWindow(windowId: number, conversationId: string): void {
     this.deps.browser.closeWindow(windowId).catch((error) => {
-      logger.warn('Failed to close hidden window', {
+      chatServiceLogger.warn('Failed to close hidden window', {
         windowId,
         conversationId,
         error: error instanceof Error ? error.message : String(error),

--- a/apps/server/src/lib/logger.ts
+++ b/apps/server/src/lib/logger.ts
@@ -114,22 +114,47 @@ function createConsoleTransport(): pino.TransportSingleOptions | null {
   return null
 }
 
-export class Logger implements LoggerInterface {
-  private consoleLogger: pino.Logger
-  private fileLogger: pino.Logger | null = null
-  private level: LogLevel
+interface LoggerState {
+  consoleLogger: pino.Logger
+  fileLogger: pino.Logger | null
+  level: LogLevel
+}
 
-  constructor(level?: LogLevel) {
-    this.level =
+export class Logger implements LoggerInterface {
+  private readonly state: LoggerState
+  private readonly bindings: Record<string, unknown>
+
+  constructor(
+    level?: LogLevel,
+    state?: LoggerState,
+    bindings: Record<string, unknown> = {},
+  ) {
+    this.bindings = bindings
+    if (state) {
+      this.state = state
+      return
+    }
+    const resolvedLevel =
       level ||
       (process.env.LOG_LEVEL as LogLevel | undefined) ||
       (isDev ? 'debug' : 'info')
-    this.consoleLogger = this.createConsoleLogger()
+    this.state = {
+      level: resolvedLevel,
+      consoleLogger: this.createConsoleLogger(resolvedLevel),
+      fileLogger: null,
+    }
   }
 
-  private createConsoleLogger(): pino.Logger {
+  child(bindings: Record<string, unknown>): Logger {
+    return new Logger(undefined, this.state, {
+      ...this.bindings,
+      ...bindings,
+    })
+  }
+
+  private createConsoleLogger(level: LogLevel): pino.Logger {
     const options: pino.LoggerOptions = {
-      level: this.level,
+      level,
     }
 
     // Add source tracking in development
@@ -168,14 +193,29 @@ export class Logger implements LoggerInterface {
     })
 
     // File logger: always JSON, no source tracking (for performance)
-    this.fileLogger = pino({ level: this.level }, fileDestination)
+    this.state.fileLogger = pino({ level: this.state.level }, fileDestination)
   }
 
   setLevel(level: LogLevel): void {
-    this.level = level
-    this.consoleLogger.level = level
-    if (this.fileLogger) {
-      this.fileLogger.level = level
+    this.state.level = level
+    this.state.consoleLogger.level = level
+    if (this.state.fileLogger) {
+      this.state.fileLogger.level = level
+    }
+  }
+
+  private mergeMeta(
+    meta?: Record<string, unknown>,
+  ): Record<string, unknown> | undefined {
+    if (Object.keys(this.bindings).length === 0) {
+      return meta
+    }
+    if (!meta) {
+      return { ...this.bindings }
+    }
+    return {
+      ...this.bindings,
+      ...meta,
     }
   }
 
@@ -184,26 +224,27 @@ export class Logger implements LoggerInterface {
     message: string,
     meta?: Record<string, unknown>,
   ): void {
-    const logFn = this.consoleLogger[level].bind(this.consoleLogger)
-    const fileLogFn = this.fileLogger?.[level].bind(this.fileLogger)
+    const logFn = this.state.consoleLogger[level].bind(this.state.consoleLogger)
+    const fileLogFn = this.state.fileLogger?.[level].bind(this.state.fileLogger)
+    const mergedMeta = this.mergeMeta(meta)
 
     // Console: truncate large values in dev (skip for error/warn so full context is visible)
-    if (meta && isDev && level !== 'error' && level !== 'warn') {
+    if (mergedMeta && isDev && level !== 'error' && level !== 'warn') {
       const truncated = truncateForConsole(
-        meta,
+        mergedMeta,
         CONTENT_LIMITS.CONSOLE_META_CHAR,
       )
       logFn(truncated, message)
-    } else if (meta) {
-      logFn(meta, message)
+    } else if (mergedMeta) {
+      logFn(mergedMeta, message)
     } else {
       logFn(message)
     }
 
     // File: always log full data, no truncation
     if (fileLogFn) {
-      if (meta) {
-        fileLogFn(meta, message)
+      if (mergedMeta) {
+        fileLogFn(mergedMeta, message)
       } else {
         fileLogFn(message)
       }


### PR DESCRIPTION
## Summary
- Add scoped logger bindings so agent-related logs automatically include a stable `key` field.
- Apply scoped loggers across the agent subsystem and chat service without changing existing log structure.
- Preserve current console/file logging behavior, including late `setLogFile()` setup during server startup.

## Design
This change extends the shared server logger with child-style bound metadata backed by shared logger state. Agent modules and the chat service now create file-scoped loggers with stable `key` values, which makes production JSON logs easier to filter without relying on message prefixes or dev-only caller metadata.

## Test plan
- `bunx biome check apps/server/src/lib/logger.ts apps/server/src/agent/ai-sdk-agent.ts apps/server/src/agent/context-overflow-middleware.ts apps/server/src/agent/mcp-builder.ts apps/server/src/agent/provider-factory.ts apps/server/src/agent/session-store.ts apps/server/src/agent/tool-adapter.ts apps/server/src/agent/compaction.ts apps/server/src/api/services/chat-service.ts`
- `bun run typecheck`
- `bun run test`
