### PR TITLE
fix: performance issue with rendering chat

### DIFF
--- a/apps/agent/entrypoints/app/create-graph/GraphChat.tsx
+++ b/apps/agent/entrypoints/app/create-graph/GraphChat.tsx
@@ -41,7 +41,6 @@ export const GraphChat: FC<GraphChatProps> = ({
   const [liked, setLiked] = useState<Record<string, boolean>>({})
   const [disliked, setDisliked] = useState<Record<string, boolean>>({})
   const [mounted, setMounted] = useState(false)
-  const messagesEndRef = useRef<HTMLDivElement>(null)
   const displayMessages = getWorkflowDisplayMessages(messages)
 
   useEffect(() => {
@@ -143,7 +142,6 @@ export const GraphChat: FC<GraphChatProps> = ({
             onClickLike={onClickLike}
             messages={displayMessages}
             status={status}
-            messagesEndRef={messagesEndRef}
             showJtbdPopup={popupVisible}
             showDontShowAgain={false}
             onTakeSurvey={onTakeSurvey}

--- a/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
@@ -1,5 +1,5 @@
 import { Loader2 } from 'lucide-react'
-import { type FC, useEffect, useRef, useState } from 'react'
+import { type FC, useEffect, useState } from 'react'
 import { ChatEmptyState } from '@/entrypoints/sidepanel/index/ChatEmptyState'
 import { ChatError } from '@/entrypoints/sidepanel/index/ChatError'
 import { ChatFooter } from '@/entrypoints/sidepanel/index/ChatFooter'
@@ -46,17 +46,11 @@ export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
 
   const [input, setInput] = useState('')
   const [attachedTabs, setAttachedTabs] = useState<chrome.tabs.Tab[]>([])
-  const messagesEndRef = useRef<HTMLDivElement>(null)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
     setMounted(true)
   }, [])
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll only when messages change
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
 
   const handleModeChange = (newMode: ChatMode) => {
     track(NEWTAB_CHAT_MODE_CHANGED_EVENT, { from: mode, to: newMode })
@@ -147,7 +141,6 @@ export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
           <ChatMessages
             messages={messages}
             status={status}
-            messagesEndRef={messagesEndRef}
             getActionForMessage={getActionForMessage}
             liked={liked}
             onClickLike={onClickLike}

--- a/apps/agent/entrypoints/sidepanel/index/Chat.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/Chat.tsx
@@ -50,7 +50,6 @@ export const Chat = () => {
 
   const [input, setInput] = useState('')
   const [attachedTabs, setAttachedTabs] = useState<chrome.tabs.Tab[]>([])
-  const messagesEndRef = useRef<HTMLDivElement>(null)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -68,15 +67,6 @@ export const Chat = () => {
       setAttachedTabs(currentTab)
     })()
   }, [])
-
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll only when messages change
-  useEffect(() => {
-    scrollToBottom()
-  }, [messages])
 
   // Trigger JTBD popup when AI finishes responding
   const previousChatStatus = useRef(status)
@@ -174,7 +164,6 @@ export const Chat = () => {
           <ChatMessages
             messages={messages}
             status={status}
-            messagesEndRef={messagesEndRef}
             getActionForMessage={getActionForMessage}
             liked={liked}
             onClickLike={onClickLike}

--- a/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage } from 'ai'
 import { Bot } from 'lucide-react'
-import { type FC, Fragment, type RefObject } from 'react'
+import { type FC, Fragment } from 'react'
 import {
   Conversation,
   ConversationContent,
@@ -28,7 +28,6 @@ import { UserActionMessage } from './UserActionMessage'
 interface ChatMessagesProps {
   messages: UIMessage[]
   status: 'streaming' | 'submitted' | 'ready' | 'error'
-  messagesEndRef: RefObject<HTMLDivElement | null>
   getActionForMessage?: (message: UIMessage) => ChatAction | undefined
   liked: Record<string, boolean>
   onClickLike: (messageId: string) => void
@@ -43,7 +42,6 @@ interface ChatMessagesProps {
 export const ChatMessages: FC<ChatMessagesProps> = ({
   messages,
   status,
-  messagesEndRef,
   getActionForMessage,
   liked,
   disliked,
@@ -177,7 +175,7 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
           </div>
         </div>
       )}
-      <div ref={messagesEndRef} />
+      <div />
     </>
   )
 }

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -408,7 +408,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     const justFinished = wasStreaming && status === 'ready'
     previousStatusRef.current = status
 
-    if (!justFinished && status !== 'ready') return
+    if (!justFinished) return
 
     const messagesToSave = messages.filter((m) => m.parts?.length > 0)
     if (messagesToSave.length === 0) return

--- a/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -393,20 +393,32 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     }
   }, [conversationIdParam, remoteConversationData, isLoggedIn])
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: only need to run when messages change
+  // Keep messagesRef in sync on every change (cheap ref assignment)
   useEffect(() => {
     messagesRef.current = messages
+  }, [messages])
+
+  // Save conversation only after streaming completes — not on every token
+  const previousStatusRef = useRef(status)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only save when streaming finishes
+  useEffect(() => {
+    const wasStreaming =
+      previousStatusRef.current === 'streaming' ||
+      previousStatusRef.current === 'submitted'
+    const justFinished = wasStreaming && status === 'ready'
+    previousStatusRef.current = status
+
+    if (!justFinished && status !== 'ready') return
+
     const messagesToSave = messages.filter((m) => m.parts?.length > 0)
-    if (messagesToSave.length > 0) {
-      if (isLoggedIn) {
-        if (status !== 'streaming') {
-          saveRemoteConversation(conversationIdRef.current, messagesToSave)
-        }
-      } else {
-        saveLocalConversation(conversationIdRef.current, messagesToSave)
-      }
+    if (messagesToSave.length === 0) return
+
+    if (isLoggedIn) {
+      saveRemoteConversation(conversationIdRef.current, messagesToSave)
+    } else {
+      saveLocalConversation(conversationIdRef.current, messagesToSave)
     }
-  }, [messages, isLoggedIn, status])
+  }, [status])
 
   const sendMessage = (params: { text: string; action?: ChatAction }) => {
     track(MESSAGE_SENT_EVENT, {


### PR DESCRIPTION
This pull request refactors how chat messages are scrolled into view and when conversations are saved. The main changes remove the use of `messagesEndRef` and related scroll logic from chat components, simplifying their structure and reducing unnecessary dependencies. Additionally, the logic for saving conversations is improved to trigger only after streaming completes, instead of on every message change.

**Chat UI simplification:**

* Removed `messagesEndRef` and associated scroll-to-bottom logic from `NewTabChat`, `Chat`, and `ChatMessages` components, resulting in cleaner component interfaces and less reliance on refs. [[1]](diffhunk://#diff-f5b7c6ed762c6417e05f7ddb5ecac9b2569945a7d99caaeddf7716fdedacf64cL2-R2) [[2]](diffhunk://#diff-f5b7c6ed762c6417e05f7ddb5ecac9b2569945a7d99caaeddf7716fdedacf64cL49-L60) [[3]](diffhunk://#diff-f5b7c6ed762c6417e05f7ddb5ecac9b2569945a7d99caaeddf7716fdedacf64cL150) [[4]](diffhunk://#diff-25d11845eb2d511396dac47c7ecc419bf9f1eb4d9ac3c1446e28b900a6402d1aL53) [[5]](diffhunk://#diff-25d11845eb2d511396dac47c7ecc419bf9f1eb4d9ac3c1446e28b900a6402d1aL72-L80) [[6]](diffhunk://#diff-25d11845eb2d511396dac47c7ecc419bf9f1eb4d9ac3c1446e28b900a6402d1aL177) [[7]](diffhunk://#diff-c890ed0d1db567a2ae67e9e53e37300c6ce0cc973c0be2cf043f09794d8e3496L3-R3) [[8]](diffhunk://#diff-c890ed0d1db567a2ae67e9e53e37300c6ce0cc973c0be2cf043f09794d8e3496L31) [[9]](diffhunk://#diff-c890ed0d1db567a2ae67e9e53e37300c6ce0cc973c0be2cf043f09794d8e3496L46) [[10]](diffhunk://#diff-c890ed0d1db567a2ae67e9e53e37300c6ce0cc973c0be2cf043f09794d8e3496L180-R178)

**Conversation saving improvements:**

* Updated `useChatSession` to save conversations only after streaming completes (`status === 'ready'`), preventing unnecessary saves during message streaming and improving efficiency.