### PR TITLE
feat: show agent side panel in every tab the agent interacts with

### DIFF
--- a/apps/agent/entrypoints/background/index.ts
+++ b/apps/agent/entrypoints/background/index.ts
@@ -35,8 +35,10 @@ export default defineBackground(() => {
   const agentTabSets = new Map<string, Set<number>>()
 
   chrome.tabs.onRemoved.addListener((tabId) => {
-    for (const tabSet of agentTabSets.values()) {
+    for (const [conversationId, tabSet] of agentTabSets) {
       tabSet.delete(tabId)
+      // Prune empty entries to prevent unbounded growth
+      if (tabSet.size === 0) agentTabSets.delete(conversationId)
     }
   })
 

--- a/apps/agent/entrypoints/background/index.ts
+++ b/apps/agent/entrypoints/background/index.ts
@@ -31,6 +31,15 @@ export default defineBackground(() => {
 
   scheduledJobRuns()
 
+  // Track which tabs belong to each agent conversation for side panel management
+  const agentTabSets = new Map<string, Set<number>>()
+
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    for (const tabSet of agentTabSets.values()) {
+      tabSet.delete(tabId)
+    }
+  })
+
   chrome.action.onClicked.addListener(async (tab) => {
     if (tab.id) {
       await toggleSidePanel(tab.id)
@@ -90,6 +99,29 @@ export default defineBackground(() => {
         conversationId: message.conversationId,
         timestamp: Date.now(),
       })
+    }
+
+    // Open side panel on tabs the agent interacts with
+    if (
+      message?.type === 'open-sidepanel-on-tab' &&
+      message?.tabId &&
+      message?.conversationId
+    ) {
+      const { tabId, conversationId } = message
+      let tabSet = agentTabSets.get(conversationId)
+      if (!tabSet) {
+        tabSet = new Set()
+        agentTabSets.set(conversationId, tabSet)
+      }
+      if (!tabSet.has(tabId)) {
+        tabSet.add(tabId)
+        openSidePanel(tabId).catch(() => {})
+      }
+    }
+
+    // Clean up tab tracking when conversation resets
+    if (message?.type === 'clear-agent-tabs' && message?.conversationId) {
+      agentTabSets.delete(message.conversationId)
     }
   })
 

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -468,6 +468,13 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   const resetConversation = () => {
     track(CONVERSATION_RESET_EVENT, { message_count: messages.length })
     stop()
+    // Clear agent tab tracking in background before generating new conversationId
+    chrome.runtime
+      .sendMessage({
+        type: 'clear-agent-tabs',
+        conversationId: conversationIdRef.current,
+      })
+      .catch(() => {})
     setConversationId(crypto.randomUUID())
     setMessages([])
     setTextToAction(new Map())

--- a/apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx
@@ -29,6 +29,7 @@ export const useNotifyActiveTab = ({
   conversationId: string
 }) => {
   const lastTabIdRef = useRef<number | null>(null)
+  const knownTabsRef = useRef<Set<number>>(new Set())
 
   const lastMessage = messages?.[messages.length - 1]
 
@@ -38,6 +39,11 @@ export const useNotifyActiveTab = ({
 
   const hasToolCalls = !!latestTool
   const toolTabId = extractTabId(latestTool as ToolUIPart | null)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally reset when conversationId changes
+  useEffect(() => {
+    knownTabsRef.current = new Set()
+  }, [conversationId])
 
   useEffect(() => {
     const isStreaming = status === 'streaming'
@@ -81,6 +87,18 @@ export const useNotifyActiveTab = ({
       }
 
       if (cancelled || !targetTabId) return
+
+      // Open side panel on tabs the agent hasn't seen yet
+      if (!knownTabsRef.current.has(targetTabId)) {
+        knownTabsRef.current.add(targetTabId)
+        chrome.runtime
+          .sendMessage({
+            type: 'open-sidepanel-on-tab',
+            tabId: targetTabId,
+            conversationId,
+          })
+          .catch(() => {})
+      }
 
       if (previousTabId && previousTabId !== targetTabId) {
         const deactivateMessage: GlowMessage = {


### PR DESCRIPTION
## Summary
- When the agent executes a tool that targets a new tab (e.g., `new_page`), the side panel now automatically opens on that tab
- The existing `useNotifyActiveTab` hook tracks which tabs the agent has touched and relays new ones to the background script via `chrome.runtime.sendMessage`
- The background script maintains an in-memory map of `conversationId → Set<tabId>` and calls `openSidePanel(tabId)` for each new tab

## Design
The solution extends the existing `useNotifyActiveTab` hook with a `Set<number>` ref that accumulates all tab IDs seen during the current conversation. When a tool's `tabId` is new, the hook sends an `open-sidepanel-on-tab` message to the background script, which calls `openSidePanel(tabId)`. Since Chrome's side panel is a single instance per extension, the same conversation renders regardless of which tab the user switches to. Tab tracking is cleaned up on conversation reset and when tabs are closed.

## Changed files
- `apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx` — Track seen tabs, send `open-sidepanel-on-tab` message to background
- `apps/agent/entrypoints/background/index.ts` — Handle `open-sidepanel-on-tab` and `clear-agent-tabs` messages, maintain tab tracking map with cleanup
- `apps/agent/entrypoints/sidepanel/index/useChatSession.ts` — Send `clear-agent-tabs` on conversation reset

## Test plan
- [ ] Open BrowserOS agent side panel on any tab
- [ ] Ask the agent to perform a task that opens new tabs (e.g., "search for BrowserOS news")
- [ ] Verify the side panel appears on each newly opened tab
- [ ] Switch between agent-opened tabs and confirm the side panel shows the same conversation
- [ ] Reset the conversation and verify no side effects on previously opened tabs
- [ ] Open tabs manually while agent is running — verify side panel does NOT open on those

🤖 Generated with [Claude Code](https://claude.com/claude-code)