### PR TITLE
fix: avoid crashing on controller startup failure

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -221,6 +221,12 @@ export class Application {
       'Controller WebSocket server unavailable, continuing without controller bridge',
       { port, error: errorMsg },
     )
+    if (isPortInUseError(error)) {
+      logger.warn(
+        'Controller WebSocket port is already in use, continuing without controller bridge',
+        { port },
+      )
+    }
     Sentry.captureException(error)
   }
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -50,19 +50,18 @@ export class Application {
 
     const dailyRateLimit = await fetchDailyRateLimit(identity.getBrowserOSId())
 
-    let controller: ControllerBackend
+    const controller = new ControllerBackend({
+      port: this.config.extensionPort,
+    })
+    let controllerServerStarted = false
     try {
       logger.debug(
         `Starting WebSocket server on port ${this.config.extensionPort}`,
       )
-      controller = new ControllerBackend({ port: this.config.extensionPort })
       await controller.start()
+      controllerServerStarted = true
     } catch (error) {
-      return this.handleStartupError(
-        'WebSocket server',
-        this.config.extensionPort,
-        error,
-      )
+      this.handleControllerStartupError(this.config.extensionPort, error)
     }
 
     if (!this.config.cdpPort) {
@@ -110,7 +109,7 @@ export class Application {
       `Health endpoint: http://127.0.0.1:${this.config.serverPort}/health`,
     )
 
-    this.logStartupSummary()
+    this.logStartupSummary(controllerServerStarted)
 
     metrics.log('http_server.started', { version: VERSION })
   }
@@ -216,11 +215,22 @@ export class Application {
     process.exit(EXIT_CODES.GENERAL_ERROR)
   }
 
-  private logStartupSummary(): void {
+  private handleControllerStartupError(port: number, error: unknown): void {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.warn(
+      'Controller WebSocket server unavailable, continuing without controller bridge',
+      { port, error: errorMsg },
+    )
+    Sentry.captureException(error)
+  }
+
+  private logStartupSummary(controllerServerStarted: boolean): void {
     logger.info('')
     logger.info('Services running:')
     logger.info(
-      `  Controller Server: ws://127.0.0.1:${this.config.extensionPort}`,
+      controllerServerStarted
+        ? `  Controller Server: ws://127.0.0.1:${this.config.extensionPort}`
+        : '  Controller Server: unavailable',
     )
     logger.info(`  HTTP Server: http://127.0.0.1:${this.config.serverPort}`)
     logger.info('')

--- a/apps/server/tests/main.test.ts
+++ b/apps/server/tests/main.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+
+const config = {
+  cdpPort: 9222,
+  serverPort: 9100,
+  agentPort: 9100,
+  extensionPort: 9300,
+  resourcesDir: '/tmp/browseros-resources',
+  executionDir: '/tmp/browseros-execution',
+  mcpAllowRemote: false,
+}
+
+describe('Application.start', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it('continues when controller startup fails', async () => {
+    const createHttpServer = mock(async () => ({}))
+    const controllerStart = mock(async () => {
+      throw new Error('bind failed')
+    })
+    const cdpConnect = mock(async () => {})
+    const sentryCaptureException = mock(() => {})
+    const loggerInfo = mock(() => {})
+    const loggerWarn = mock(() => {})
+    const loggerDebug = mock(() => {})
+    const loggerError = mock(() => {})
+
+    mock.module('../src/api/server', () => ({
+      createHttpServer,
+    }))
+    mock.module('../src/browser/backends/controller', () => ({
+      ControllerBackend: class {
+        async start(): Promise<void> {
+          await controllerStart()
+        }
+
+        async stop(): Promise<void> {}
+
+        isConnected(): boolean {
+          return false
+        }
+
+        async send(): Promise<never> {
+          throw new Error('BrowserOS helper service not connected')
+        }
+      },
+    }))
+    mock.module('../src/browser/backends/cdp', () => ({
+      CdpBackend: class {
+        async connect(): Promise<void> {
+          await cdpConnect()
+        }
+      },
+    }))
+    mock.module('../src/browser/browser', () => ({
+      Browser: class {},
+    }))
+    mock.module('../src/lib/browseros-dir', () => ({
+      ensureBrowserosDir: mock(async () => {}),
+    }))
+    mock.module('../src/lib/db', () => ({
+      initializeDb: mock(() => ({}) as never),
+    }))
+    mock.module('../src/lib/identity', () => ({
+      identity: {
+        initialize: mock(() => {}),
+        getBrowserOSId: mock(() => 'browseros-id'),
+      },
+    }))
+    mock.module('../src/lib/logger', () => ({
+      logger: {
+        setLogFile: mock(() => {}),
+        info: loggerInfo,
+        warn: loggerWarn,
+        debug: loggerDebug,
+        error: loggerError,
+      },
+    }))
+    mock.module('../src/lib/metrics', () => ({
+      metrics: {
+        initialize: mock(() => {}),
+        isEnabled: mock(() => true),
+        log: mock(() => {}),
+      },
+    }))
+    mock.module('../src/lib/rate-limiter/fetch-config', () => ({
+      fetchDailyRateLimit: mock(async () => 100),
+    }))
+    mock.module('../src/lib/rate-limiter/rate-limiter', () => ({
+      RateLimiter: class {},
+    }))
+    mock.module('../src/lib/sentry', () => ({
+      Sentry: {
+        setContext: mock(() => {}),
+        captureException: sentryCaptureException,
+      },
+    }))
+    mock.module('../src/lib/soul', () => ({
+      seedSoulTemplate: mock(async () => {}),
+    }))
+    mock.module('../src/tools/registry', () => ({
+      registry: {
+        names: () => ['test_tool'],
+      },
+    }))
+
+    const { Application } = await import('../src/main')
+    const app = new Application(config)
+
+    await app.start()
+
+    expect(controllerStart).toHaveBeenCalledTimes(1)
+    expect(cdpConnect).toHaveBeenCalledTimes(1)
+    expect(createHttpServer).toHaveBeenCalledTimes(1)
+    expect(sentryCaptureException).toHaveBeenCalledTimes(1)
+
+    const warningCall = loggerWarn.mock.calls.find(
+      ([message]) =>
+        message ===
+        'Controller WebSocket server unavailable, continuing without controller bridge',
+    )
+    expect(warningCall).toBeDefined()
+    expect(warningCall?.[1]).toEqual({
+      port: config.extensionPort,
+      error: 'bind failed',
+    })
+
+    expect(
+      loggerInfo.mock.calls.some(
+        ([message]) => message === '  Controller Server: unavailable',
+      ),
+    ).toBe(true)
+    expect(loggerError).not.toHaveBeenCalled()
+  })
+})

--- a/apps/server/tests/main.test.ts
+++ b/apps/server/tests/main.test.ts
@@ -21,9 +21,12 @@ describe('Application.start', () => {
   })
 
   it('continues when controller startup fails', async () => {
+    const controllerError = Object.assign(new Error('bind failed'), {
+      code: 'EADDRINUSE',
+    })
     const createHttpServer = mock(async () => ({}))
     const controllerStart = mock(async () => {
-      throw new Error('bind failed')
+      throw controllerError
     })
     const cdpConnect = mock(async () => {})
     const sentryCaptureException = mock(() => {})
@@ -31,112 +34,132 @@ describe('Application.start', () => {
     const loggerWarn = mock(() => {})
     const loggerDebug = mock(() => {})
     const loggerError = mock(() => {})
+    const processExit = mock((() => {
+      throw new Error('process.exit called')
+    }) as typeof process.exit)
+    const originalExit = process.exit
+    process.exit = processExit
 
-    mock.module('../src/api/server', () => ({
-      createHttpServer,
-    }))
-    mock.module('../src/browser/backends/controller', () => ({
-      ControllerBackend: class {
-        async start(): Promise<void> {
-          await controllerStart()
-        }
+    try {
+      mock.module('../src/api/server', () => ({
+        createHttpServer,
+      }))
+      mock.module('../src/browser/backends/controller', () => ({
+        ControllerBackend: class {
+          async start(): Promise<void> {
+            await controllerStart()
+          }
 
-        async stop(): Promise<void> {}
+          async stop(): Promise<void> {}
 
-        isConnected(): boolean {
-          return false
-        }
+          isConnected(): boolean {
+            return false
+          }
 
-        async send(): Promise<never> {
-          throw new Error('BrowserOS helper service not connected')
-        }
-      },
-    }))
-    mock.module('../src/browser/backends/cdp', () => ({
-      CdpBackend: class {
-        async connect(): Promise<void> {
-          await cdpConnect()
-        }
-      },
-    }))
-    mock.module('../src/browser/browser', () => ({
-      Browser: class {},
-    }))
-    mock.module('../src/lib/browseros-dir', () => ({
-      ensureBrowserosDir: mock(async () => {}),
-    }))
-    mock.module('../src/lib/db', () => ({
-      initializeDb: mock(() => ({}) as never),
-    }))
-    mock.module('../src/lib/identity', () => ({
-      identity: {
-        initialize: mock(() => {}),
-        getBrowserOSId: mock(() => 'browseros-id'),
-      },
-    }))
-    mock.module('../src/lib/logger', () => ({
-      logger: {
-        setLogFile: mock(() => {}),
-        info: loggerInfo,
-        warn: loggerWarn,
-        debug: loggerDebug,
-        error: loggerError,
-      },
-    }))
-    mock.module('../src/lib/metrics', () => ({
-      metrics: {
-        initialize: mock(() => {}),
-        isEnabled: mock(() => true),
-        log: mock(() => {}),
-      },
-    }))
-    mock.module('../src/lib/rate-limiter/fetch-config', () => ({
-      fetchDailyRateLimit: mock(async () => 100),
-    }))
-    mock.module('../src/lib/rate-limiter/rate-limiter', () => ({
-      RateLimiter: class {},
-    }))
-    mock.module('../src/lib/sentry', () => ({
-      Sentry: {
-        setContext: mock(() => {}),
-        captureException: sentryCaptureException,
-      },
-    }))
-    mock.module('../src/lib/soul', () => ({
-      seedSoulTemplate: mock(async () => {}),
-    }))
-    mock.module('../src/tools/registry', () => ({
-      registry: {
-        names: () => ['test_tool'],
-      },
-    }))
+          async send(): Promise<never> {
+            throw new Error('BrowserOS helper service not connected')
+          }
+        },
+      }))
+      mock.module('../src/browser/backends/cdp', () => ({
+        CdpBackend: class {
+          async connect(): Promise<void> {
+            await cdpConnect()
+          }
+        },
+      }))
+      mock.module('../src/browser/browser', () => ({
+        Browser: class {},
+      }))
+      mock.module('../src/lib/browseros-dir', () => ({
+        ensureBrowserosDir: mock(async () => {}),
+      }))
+      mock.module('../src/lib/db', () => ({
+        initializeDb: mock(() => ({})),
+      }))
+      mock.module('../src/lib/identity', () => ({
+        identity: {
+          initialize: mock(() => {}),
+          getBrowserOSId: mock(() => 'browseros-id'),
+        },
+      }))
+      mock.module('../src/lib/logger', () => ({
+        logger: {
+          setLogFile: mock(() => {}),
+          info: loggerInfo,
+          warn: loggerWarn,
+          debug: loggerDebug,
+          error: loggerError,
+        },
+      }))
+      mock.module('../src/lib/metrics', () => ({
+        metrics: {
+          initialize: mock(() => {}),
+          isEnabled: mock(() => true),
+          log: mock(() => {}),
+        },
+      }))
+      mock.module('../src/lib/rate-limiter/fetch-config', () => ({
+        fetchDailyRateLimit: mock(async () => 100),
+      }))
+      mock.module('../src/lib/rate-limiter/rate-limiter', () => ({
+        RateLimiter: class {},
+      }))
+      mock.module('../src/lib/sentry', () => ({
+        Sentry: {
+          setContext: mock(() => {}),
+          captureException: sentryCaptureException,
+        },
+      }))
+      mock.module('../src/lib/soul', () => ({
+        seedSoulTemplate: mock(async () => {}),
+      }))
+      mock.module('../src/tools/registry', () => ({
+        registry: {
+          names: () => ['test_tool'],
+        },
+      }))
 
-    const { Application } = await import('../src/main')
-    const app = new Application(config)
+      const { Application } = await import('../src/main')
+      const app = new Application(config)
 
-    await app.start()
+      await app.start()
 
-    expect(controllerStart).toHaveBeenCalledTimes(1)
-    expect(cdpConnect).toHaveBeenCalledTimes(1)
-    expect(createHttpServer).toHaveBeenCalledTimes(1)
-    expect(sentryCaptureException).toHaveBeenCalledTimes(1)
+      expect(controllerStart).toHaveBeenCalledTimes(1)
+      expect(cdpConnect).toHaveBeenCalledTimes(1)
+      expect(createHttpServer).toHaveBeenCalledTimes(1)
+      expect(sentryCaptureException).toHaveBeenCalledTimes(1)
+      expect(sentryCaptureException).toHaveBeenCalledWith(controllerError)
+      expect(processExit).not.toHaveBeenCalled()
 
-    const warningCall = loggerWarn.mock.calls.find(
-      ([message]) =>
-        message ===
-        'Controller WebSocket server unavailable, continuing without controller bridge',
-    )
-    expect(warningCall).toBeDefined()
-    expect(warningCall?.[1]).toEqual({
-      port: config.extensionPort,
-      error: 'bind failed',
-    })
+      const warningCall = loggerWarn.mock.calls.find(
+        ([message]) =>
+          message ===
+          'Controller WebSocket server unavailable, continuing without controller bridge',
+      )
+      expect(warningCall).toBeDefined()
+      expect(warningCall?.[1]).toEqual({
+        port: config.extensionPort,
+        error: 'bind failed',
+      })
 
-    expect(
-      loggerInfo.mock.calls.some(
-        ([message]) => message === '  Controller Server: unavailable',
-      ),
-    ).toBe(true)
-    expect(loggerError).not.toHaveBeenCalled()
+      const portConflictCall = loggerWarn.mock.calls.find(
+        ([message]) =>
+          message ===
+          'Controller WebSocket port is already in use, continuing without controller bridge',
+      )
+      expect(portConflictCall).toBeDefined()
+      expect(portConflictCall?.[1]).toEqual({
+        port: config.extensionPort,
+      })
+      expect(
+        loggerInfo.mock.calls.some(
+          ([message]) => message === '  Controller Server: unavailable',
+        ),
+      ).toBe(true)
+      expect(loggerError).not.toHaveBeenCalled()
+    } finally {
+      process.exit = originalExit
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Keep BrowserOS server startup alive when the controller WebSocket server fails to start.
- Keep CDP and HTTP startup failures fatal so core browser automation behavior does not change.
- Report controller startup unavailability accurately in startup logs and cover the degraded path with a focused Bun test.

## Design
This keeps the existing startup graph intact. `Application.start()` still creates a `ControllerBackend`, but controller startup failure is downgraded from a fatal exit to a warning plus Sentry capture, while the existing request-time `not connected` behavior continues to handle controller-backed operations lazily. The startup summary now reflects whether the controller server actually came up instead of always printing a listening address.

## Test plan
- `bun test apps/server/tests/main.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
