### PR TITLE
feat: add memory workspace to personalize

### DIFF
--- a/apps/agent/entrypoints/newtab/personalize/MarkdownPreview.tsx
+++ b/apps/agent/entrypoints/newtab/personalize/MarkdownPreview.tsx
@@ -1,0 +1,41 @@
+import type { FC } from 'react'
+import { MessageResponse } from '@/components/ai-elements/message'
+import { cn } from '@/lib/utils'
+
+interface MarkdownPreviewProps {
+  content: string
+  className?: string
+  emptyMessage?: string
+}
+
+export const MarkdownPreview: FC<MarkdownPreviewProps> = ({
+  content,
+  className,
+  emptyMessage = 'Nothing here yet.',
+}) => {
+  if (!content.trim()) {
+    return (
+      <div
+        className={cn(
+          'flex min-h-40 items-center justify-center rounded-2xl border border-border/70 border-dashed bg-muted/20 px-6 py-10 text-center text-muted-foreground text-sm',
+          className,
+        )}
+      >
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        "prose prose-sm dark:prose-invert [&_[data-streamdown='code-block']]:!w-full [&_[data-streamdown='table-wrapper']]:!w-full max-w-none break-words rounded-2xl border border-border/70 bg-muted/20 p-4",
+        className,
+      )}
+    >
+      <MessageResponse className="[&_[data-streamdown='code-block']]:!w-full [&_[data-streamdown='table-wrapper']]:!w-full">
+        {content}
+      </MessageResponse>
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/newtab/personalize/Personalize.tsx
+++ b/apps/agent/entrypoints/newtab/personalize/Personalize.tsx
@@ -1,163 +1,508 @@
-import { Check, ChevronDown, Copy } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import {
+  BookOpenText,
+  Brain,
+  Clock3,
+  Loader2,
+  RefreshCw,
+  RotateCcw,
+  Save,
+  Sparkles,
+} from 'lucide-react'
+import { type FC, useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router'
+import { toast } from 'sonner'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible'
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { usePersonalization } from '@/lib/personalization/personalizationStorage'
 import { cn } from '@/lib/utils'
 import { NewTabBranding } from '../index/NewTabBranding'
-import { templates } from './templates'
+import { MarkdownPreview } from './MarkdownPreview'
+import { PromptTemplates } from './PromptTemplates'
+import type { DailyMemoryFile } from './useMemory'
+import { useMemory } from './useMemory'
 
-const sections = [
-  {
-    key: 'aboutYou' as const,
-    title: 'Add more info about you',
-    description: 'Help BrowserOS understand who you are',
-  },
-  {
-    key: 'expectations' as const,
-    title: 'What you expect from the browser',
-    description: 'Share your preferences and needs',
-  },
-  {
-    key: 'commonActions' as const,
-    title: 'Your commonly performed actions',
-    description: 'Describe your daily workflows',
-  },
-]
+type PersonalizeTab = 'memory' | 'prompt'
+type CoreView = 'preview' | 'edit'
+
+const formatMemoryDate = (date: string) =>
+  new Intl.DateTimeFormat(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(`${date}T00:00:00`))
+
+const getTodayDate = () => {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+const getEntryCount = (content: string) => content.match(/^##\s/gm)?.length ?? 0
+
+const getCoreLineCount = (content: string) =>
+  content.trim() ? content.trim().split('\n').length : 0
+
+const getDailySummary = (content: string) => {
+  const firstLine = content
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && !line.startsWith('## '))
+
+  if (!firstLine) return 'Recent session notes'
+  return firstLine.length > 88 ? `${firstLine.slice(0, 88)}...` : firstLine
+}
+
+const OverviewCard: FC<{
+  icon: typeof Brain
+  title: string
+  value: string
+  description: string
+}> = ({ icon: Icon, title, value, description }) => (
+  <div className="rounded-2xl border border-border/60 bg-background/80 p-4 backdrop-blur-sm">
+    <div className="flex items-center gap-2 text-muted-foreground text-xs uppercase tracking-[0.18em]">
+      <Icon className="h-4 w-4" />
+      {title}
+    </div>
+    <div className="mt-3 font-semibold text-2xl">{value}</div>
+    <p className="mt-1 text-muted-foreground text-sm">{description}</p>
+  </div>
+)
+
+const DailyMemoryButton: FC<{
+  item: DailyMemoryFile
+  selected: boolean
+  onSelect: (fileName: string) => void
+}> = ({ item, selected, onSelect }) => (
+  <button
+    type="button"
+    onClick={() => onSelect(item.fileName)}
+    className={cn(
+      'w-full rounded-2xl border px-4 py-3 text-left transition-colors',
+      selected
+        ? 'border-orange-400/70 bg-orange-500/10'
+        : 'border-border/60 bg-background hover:bg-muted/50',
+    )}
+  >
+    <div className="flex items-center justify-between gap-2">
+      <span className="font-medium text-sm">{formatMemoryDate(item.date)}</span>
+      {item.date === getTodayDate() ? (
+        <Badge variant="secondary">Today</Badge>
+      ) : null}
+    </div>
+    <p className="mt-2 text-muted-foreground text-sm">
+      {getEntryCount(item.content)} entries
+    </p>
+    <p className="mt-1 text-muted-foreground text-xs">
+      {getDailySummary(item.content)}
+    </p>
+  </button>
+)
 
 export const Personalize = () => {
   const [mounted, setMounted] = useState(false)
-  const [expandedSection, setExpandedSection] = useState<string | null>(
-    sections[0].key,
+  const [activeTab, setActiveTab] = useState<PersonalizeTab>('memory')
+  const [coreView, setCoreView] = useState<CoreView>('preview')
+  const [coreDraft, setCoreDraft] = useState('')
+  const [selectedDailyFile, setSelectedDailyFile] = useState<string | null>(
+    null,
   )
-  const [copiedSection, setCopiedSection] = useState<string | null>(null)
+  const lastLoadedCore = useRef('')
   const { personalization, setPersonalization } = usePersonalization()
+  const { memory, isLoading, error, refetch, saveCoreMemory, isSavingCore } =
+    useMemory()
 
   useEffect(() => {
     setMounted(true)
   }, [])
 
-  const copyTemplate = (templateKey: keyof typeof templates) => {
-    const template = templates[templateKey].template
-    navigator.clipboard.writeText(template)
-    setCopiedSection(templateKey)
-    setTimeout(() => setCopiedSection(null), 2000)
+  useEffect(() => {
+    if (!memory) return
+    setCoreDraft((current) =>
+      current === lastLoadedCore.current ? memory.coreMemory : current,
+    )
+    lastLoadedCore.current = memory.coreMemory
+  }, [memory])
+
+  useEffect(() => {
+    if (!memory) return
+    if (memory.dailyMemories.length === 0) {
+      setSelectedDailyFile(null)
+      return
+    }
+
+    setSelectedDailyFile((current) =>
+      current &&
+      memory.dailyMemories.some((entry) => entry.fileName === current)
+        ? current
+        : memory.dailyMemories[0].fileName,
+    )
+  }, [memory])
+
+  const isCoreDirty = coreDraft !== lastLoadedCore.current
+  const todayDate = getTodayDate()
+  const selectedDailyMemory =
+    memory?.dailyMemories.find(
+      (entry) => entry.fileName === selectedDailyFile,
+    ) ?? null
+  const coreLineCount = getCoreLineCount(memory?.coreMemory ?? '')
+  const dailyMemoryCount = memory?.dailyMemories.length ?? 0
+
+  const handleSaveCore = async () => {
+    try {
+      await saveCoreMemory(coreDraft)
+      toast.success('Core memory updated')
+      setCoreView('preview')
+    } catch (saveError) {
+      const message =
+        saveError instanceof Error ? saveError.message : 'Failed to save memory'
+      toast.error(message)
+    }
   }
 
   return (
-    <div className="mx-auto w-full max-w-2xl space-y-8">
+    <div className="mx-auto w-full max-w-5xl space-y-8">
       <NewTabBranding />
 
       <div
         className={cn(
-          'space-y-3 transition-all duration-500',
+          'overflow-hidden rounded-[28px] border border-border/60 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.16),transparent_34%),radial-gradient(circle_at_top_right,rgba(251,191,36,0.12),transparent_28%)] bg-background p-6 transition-all duration-500',
           mounted ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0',
         )}
       >
-        <Label htmlFor="personalization">Your Information</Label>
-        <Textarea
-          id="personalization"
-          value={personalization}
-          autoFocus
-          onChange={(e) => setPersonalization(e.target.value)}
-          placeholder="Tell BrowserOS about yourself... (Supports Markdown)"
-          className="styled-scrollbar h-96 resize-none rounded-2xl border-2 border-border/50 bg-card px-4 py-3 transition-transform placeholder:text-muted-foreground focus:border-[var(--accent-orange)]/30 focus:ring-4 focus:ring-[var(--accent-orange)]/10"
-        />
-        <p className="text-muted-foreground text-xs">
-          Your information is saved locally and never leaves your device.
-          Markdown formatting is supported.
-        </p>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-2xl space-y-3">
+            <Badge
+              variant="secondary"
+              className="bg-orange-500/10 text-orange-700 dark:text-orange-300"
+            >
+              Personalize
+            </Badge>
+            <div className="space-y-2">
+              <h1 className="font-semibold text-3xl tracking-tight">
+                Shape what BrowserOS knows and remembers
+              </h1>
+              <p className="text-base text-muted-foreground leading-7">
+                Keep your live prompt separate from long-term memory, review
+                what the agent has saved, and update your durable facts without
+                digging through markdown files by hand.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-border/60 bg-background/75 p-4 text-sm backdrop-blur-sm">
+            <div className="flex items-center gap-2 font-medium">
+              <Sparkles className="h-4 w-4 text-orange-500" />
+              Behavior lives in Agent Soul
+            </div>
+            <p className="mt-2 max-w-sm text-muted-foreground">
+              Use memory for user facts and recent context. Use Soul for tone,
+              boundaries, and how the agent behaves.
+            </p>
+            <Button variant="link" className="mt-2 h-auto px-0" asChild>
+              <Link to="/settings/soul">Open Agent Soul</Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-3 sm:grid-cols-3">
+          <OverviewCard
+            icon={BookOpenText}
+            title="Prompt"
+            value={personalization.trim() ? 'Active' : 'Empty'}
+            description="Injected directly into chat as your local personalization prompt."
+          />
+          <OverviewCard
+            icon={Brain}
+            title="Core Memory"
+            value={coreLineCount > 0 ? `${coreLineCount}` : '0'}
+            description="Durable markdown facts that stay until you edit them."
+          />
+          <OverviewCard
+            icon={Clock3}
+            title="Daily Memory"
+            value={`${dailyMemoryCount}`}
+            description={`Recent notes saved by the agent and retained for ${memory?.retentionDays ?? 30} days.`}
+          />
+        </div>
       </div>
 
       <div
         className={cn(
-          'space-y-3 transition-all delay-100 duration-500',
+          'transition-all delay-100 duration-500',
           mounted ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0',
         )}
       >
-        <h2 className="font-semibold text-muted-foreground text-sm uppercase tracking-wide">
-          Need help getting started?
-        </h2>
-        <div className="space-y-2">
-          {sections.map((section) => (
-            <Collapsible
-              key={section.key}
-              open={expandedSection === section.key}
-              onOpenChange={(open) =>
-                setExpandedSection(open ? section.key : null)
-              }
-              className="w-full rounded-xl border border-border/50 bg-card hover:border-border"
-            >
-              <CollapsibleTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="flex h-auto w-full items-center justify-between p-4 text-left hover:bg-accent/50"
-                >
-                  <div className="flex-1">
-                    <h3 className="mb-1 font-medium text-foreground text-sm">
-                      {section.title}
-                    </h3>
-                    <p className="text-muted-foreground text-xs">
-                      {section.description}
-                    </p>
-                  </div>
-                  <ChevronDown
-                    className={`h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200 ${expandedSection === section.key ? 'rotate-180' : ''}`}
-                  />
-                </Button>
-              </CollapsibleTrigger>
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as PersonalizeTab)}
+        >
+          <TabsList variant="line" className="mb-2">
+            <TabsTrigger value="memory">Memory</TabsTrigger>
+            <TabsTrigger value="prompt">Prompt</TabsTrigger>
+          </TabsList>
 
-              <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-                <div className="space-y-3 px-4 pb-4">
-                  <div>
-                    <p className="mb-2 font-medium text-muted-foreground text-xs">
-                      Template (click to copy):
-                    </p>
-                    <div className="relative">
-                      <pre className="styled-scrollbar overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-border bg-accent/50 p-4 text-foreground text-xs">
-                        {templates[section.key].template}
-                      </pre>
-                      <Button
-                        variant="outline"
-                        size="icon-sm"
-                        onClick={() => copyTemplate(section.key)}
-                        className="absolute top-3 right-3"
-                        title="Copy template"
-                      >
-                        {copiedSection === section.key ? (
-                          <Check className="h-4 w-4 text-green-500" />
-                        ) : (
-                          <Copy className="h-4 w-4 text-muted-foreground" />
-                        )}
-                      </Button>
-                    </div>
+          <TabsContent value="memory" className="space-y-6">
+            <Card className="gap-0 py-0">
+              <CardHeader className="border-b py-5">
+                <CardTitle>Memory Model</CardTitle>
+                <CardDescription>
+                  Core memory holds durable facts. Daily memory captures recent
+                  notes and expires automatically.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-3 py-5 md:grid-cols-3">
+                <div className="rounded-2xl border border-border/60 bg-muted/20 p-4">
+                  <div className="flex items-center gap-2 font-medium text-sm">
+                    <Brain className="h-4 w-4 text-orange-500" />
+                    Core memory
                   </div>
-
-                  <div>
-                    <p className="mb-2 font-medium text-muted-foreground text-xs">
-                      Example:
-                    </p>
-                    <pre className="styled-scrollbar overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-border/30 bg-muted/30 p-4 text-muted-foreground text-xs">
-                      {templates[section.key].example}
-                    </pre>
-                  </div>
-
-                  <p className="text-muted-foreground text-xs">
-                    Click the copy button to add this template to your
-                    clipboard, then paste it into the text area above and
-                    customize it.
+                  <p className="mt-2 text-muted-foreground text-sm leading-6">
+                    Stable facts about you, your projects, tools, people, and
+                    preferences.
                   </p>
                 </div>
-              </CollapsibleContent>
-            </Collapsible>
-          ))}
-        </div>
+                <div className="rounded-2xl border border-border/60 bg-muted/20 p-4">
+                  <div className="flex items-center gap-2 font-medium text-sm">
+                    <Clock3 className="h-4 w-4 text-orange-500" />
+                    Daily memory
+                  </div>
+                  <p className="mt-2 text-muted-foreground text-sm leading-6">
+                    Session notes and recent context saved into date-based
+                    markdown files.
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-border/60 bg-muted/20 p-4">
+                  <div className="flex items-center gap-2 font-medium text-sm">
+                    <Sparkles className="h-4 w-4 text-orange-500" />
+                    Agent soul
+                  </div>
+                  <p className="mt-2 text-muted-foreground text-sm leading-6">
+                    Tone, behavior, and boundaries. Keep it separate from
+                    factual memory.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            {error ? (
+              <div className="rounded-2xl border border-destructive/40 bg-destructive/5 p-5">
+                <p className="font-medium text-destructive text-sm">
+                  Could not load memory from the local BrowserOS server.
+                </p>
+                <p className="mt-1 text-muted-foreground text-sm">
+                  Make sure the BrowserOS server is running, then refresh.
+                </p>
+                <Button
+                  variant="outline"
+                  className="mt-4"
+                  onClick={() => void refetch()}
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  Retry
+                </Button>
+              </div>
+            ) : null}
+
+            <Card className="gap-0 py-0">
+              <CardHeader className="border-b py-5">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <CardTitle>Core Memory</CardTitle>
+                    <Badge variant="outline">CORE.md</Badge>
+                    <Badge variant="secondary">Editable</Badge>
+                    {isCoreDirty ? (
+                      <Badge variant="secondary">Unsaved</Badge>
+                    ) : null}
+                  </div>
+                  <CardDescription className="mt-2">
+                    Add or refine the durable facts you want BrowserOS to keep.
+                  </CardDescription>
+                </div>
+                <CardAction className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void refetch()}
+                    disabled={isLoading}
+                  >
+                    <RefreshCw
+                      className={cn('h-4 w-4', isLoading && 'animate-spin')}
+                    />
+                    Refresh
+                  </Button>
+                </CardAction>
+              </CardHeader>
+              <CardContent className="space-y-4 py-5">
+                {isLoading && !memory ? (
+                  <div className="flex min-h-48 items-center justify-center rounded-2xl border border-border/60 bg-muted/20">
+                    <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : (
+                  <Tabs
+                    value={coreView}
+                    onValueChange={(value) => setCoreView(value as CoreView)}
+                  >
+                    <TabsList>
+                      <TabsTrigger value="preview">Preview</TabsTrigger>
+                      <TabsTrigger value="edit">Edit</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="preview">
+                      <MarkdownPreview
+                        content={coreDraft}
+                        emptyMessage="Core memory is empty. Add durable facts you want the agent to keep."
+                      />
+                    </TabsContent>
+                    <TabsContent value="edit">
+                      <Textarea
+                        value={coreDraft}
+                        onChange={(event) => setCoreDraft(event.target.value)}
+                        placeholder="Write stable facts you want BrowserOS to remember. Markdown is supported."
+                        className="styled-scrollbar min-h-80 resize-y rounded-2xl border-border/70 bg-muted/10 px-4 py-3"
+                      />
+                    </TabsContent>
+                  </Tabs>
+                )}
+
+                <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-muted-foreground text-sm">
+                    Facts belong here. Behavior and tone belong in Agent Soul.
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="ghost"
+                      onClick={() => setCoreDraft(lastLoadedCore.current)}
+                      disabled={!isCoreDirty || isSavingCore}
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                      Reset
+                    </Button>
+                    <Button
+                      onClick={() => void handleSaveCore()}
+                      disabled={!isCoreDirty || isSavingCore || !!error}
+                    >
+                      {isSavingCore ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Save className="h-4 w-4" />
+                      )}
+                      Save core memory
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="gap-0 py-0">
+              <CardHeader className="border-b py-5">
+                <CardTitle>Daily Memory</CardTitle>
+                <CardDescription>
+                  Recent notes the agent has saved. Files rotate automatically
+                  after {memory?.retentionDays ?? 30} days.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="py-5">
+                {isLoading && !memory ? (
+                  <div className="flex min-h-48 items-center justify-center rounded-2xl border border-border/60 bg-muted/20">
+                    <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : dailyMemoryCount === 0 ? (
+                  <div className="rounded-2xl border border-border/70 border-dashed bg-muted/20 px-6 py-12 text-center">
+                    <Clock3 className="mx-auto h-6 w-6 text-muted-foreground/70" />
+                    <p className="mt-3 font-medium text-sm">
+                      No daily memories yet
+                    </p>
+                    <p className="mt-1 text-muted-foreground text-sm">
+                      As the agent saves recent context, date-based markdown
+                      files will appear here.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="grid gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
+                    <ScrollArea className="h-[420px] rounded-2xl border border-border/60 bg-muted/10 p-2">
+                      <div className="space-y-2 pr-3">
+                        {memory?.dailyMemories.map((item) => (
+                          <DailyMemoryButton
+                            key={item.fileName}
+                            item={item}
+                            selected={item.fileName === selectedDailyFile}
+                            onSelect={setSelectedDailyFile}
+                          />
+                        ))}
+                      </div>
+                    </ScrollArea>
+
+                    <div className="space-y-3 rounded-2xl border border-border/60 bg-muted/10 p-4">
+                      <div className="flex items-center justify-between gap-2">
+                        <div>
+                          <p className="font-medium text-sm">
+                            {selectedDailyMemory
+                              ? formatMemoryDate(selectedDailyMemory.date)
+                              : 'Select a file'}
+                          </p>
+                          <p className="text-muted-foreground text-xs">
+                            {selectedDailyMemory?.fileName ?? ''}
+                          </p>
+                        </div>
+                        {selectedDailyMemory?.date === todayDate ? (
+                          <Badge variant="secondary">Today</Badge>
+                        ) : null}
+                      </div>
+                      <MarkdownPreview
+                        content={selectedDailyMemory?.content ?? ''}
+                        className="min-h-[340px]"
+                        emptyMessage="Select a daily memory file to inspect its contents."
+                      />
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="prompt" className="space-y-6">
+            <Card className="gap-0 py-0">
+              <CardHeader className="border-b py-5">
+                <CardTitle>Live Personalization Prompt</CardTitle>
+                <CardDescription>
+                  This stays local and is injected into chat directly. Use it
+                  for immediate instructions or context you always want present.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 py-5">
+                <div className="space-y-3">
+                  <Label htmlFor="personalization">Your information</Label>
+                  <Textarea
+                    id="personalization"
+                    value={personalization}
+                    onChange={(event) => setPersonalization(event.target.value)}
+                    placeholder="Tell BrowserOS about yourself... (Supports Markdown)"
+                    className="styled-scrollbar h-96 resize-none rounded-2xl border-2 border-border/50 bg-card px-4 py-3 transition-transform placeholder:text-muted-foreground focus:border-orange-500/30 focus:ring-4 focus:ring-orange-500/10"
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    This prompt is saved locally and never leaves your device
+                    until BrowserOS includes it in your chat request.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <PromptTemplates />
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   )

--- a/apps/agent/entrypoints/newtab/personalize/PromptTemplates.tsx
+++ b/apps/agent/entrypoints/newtab/personalize/PromptTemplates.tsx
@@ -1,0 +1,122 @@
+import { Check, ChevronDown, Copy } from 'lucide-react'
+import { type FC, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { templates } from './templates'
+
+const sections = [
+  {
+    key: 'aboutYou' as const,
+    title: 'Add more info about you',
+    description: 'Help BrowserOS understand who you are',
+  },
+  {
+    key: 'expectations' as const,
+    title: 'What you expect from the browser',
+    description: 'Share your preferences and needs',
+  },
+  {
+    key: 'commonActions' as const,
+    title: 'Your commonly performed actions',
+    description: 'Describe your daily workflows',
+  },
+]
+
+export const PromptTemplates: FC = () => {
+  const [expandedSection, setExpandedSection] = useState<string | null>(
+    sections[0].key,
+  )
+  const [copiedSection, setCopiedSection] = useState<string | null>(null)
+
+  const copyTemplate = (templateKey: keyof typeof templates) => {
+    const template = templates[templateKey].template
+    navigator.clipboard.writeText(template)
+    setCopiedSection(templateKey)
+    setTimeout(() => setCopiedSection(null), 2000)
+  }
+
+  return (
+    <div className="space-y-3">
+      <h2 className="font-semibold text-muted-foreground text-sm uppercase tracking-wide">
+        Need help getting started?
+      </h2>
+      <div className="space-y-2">
+        {sections.map((section) => (
+          <Collapsible
+            key={section.key}
+            open={expandedSection === section.key}
+            onOpenChange={(open) =>
+              setExpandedSection(open ? section.key : null)
+            }
+            className="w-full rounded-xl border border-border/50 bg-card hover:border-border"
+          >
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="ghost"
+                className="flex h-auto w-full items-center justify-between p-4 text-left hover:bg-accent/50"
+              >
+                <div className="flex-1">
+                  <h3 className="mb-1 font-medium text-foreground text-sm">
+                    {section.title}
+                  </h3>
+                  <p className="text-muted-foreground text-xs">
+                    {section.description}
+                  </p>
+                </div>
+                <ChevronDown
+                  className={`h-5 w-5 shrink-0 text-muted-foreground transition-transform duration-200 ${expandedSection === section.key ? 'rotate-180' : ''}`}
+                />
+              </Button>
+            </CollapsibleTrigger>
+
+            <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+              <div className="space-y-3 px-4 pb-4">
+                <div>
+                  <p className="mb-2 font-medium text-muted-foreground text-xs">
+                    Template (click to copy):
+                  </p>
+                  <div className="relative">
+                    <pre className="styled-scrollbar overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-border bg-accent/50 p-4 text-foreground text-xs">
+                      {templates[section.key].template}
+                    </pre>
+                    <Button
+                      variant="outline"
+                      size="icon-sm"
+                      onClick={() => copyTemplate(section.key)}
+                      className="absolute top-3 right-3"
+                      title="Copy template"
+                    >
+                      {copiedSection === section.key ? (
+                        <Check className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <Copy className="h-4 w-4 text-muted-foreground" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+
+                <div>
+                  <p className="mb-2 font-medium text-muted-foreground text-xs">
+                    Example:
+                  </p>
+                  <pre className="styled-scrollbar overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-border/30 bg-muted/30 p-4 text-muted-foreground text-xs">
+                    {templates[section.key].example}
+                  </pre>
+                </div>
+
+                <p className="text-muted-foreground text-xs">
+                  Copy a template, paste it into your prompt, and tailor it to
+                  how you want BrowserOS to respond.
+                </p>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/newtab/personalize/useMemory.ts
+++ b/apps/agent/entrypoints/newtab/personalize/useMemory.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
+
+export interface DailyMemoryFile {
+  fileName: string
+  date: string
+  content: string
+}
+
+export interface MemorySnapshot {
+  coreMemory: string
+  dailyMemories: DailyMemoryFile[]
+  retentionDays: number
+}
+
+const MEMORY_QUERY_KEY = 'memory'
+
+async function fetchMemory(baseUrl: string): Promise<MemorySnapshot> {
+  const response = await fetch(`${baseUrl}/memory`)
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  return response.json()
+}
+
+async function updateCoreMemory(baseUrl: string, content: string) {
+  const response = await fetch(`${baseUrl}/memory/core`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.error || `HTTP ${response.status}`)
+  }
+}
+
+export function useMemory() {
+  const {
+    baseUrl,
+    isLoading: urlLoading,
+    error: urlError,
+  } = useAgentServerUrl()
+  const queryClient = useQueryClient()
+  const queryKey = [MEMORY_QUERY_KEY, baseUrl]
+
+  const { data, isLoading, error, refetch } = useQuery<MemorySnapshot, Error>({
+    queryKey,
+    queryFn: () => fetchMemory(baseUrl as string),
+    enabled: !!baseUrl && !urlLoading,
+  })
+
+  const saveCoreMutation = useMutation({
+    mutationFn: async (content: string) => {
+      if (!baseUrl) throw new Error('BrowserOS server URL is unavailable')
+      await updateCoreMemory(baseUrl, content)
+      return content
+    },
+    onSuccess: (content) => {
+      queryClient.setQueryData<MemorySnapshot | undefined>(
+        queryKey,
+        (current) => (current ? { ...current, coreMemory: content } : current),
+      )
+    },
+  })
+
+  return {
+    memory: data ?? null,
+    isLoading: isLoading || urlLoading,
+    error: error ?? urlError,
+    refetch,
+    saveCoreMemory: saveCoreMutation.mutateAsync,
+    isSavingCore: saveCoreMutation.isPending,
+  }
+}

--- a/apps/server/src/api/routes/memory.ts
+++ b/apps/server/src/api/routes/memory.ts
@@ -1,0 +1,21 @@
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { readMemorySnapshot, saveCoreMemory } from '../../lib/memory'
+
+const UpdateCoreMemorySchema = z.object({
+  content: z.string().max(200_000),
+})
+
+export function createMemoryRoutes() {
+  return new Hono()
+    .get('/', async (c) => {
+      const memory = await readMemorySnapshot()
+      return c.json(memory)
+    })
+    .put('/core', zValidator('json', UpdateCoreMemorySchema), async (c) => {
+      const { content } = c.req.valid('json')
+      await saveCoreMemory(content)
+      return c.json({ ok: true })
+    })
+}

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -21,6 +21,7 @@ import { createGraphRoutes } from './routes/graph'
 import { createHealthRoute } from './routes/health'
 import { createKlavisRoutes } from './routes/klavis'
 import { createMcpRoutes } from './routes/mcp'
+import { createMemoryRoutes } from './routes/memory'
 import { createProviderRoutes } from './routes/provider'
 import { createSdkRoutes } from './routes/sdk'
 import { createShutdownRoute } from './routes/shutdown'
@@ -109,6 +110,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     )
     .route('/status', createStatusRoute({ controller }))
     .route('/soul', createSoulRoutes())
+    .route('/memory', createMemoryRoutes())
     .route('/skills', createSkillsRoutes())
     .route('/test-provider', createProviderRoutes())
     .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))

--- a/apps/server/src/lib/memory.ts
+++ b/apps/server/src/lib/memory.ts
@@ -1,0 +1,125 @@
+import { appendFile, readdir, readFile, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
+import { PATHS } from '@browseros/shared/constants/paths'
+import {
+  ensureBrowserosDir,
+  getCoreMemoryPath,
+  getMemoryDir,
+} from './browseros-dir'
+
+const DAILY_MEMORY_FILE_PATTERN = /^(\d{4}-\d{2}-\d{2})\.md$/
+
+export interface DailyMemoryFile {
+  fileName: string
+  date: string
+  content: string
+}
+
+export interface MemorySnapshot {
+  coreMemory: string
+  dailyMemories: DailyMemoryFile[]
+  retentionDays: number
+}
+
+function formatDateParts(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function getTodayMemoryFileName(date = new Date()): string {
+  return `${formatDateParts(date)}.md`
+}
+
+export function getCurrentMemoryTimestamp(date = new Date()): string {
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${hours}:${minutes}`
+}
+
+async function listMemoryFiles(): Promise<string[]> {
+  try {
+    return await readdir(getMemoryDir())
+  } catch {
+    return []
+  }
+}
+
+export async function cleanOldDailyMemories(): Promise<void> {
+  const files = await listMemoryFiles()
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - PATHS.MEMORY_RETENTION_DAYS)
+  const cutoffDate = formatDateParts(cutoff)
+
+  for (const file of files) {
+    const match = file.match(DAILY_MEMORY_FILE_PATTERN)
+    if (!match || match[1] >= cutoffDate) continue
+    try {
+      await unlink(join(getMemoryDir(), file))
+    } catch {}
+  }
+}
+
+export async function appendDailyMemory(content: string): Promise<string> {
+  await ensureBrowserosDir()
+  const fileName = getTodayMemoryFileName()
+  const filePath = join(getMemoryDir(), fileName)
+  const entry = `\n## ${getCurrentMemoryTimestamp()}\n\n${content}\n`
+
+  await appendFile(filePath, entry, 'utf-8')
+  await cleanOldDailyMemories()
+
+  return fileName
+}
+
+export async function readCoreMemory(): Promise<string> {
+  const file = Bun.file(getCoreMemoryPath())
+  if (!(await file.exists())) return ''
+  return file.text()
+}
+
+export async function saveCoreMemory(content: string): Promise<void> {
+  await ensureBrowserosDir()
+  await Bun.write(getCoreMemoryPath(), content)
+}
+
+export async function listDailyMemories(): Promise<DailyMemoryFile[]> {
+  const files = await listMemoryFiles()
+  const dailyFiles = files
+    .map((fileName) => {
+      const match = fileName.match(DAILY_MEMORY_FILE_PATTERN)
+      if (!match) return null
+      return { fileName, date: match[1] }
+    })
+    .filter(
+      (entry): entry is { fileName: string; date: string } => entry !== null,
+    )
+    .sort((a, b) => b.date.localeCompare(a.date))
+
+  const memories: DailyMemoryFile[] = []
+  for (const dailyFile of dailyFiles) {
+    try {
+      const content = await readFile(
+        join(getMemoryDir(), dailyFile.fileName),
+        'utf-8',
+      )
+      memories.push({ ...dailyFile, content })
+    } catch {}
+  }
+
+  return memories
+}
+
+export async function readMemorySnapshot(): Promise<MemorySnapshot> {
+  const [coreMemory, dailyMemories] = await Promise.all([
+    readCoreMemory(),
+    listDailyMemories(),
+  ])
+
+  return {
+    coreMemory,
+    dailyMemories,
+    retentionDays: PATHS.MEMORY_RETENTION_DAYS,
+  }
+}

--- a/apps/server/src/tools/memory/read-core.ts
+++ b/apps/server/src/tools/memory/read-core.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai'
 import { z } from 'zod'
-import { getCoreMemoryPath } from '../../lib/browseros-dir'
+import { readCoreMemory } from '../../lib/memory'
 import { executeWithMetrics, toModelOutput } from '../filesystem/utils'
 
 const TOOL_NAME = 'memory_read_core'
@@ -12,13 +12,9 @@ export function createReadCoreTool() {
     inputSchema: z.object({}),
     execute: () =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const file = Bun.file(getCoreMemoryPath())
-        if (!(await file.exists())) {
-          return { text: 'No core memories yet.' }
-        }
-        const content = await file.text()
+        const content = await readCoreMemory()
         if (!content.trim()) {
-          return { text: 'Core memory file is empty.' }
+          return { text: 'No core memories yet.' }
         }
         return { text: content }
       }),

--- a/apps/server/src/tools/memory/save-core.ts
+++ b/apps/server/src/tools/memory/save-core.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai'
 import { z } from 'zod'
-import { getCoreMemoryPath } from '../../lib/browseros-dir'
+import { saveCoreMemory } from '../../lib/memory'
 import { executeWithMetrics, toModelOutput } from '../filesystem/utils'
 
 const TOOL_NAME = 'memory_save_core'
@@ -14,7 +14,7 @@ export function createSaveCoreTool() {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        await Bun.write(getCoreMemoryPath(), params.content)
+        await saveCoreMemory(params.content)
         return { text: 'Core memories updated.' }
       }),
     toModelOutput,

--- a/apps/server/src/tools/memory/write.ts
+++ b/apps/server/src/tools/memory/write.ts
@@ -1,52 +1,9 @@
-import { appendFile, readdir, unlink } from 'node:fs/promises'
-import { join } from 'node:path'
-import { PATHS } from '@browseros/shared/constants/paths'
 import { tool } from 'ai'
 import { z } from 'zod'
-import { getMemoryDir } from '../../lib/browseros-dir'
+import { appendDailyMemory } from '../../lib/memory'
 import { executeWithMetrics, toModelOutput } from '../filesystem/utils'
 
 const TOOL_NAME = 'memory_write'
-
-function getTodayFileName(): string {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}.md`
-}
-
-function getCurrentTime(): string {
-  const now = new Date()
-  return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
-}
-
-async function cleanOldMemories(memoryDir: string): Promise<void> {
-  let files: string[]
-  try {
-    files = await readdir(memoryDir)
-  } catch {
-    return
-  }
-
-  const cutoff = new Date()
-  cutoff.setDate(cutoff.getDate() - PATHS.MEMORY_RETENTION_DAYS)
-  const year = cutoff.getFullYear()
-  const month = String(cutoff.getMonth() + 1).padStart(2, '0')
-  const day = String(cutoff.getDate()).padStart(2, '0')
-  const cutoffStr = `${year}-${month}-${day}`
-
-  for (const file of files) {
-    const match = file.match(/^(\d{4}-\d{2}-\d{2})\.md$/)
-    if (match && match[1] < cutoffStr) {
-      try {
-        await unlink(join(memoryDir, file))
-      } catch {
-        // skip if already removed
-      }
-    }
-  }
-}
 
 export function createMemoryWriteTool() {
   return tool({
@@ -57,15 +14,8 @@ export function createMemoryWriteTool() {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const memoryDir = getMemoryDir()
-        const filePath = join(memoryDir, getTodayFileName())
-        const entry = `\n## ${getCurrentTime()}\n\n${params.content}\n`
-
-        await appendFile(filePath, entry, 'utf-8')
-
-        await cleanOldMemories(memoryDir)
-
-        return { text: `Memory saved to ${getTodayFileName()}` }
+        const fileName = await appendDailyMemory(params.content)
+        return { text: `Memory saved to ${fileName}` }
       }),
     toModelOutput,
   })


### PR DESCRIPTION
## Summary
- Show core and daily memory in the Personalize workspace using the existing markdown memory files.
- Allow direct editing and saving of `CORE.md` while keeping daily memory browsable and read-only.
- Preserve the local personalization prompt and clearly separate prompt, memory, and Agent Soul.

## Design
This change adds a thin Hono memory API over the existing `~/.browseros/memory` files and reworks the Personalize page into a memory-first workspace. The UI keeps the current local prompt flow intact, adds a server-backed core memory editor with markdown preview, and adds a daily-memory browser with clean empty/error states.

## Test Plan
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run --filter @browseros/agent build:dev`