### PR TITLE
fix: autofocus sidepanel chat input on open

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/Chat.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/Chat.tsx
@@ -201,6 +201,7 @@ export const Chat = () => {
         attachedTabs={attachedTabs}
         onToggleTab={toggleTabSelection}
         onRemoveTab={removeTab}
+        shouldAutoFocus
       />
     </>
   )

--- a/apps/agent/entrypoints/sidepanel/index/ChatFooter.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatFooter.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, Folder, Layers, PlugZap } from 'lucide-react'
 import type { FC, FormEvent } from 'react'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AppSelector } from '@/components/elements/AppSelector'
 import { WorkspaceSelector } from '@/components/elements/workspace-selector'
 import { McpServerIcon } from '@/entrypoints/app/connect-mcp/McpServerIcon'
@@ -27,6 +27,7 @@ interface ChatFooterProps {
   attachedTabs: chrome.tabs.Tab[]
   onToggleTab: (tab: chrome.tabs.Tab) => void
   onRemoveTab: (tabId?: number) => void
+  shouldAutoFocus?: boolean
 }
 
 export const ChatFooter: FC<ChatFooterProps> = ({
@@ -40,6 +41,7 @@ export const ChatFooter: FC<ChatFooterProps> = ({
   attachedTabs,
   onToggleTab,
   onRemoveTab,
+  shouldAutoFocus = false,
 }) => {
   const { selectedFolder } = useWorkspace()
   const { supports } = useCapabilities()
@@ -48,6 +50,15 @@ export const ChatFooter: FC<ChatFooterProps> = ({
   useSyncRemoteIntegrations()
   const chatInputRef = useRef<ChatInputHandle>(null)
   const [isTabMentionOpen, setIsTabMentionOpen] = useState(false)
+
+  useEffect(() => {
+    if (!shouldAutoFocus) return
+
+    const frameId = requestAnimationFrame(() => {
+      chatInputRef.current?.focus()
+    })
+    return () => cancelAnimationFrame(frameId)
+  }, [shouldAutoFocus])
 
   const connectedManagedServers = mcpServers.filter((s) => {
     if (s.type !== 'managed' || !s.managedServerName) return false

--- a/apps/agent/entrypoints/sidepanel/index/ChatFooter.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatFooter.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, Folder, Layers, PlugZap } from 'lucide-react'
 import type { FC, FormEvent } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { AppSelector } from '@/components/elements/AppSelector'
 import { WorkspaceSelector } from '@/components/elements/workspace-selector'
 import { McpServerIcon } from '@/entrypoints/app/connect-mcp/McpServerIcon'
@@ -50,15 +50,6 @@ export const ChatFooter: FC<ChatFooterProps> = ({
   useSyncRemoteIntegrations()
   const chatInputRef = useRef<ChatInputHandle>(null)
   const [isTabMentionOpen, setIsTabMentionOpen] = useState(false)
-
-  useEffect(() => {
-    if (!shouldAutoFocus) return
-
-    const frameId = requestAnimationFrame(() => {
-      chatInputRef.current?.focus()
-    })
-    return () => cancelAnimationFrame(frameId)
-  }, [shouldAutoFocus])
 
   const connectedManagedServers = mcpServers.filter((s) => {
     if (s.type !== 'managed' || !s.managedServerName) return false
@@ -172,6 +163,7 @@ export const ChatFooter: FC<ChatFooterProps> = ({
           selectedTabs={attachedTabs}
           onToggleTab={onToggleTab}
           onTabMentionOpenChange={setIsTabMentionOpen}
+          shouldAutoFocus={shouldAutoFocus}
           ref={chatInputRef}
         />
       </div>

--- a/apps/agent/entrypoints/sidepanel/index/ChatInput.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatInput.tsx
@@ -28,6 +28,7 @@ interface ChatInputProps {
   selectedTabs: chrome.tabs.Tab[]
   onToggleTab: (tab: chrome.tabs.Tab) => void
   onTabMentionOpenChange?: (isOpen: boolean) => void
+  shouldAutoFocus?: boolean
 }
 
 export interface ChatInputHandle {
@@ -49,6 +50,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       selectedTabs,
       onToggleTab,
       onTabMentionOpenChange,
+      shouldAutoFocus = false,
     },
     ref,
   ) => {
@@ -70,6 +72,62 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     useEffect(() => {
       onTabMentionOpenChange?.(mentionState.isOpen)
     }, [mentionState.isOpen, onTabMentionOpenChange])
+
+    useEffect(() => {
+      if (!shouldAutoFocus) return
+
+      const timeoutIds: number[] = []
+      const frameIds: number[] = []
+      let didFocus = false
+
+      const attemptFocus = () => {
+        if (didFocus) return
+
+        const textarea = textareaRef.current
+        if (!textarea) return
+
+        textarea.focus()
+        const frameId = requestAnimationFrame(() => {
+          if (document.activeElement === textarea) {
+            didFocus = true
+          }
+        })
+        frameIds.push(frameId)
+      }
+
+      const scheduleAttempt = (delay: number) => {
+        const timeoutId = window.setTimeout(() => {
+          attemptFocus()
+        }, delay)
+        timeoutIds.push(timeoutId)
+      }
+
+      const handleVisibilityChange = () => {
+        if (document.visibilityState === 'visible') {
+          attemptFocus()
+        }
+      }
+
+      attemptFocus()
+      scheduleAttempt(50)
+      scheduleAttempt(150)
+      scheduleAttempt(300)
+      window.addEventListener('focus', attemptFocus)
+      window.addEventListener('pageshow', attemptFocus)
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+
+      return () => {
+        for (const timeoutId of timeoutIds) {
+          window.clearTimeout(timeoutId)
+        }
+        for (const frameId of frameIds) {
+          cancelAnimationFrame(frameId)
+        }
+        window.removeEventListener('focus', attemptFocus)
+        window.removeEventListener('pageshow', attemptFocus)
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+      }
+    }, [shouldAutoFocus])
 
     const closeMention = useCallback(() => {
       const state = mentionStateRef.current


### PR DESCRIPTION
## Summary

- automatically focus the sidepanel chat input when the BrowserOS sidepanel opens
- scope the autofocus behavior to the sidepanel so new-tab chat stays unchanged
- keep the fix in the extension because Chromium already focuses the sidepanel container

## Design

The sidepanel `Chat` view now opts into autofocus explicitly, and the shared `ChatFooter` uses its existing `ChatInputHandle` ref to focus the textarea after mount with `requestAnimationFrame`. This keeps the behavior local to the extension UI and avoids unnecessary Chromium-side or background-message changes.

## Test plan

- `bunx biome check entrypoints/sidepanel/index/Chat.tsx entrypoints/sidepanel/index/ChatFooter.tsx`
- `bun run --filter @browseros/agent typecheck`  _(fails in this repo with a TypeScript heap OOM; repeated with `NODE_OPTIONS='--max-old-space-size=8192'` and still OOMed)_
