### PR TITLE
fix: auto-focus chat input when side panel opens

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/ChatFooter.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatFooter.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, Folder, Layers, PlugZap } from 'lucide-react'
 import type { FC, FormEvent } from 'react'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { AppSelector } from '@/components/elements/AppSelector'
 import { WorkspaceSelector } from '@/components/elements/workspace-selector'
 import { McpServerIcon } from '@/entrypoints/app/connect-mcp/McpServerIcon'
@@ -48,6 +48,27 @@ export const ChatFooter: FC<ChatFooterProps> = ({
   useSyncRemoteIntegrations()
   const chatInputRef = useRef<ChatInputHandle>(null)
   const [isTabMentionOpen, setIsTabMentionOpen] = useState(false)
+
+  useEffect(() => {
+    const focusInput = () => {
+      const active = document.activeElement
+      const isInteractiveElementFocused =
+        active instanceof HTMLInputElement ||
+        active instanceof HTMLTextAreaElement ||
+        active instanceof HTMLSelectElement ||
+        active instanceof HTMLButtonElement
+      if (!isInteractiveElementFocused) {
+        chatInputRef.current?.focus()
+      }
+    }
+
+    if (document.hasFocus()) {
+      focusInput()
+    }
+
+    window.addEventListener('focus', focusInput)
+    return () => window.removeEventListener('focus', focusInput)
+  }, [])
 
   const connectedManagedServers = mcpServers.filter((s) => {
     if (s.type !== 'managed' || !s.managedServerName) return false


### PR DESCRIPTION
## Summary
- Add `window.focus` event listener in `ChatFooter` that auto-focuses the chat textarea when the side panel receives focus
- On mount, checks `document.hasFocus()` to immediately focus if the panel already has focus
- Guards against stealing focus from other interactive elements (inputs, buttons, selects)

## Chromium companion change
In `side_panel_coordinator.cc:PopulateSidePanel()`, `content->RequestFocus()` is moved out of the `else` branch to always execute — ensuring the side panel WebContents receives focus on every open/toggle, not just the first time.

**Root cause:** Chromium only called `RequestFocus()` when there was no `previous_entry` in the side panel. When toggling the BrowserOS side panel with a previous entry present, focus stayed on the web page. This is a known Chromium limitation ([w3c/webextensions#693](https://github.com/w3c/webextensions/issues/693)).

## Test plan
- [ ] Open side panel → textarea should be focused automatically
- [ ] Close and re-open side panel → textarea should be focused
- [ ] Click somewhere on the web page, then click back into side panel → textarea should refocus
- [ ] Open side panel, click a button (e.g., tab picker), close button popover → focus should NOT jump to textarea while button is focused
- [ ] Verify with both Chromium `RequestFocus()` fix applied and without (extension-only should handle `window.focus` events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)