### PR TITLE
feat: refine new tab suggestion overflow

### DIFF
--- a/apps/agent/entrypoints/newtab/index/SearchSuggestions.tsx
+++ b/apps/agent/entrypoints/newtab/index/SearchSuggestions.tsx
@@ -37,8 +37,10 @@ const SuggestionItemRenderer: FC<{
     case 'search':
       return (
         <li className={baseClassName} {...getItemProps({ item, index })}>
-          <Search className="h-4 w-4 text-muted-foreground" />
-          {item.query}
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate" title={item.query}>
+            {item.query}
+          </span>
         </li>
       )
 
@@ -64,9 +66,14 @@ const SuggestionItemRenderer: FC<{
     case 'browseros':
       return (
         <li className={baseClassName} {...getItemProps({ item, index })}>
-          <Sparkles className="h-4 w-4 text-muted-foreground" />
-          <span className="font-semibold">Ask BrowserOS:</span>
-          {item.message || 'Type a message...'}
+          <Sparkles className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="flex-shrink-0 font-semibold">Ask BrowserOS:</span>
+          <span
+            className="min-w-0 flex-1 truncate"
+            title={item.message || 'Type a message...'}
+          >
+            {item.message || 'Type a message...'}
+          </span>
         </li>
       )
   }

--- a/apps/agent/entrypoints/newtab/index/lib/suggestions/useSuggestions.ts
+++ b/apps/agent/entrypoints/newtab/index/lib/suggestions/useSuggestions.ts
@@ -17,12 +17,40 @@ interface UseSuggestionsArgs {
   selectedTabs: chrome.tabs.Tab[]
 }
 
+function buildSearchResults(
+  query: string,
+  searchResultsFromApi: string[] | undefined,
+): string[] {
+  const orderedResults = [query.trim(), ...(searchResultsFromApi ?? [])]
+  const seen = new Set<string>()
+  const dedupedResults: string[] = []
+
+  for (const item of orderedResults) {
+    const normalizedItem = item.trim()
+    if (!normalizedItem) {
+      continue
+    }
+
+    const suggestionKey = normalizedItem.toLowerCase()
+    if (seen.has(suggestionKey)) {
+      continue
+    }
+
+    seen.add(suggestionKey)
+    dedupedResults.push(normalizedItem)
+  }
+
+  return dedupedResults
+}
+
 /**
  * @public
  */
 export const useSuggestions = ({ query, selectedTabs }: UseSuggestionsArgs) => {
   const { provider } = useSearchProvider()
   const providerConfig = getProviderConfig(provider)
+  const trimmedQuery = query.trim()
+  const hasQuery = trimmedQuery.length > 0
 
   const { data: searchResultsFromAPI } = useSearchSuggestions({
     query,
@@ -30,20 +58,16 @@ export const useSuggestions = ({ query, selectedTabs }: UseSuggestionsArgs) => {
   })
 
   const searchResults: string[] = useMemo(() => {
-    const results = [...(searchResultsFromAPI ?? [])]
-    if (query && !results.includes(query)) {
-      results.unshift(query)
-    }
-    return results
+    return buildSearchResults(query, searchResultsFromAPI)
   }, [searchResultsFromAPI, query])
 
   const aiTabResults = useAITabSuggestions({ selectedTabs, input: query })
-  const browserOSResults = useBrowserOSSuggestions({ query })
+  const browserOSResults = useBrowserOSSuggestions({ query: trimmedQuery })
 
   const sections = useMemo(() => {
     const result: SuggestionSection[] = []
 
-    if (query && browserOSResults.length > 0) {
+    if (hasQuery && browserOSResults.length > 0) {
       const browserOSItems: BrowserOSSuggestionItem[] = browserOSResults.map(
         (item, index) => ({
           id: `browseros-${index}`,
@@ -77,7 +101,7 @@ export const useSuggestions = ({ query, selectedTabs }: UseSuggestionsArgs) => {
         title: 'AI Actions',
         items: aiItems,
       })
-    } else if (query && searchResults && searchResults.length > 0) {
+    } else if (hasQuery && searchResults.length > 0) {
       const searchItems: SearchSuggestionItem[] = searchResults.map(
         (item, index) => ({
           id: `search-${index}`,
@@ -94,7 +118,7 @@ export const useSuggestions = ({ query, selectedTabs }: UseSuggestionsArgs) => {
 
     return result
   }, [
-    query,
+    hasQuery,
     browserOSResults,
     selectedTabs.length,
     aiTabResults,


### PR DESCRIPTION
## Summary
- keep the Ask BrowserOS suggestion visually unchanged while constraining long prompt text to a single line
- always place the current user query first in the search suggestions list after trimming and de-duplicating provider results
- avoid duplicate exact-query suggestions caused by whitespace or case-only variants from the provider API

## Design
This keeps the existing new-tab suggestion flow intact.  remains responsible for section ordering and now normalizes the raw query before injecting it into the search section, while  preserves the current BrowserOS row styling and only adds bounded text containers so long rows truncate instead of expanding the UI.

## Test plan
- Checked 2 files in 6ms. No fixes applied.
- 
- @browseros/agent build: $ bun --env-file=.env.development graphql-codegen --config codegen.ts
@browseros/agent build: ❯ Parse Configuration
@browseros/agent build: ✔ Parse Configuration
@browseros/agent build: ❯ Generate outputs
@browseros/agent build: ❯ Generate to ./generated/graphql/
@browseros/agent build: ❯ Generate to ./generated/graphql/schema.graphql
@browseros/agent build: ❯ Load GraphQL schemas
@browseros/agent build: ❯ Load GraphQL schemas
@browseros/agent build: ✔ Load GraphQL schemas
@browseros/agent build: ✔ Load GraphQL schemas
@browseros/agent build: ❯ Load GraphQL documents
@browseros/agent build: ❯ Load GraphQL documents
@browseros/agent build: ✔ Load GraphQL documents
@browseros/agent build: ❯ Generate
@browseros/agent build: ✔ Generate
@browseros/agent build: ✔ Generate to ./generated/graphql/schema.graphql
@browseros/agent build: ✔ Load GraphQL documents
@browseros/agent build: ❯ Generate
@browseros/agent build: ✔ Generate
@browseros/agent build: ✔ Generate to ./generated/graphql/
@browseros/agent build: ✔ Generate outputs
@browseros/agent build: 
@browseros/agent build: WXT 0.20.18
@browseros/agent build: ✖ Command failed after 129 ms
@browseros/agent build: 
@browseros/agent build:  ERROR  Invalid URL
@browseros/agent build: 
@browseros/agent build:     at new URL (node:internal/url:825:25)
@browseros/agent build:     at wxt.config.ts:11:16
@browseros/agent build:     at async Function.import (/Users/shadowfax/code/browseros-project/mono/.grove/worktrees/fix/search-ui-update/node_modules/.bun/jiti@2.6.1/node_modules/jiti/dist/jiti.cjs:1:158301)
@browseros/agent build:     at async resolveConfig (/Users/shadowfax/code/browseros-project/mono/.grove/worktrees/fix/search-ui-update/node_modules/.bun/c12@3.3.3+2c01c9708b757763/node_modules/c12/dist/index.mjs:320:20)
@browseros/agent build:     at async loadConfig (/Users/shadowfax/code/browseros-project/mono/.grove/worktrees/fix/search-ui-update/node_modules/.bun/c12@3.3.3+2c01c9708b757763/node_modules/c12/dist/index.mjs:149:22)
@browseros/agent build:     at async resolveConfig (/Users/shadowfax/code/browseros-project/mono/.grove/worktrees/fix/search-ui-update/node_modules/.bun/wxt@0.20.18+37e7607934d5e788/node_modules/wxt/dist/core/resolve-config.mjs:30:49)
@browseros/agent build:     at async registerWxt (/Users/shadowfax/code/browseros-project/mono/.grove/worktrees/fix/search-ui-update/node_modules/.bun/wxt@0.20.18+37e7607934d5e788/node_modules/wxt/dist/core/wxt.mjs:20:17)
@browseros/agent build:     at async build (/Users/shadowfax/code/browseros-project/mono/.grove/worktrees/fix/search-ui-update/node_modules/.bun/wxt@0.20.18+37e7607934d5e788/node_modules/wxt/dist/core/build.mjs:20:2)
@browseros/agent build:     at async /Users/shadowfax/code/browseros-project/mono/.grove/worktrees/fix/search-ui-update/node_modules/.bun/wxt@0.20.18+37e7607934d5e788/node_modules/wxt/dist/cli/commands.mjs:32:2
@browseros/agent build:     at async CAC.<anonymous> (/Users/shadowfax/code/browseros-project/mono/.grove/worktrees/fix/search-ui-update/node_modules/.bun/wxt@0.20.18+37e7607934d5e788/node_modules/wxt/dist/cli/cli-utils.mjs:22:10)
@browseros/agent build: 
@browseros/agent build: Exited with code 1 currently fails in local env with  from  /  before app compilation