### PR TITLE
feat: add core memory sidepanel

### DIFF
--- a/apps/agent/components/elements/markdown-document.tsx
+++ b/apps/agent/components/elements/markdown-document.tsx
@@ -1,0 +1,30 @@
+import type { ComponentProps } from 'react'
+import { memo } from 'react'
+import type { BundledTheme } from 'shiki'
+import { Streamdown } from 'streamdown'
+import { cn } from '@/lib/utils'
+
+const themes = ['catppuccin-latte', 'catppuccin-mocha'] as [
+  BundledTheme,
+  BundledTheme,
+]
+
+export type MarkdownDocumentProps = ComponentProps<typeof Streamdown>
+
+export const MarkdownDocument = memo(
+  ({ className, ...props }: MarkdownDocumentProps) => (
+    <Streamdown
+      className={cn(
+        'size-full break-words text-sm leading-7 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_[data-streamdown="code-block"]]:w-full! [&_[data-streamdown="table-wrapper"]]:w-full!',
+        className,
+      )}
+      shikiTheme={themes}
+      {...props}
+    />
+  ),
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children &&
+    prevProps.className === nextProps.className,
+)
+
+MarkdownDocument.displayName = 'MarkdownDocument'

--- a/apps/agent/entrypoints/app/soul/SoulViewer.tsx
+++ b/apps/agent/entrypoints/app/soul/SoulViewer.tsx
@@ -1,5 +1,6 @@
 import { FileText, Loader2 } from 'lucide-react'
 import type { FC } from 'react'
+import { MarkdownDocument } from '@/components/elements/markdown-document'
 import { useSoulContent } from './useSoulContent'
 
 export const SoulViewer: FC = () => {
@@ -52,9 +53,9 @@ export const SoulViewer: FC = () => {
           <span className="text-muted-foreground text-xs">read-only</span>
         </div>
       </div>
-      <pre className="overflow-x-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
-        {content}
-      </pre>
+      <div className="px-4 py-4">
+        <MarkdownDocument>{content}</MarkdownDocument>
+      </div>
     </div>
   )
 }

--- a/apps/agent/entrypoints/sidepanel/App.tsx
+++ b/apps/agent/entrypoints/sidepanel/App.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Route, Routes } from 'react-router'
 import { ChatHistory } from './history/ChatHistory'
 import { Chat } from './index/Chat'
 import { ChatLayout } from './layout/ChatLayout'
+import { CoreMemoryPage } from './memory/CoreMemoryPage'
 
 export const App: FC = () => {
   return (
@@ -11,6 +12,7 @@ export const App: FC = () => {
         <Route element={<ChatLayout />}>
           <Route index element={<Chat />} />
           <Route path="history" element={<ChatHistory />} />
+          <Route path="memory" element={<CoreMemoryPage />} />
         </Route>
       </Routes>
     </HashRouter>

--- a/apps/agent/entrypoints/sidepanel/index/ChatHeader.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/ChatHeader.tsx
@@ -1,4 +1,4 @@
-import { Github, History, Plus, SettingsIcon } from 'lucide-react'
+import { Brain, Github, History, Plus, SettingsIcon } from 'lucide-react'
 import type { FC } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 import { ChatProviderSelector } from '@/components/chat/ChatProviderSelector'
@@ -7,6 +7,7 @@ import { ThemeToggle } from '@/components/elements/theme-toggle'
 import { productRepositoryUrl } from '@/lib/constants/productUrls'
 import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderType } from '@/lib/llm-providers/types'
+import { cn } from '@/lib/utils'
 
 interface ChatHeaderProps {
   selectedProvider: Provider
@@ -26,8 +27,10 @@ export const ChatHeader: FC<ChatHeaderProps> = ({
   const location = useLocation()
   const navigate = useNavigate()
   const isHistoryPage = location.pathname === '/history'
+  const isMemoryPage = location.pathname === '/memory'
+  const isChatPage = !isHistoryPage && !isMemoryPage
 
-  const handleNewConversationFromHistory = () => {
+  const handleNewConversation = () => {
     onNewConversation()
     navigate('/')
   }
@@ -62,10 +65,10 @@ export const ChatHeader: FC<ChatHeaderProps> = ({
       </div>
 
       <div className="flex items-center gap-1">
-        {!isHistoryPage && hasMessages && (
+        {(isChatPage ? hasMessages : true) && (
           <button
             type="button"
-            onClick={onNewConversation}
+            onClick={handleNewConversation}
             className="cursor-pointer rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
             title="New conversation"
           >
@@ -73,24 +76,27 @@ export const ChatHeader: FC<ChatHeaderProps> = ({
           </button>
         )}
 
-        {isHistoryPage ? (
-          <button
-            type="button"
-            onClick={handleNewConversationFromHistory}
-            className="cursor-pointer rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-            title="New conversation"
-          >
-            <Plus className="h-4 w-4" />
-          </button>
-        ) : (
-          <Link
-            to="/history"
-            className="cursor-pointer rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-            title="Chat history"
-          >
-            <History className="h-4 w-4" />
-          </Link>
-        )}
+        <Link
+          to="/history"
+          className={cn(
+            'cursor-pointer rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground',
+            isHistoryPage && 'bg-muted/70 text-foreground',
+          )}
+          title="Chat history"
+        >
+          <History className="h-4 w-4" />
+        </Link>
+
+        <Link
+          to="/memory"
+          className={cn(
+            'cursor-pointer rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground',
+            isMemoryPage && 'bg-muted/70 text-foreground',
+          )}
+          title="Core memory"
+        >
+          <Brain className="h-4 w-4" />
+        </Link>
 
         <a
           href={productRepositoryUrl}

--- a/apps/agent/entrypoints/sidepanel/memory/CoreMemoryPage.tsx
+++ b/apps/agent/entrypoints/sidepanel/memory/CoreMemoryPage.tsx
@@ -1,0 +1,236 @@
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import {
+  AlertCircle,
+  Brain,
+  FileText,
+  Loader2,
+  PencilLine,
+  RefreshCw,
+  Save,
+  X,
+} from 'lucide-react'
+import { type FC, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { MarkdownDocument } from '@/components/elements/markdown-document'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { useCoreMemory } from './useCoreMemory'
+
+dayjs.extend(relativeTime)
+
+const EMPTY_STATE_ITEMS = [
+  'Your name, role, and working context',
+  'Long-lived project details or constraints',
+  'Preferences the agent should consistently remember',
+]
+
+export const CoreMemoryPage: FC = () => {
+  const { memory, isLoading, error, refetch, saveMemory, isSaving } =
+    useCoreMemory()
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState('')
+
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(memory?.content ?? '')
+    }
+  }, [memory?.content, isEditing])
+
+  const currentContent = memory?.content ?? ''
+  const hasContent = currentContent.trim().length > 0
+  const hasUnsavedChanges = draft !== currentContent
+  const updatedLabel = memory?.updatedAt
+    ? `Updated ${dayjs(memory.updatedAt).fromNow()}`
+    : memory?.exists
+      ? 'Saved locally'
+      : 'Not created yet'
+
+  const handleEdit = () => {
+    setDraft(currentContent)
+    setIsEditing(true)
+  }
+
+  const handleCancel = () => {
+    setDraft(currentContent)
+    setIsEditing(false)
+  }
+
+  const handleSave = async () => {
+    try {
+      await saveMemory(draft)
+      toast.success('Core memory saved')
+      setIsEditing(false)
+    } catch {
+      toast.error('Failed to save core memory')
+    }
+  }
+
+  return (
+    <main className="mt-4 flex h-full flex-1 flex-col overflow-y-auto">
+      <div className="fade-in slide-in-from-bottom-2 flex w-full flex-1 animate-in flex-col gap-4 p-3 duration-300">
+        <section className="overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-card via-card to-muted/40 shadow-sm">
+          <div className="flex items-start justify-between gap-3 p-4">
+            <div className="min-w-0 space-y-3">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-[var(--accent-orange)]/12 text-[var(--accent-orange)]">
+                  <Brain className="h-5 w-5" />
+                </div>
+                <div className="min-w-0">
+                  <p className="font-semibold text-sm">Core Memory</p>
+                  <p className="text-muted-foreground text-xs leading-5">
+                    Durable facts the agent should retain across sessions.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+                <span className="rounded-full border border-border/60 bg-background/70 px-2.5 py-1">
+                  CORE.md
+                </span>
+                <span className="rounded-full border border-border/60 bg-background/70 px-2.5 py-1">
+                  Markdown supported
+                </span>
+                <span className="rounded-full border border-border/60 bg-background/70 px-2.5 py-1">
+                  {updatedLabel}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex shrink-0 items-center gap-2">
+              {isEditing ? (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCancel}
+                    disabled={isSaving}
+                  >
+                    <X className="size-4" />
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={handleSave}
+                    disabled={!hasUnsavedChanges || isSaving}
+                  >
+                    {isSaving ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Save className="size-4" />
+                    )}
+                    Save
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => refetch()}
+                    disabled={isLoading}
+                  >
+                    <RefreshCw className="size-4" />
+                    Refresh
+                  </Button>
+                  <Button size="sm" onClick={handleEdit} disabled={isLoading}>
+                    <PencilLine className="size-4" />
+                    Edit
+                  </Button>
+                </>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {isLoading ? (
+          <section className="flex flex-1 items-center justify-center rounded-2xl border border-border bg-card p-6 shadow-sm">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </section>
+        ) : error ? (
+          <section className="rounded-2xl border border-destructive/40 bg-destructive/5 p-5 shadow-sm">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+              <div className="min-w-0 space-y-3">
+                <div>
+                  <p className="font-medium text-destructive text-sm">
+                    Could not load core memory
+                  </p>
+                  <p className="mt-1 text-muted-foreground text-xs leading-5">
+                    Make sure the BrowserOS server is running and supports the
+                    memory API.
+                  </p>
+                </div>
+                <Button variant="outline" size="sm" onClick={() => refetch()}>
+                  <RefreshCw className="size-4" />
+                  Try again
+                </Button>
+              </div>
+            </div>
+          </section>
+        ) : isEditing ? (
+          <section className="rounded-2xl border border-border bg-card p-4 shadow-sm">
+            <div className="mb-3 flex items-center gap-2 text-muted-foreground text-xs">
+              <FileText className="size-4" />
+              Edit the full `CORE.md` document. Save replaces the current file.
+            </div>
+            <Textarea
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              placeholder="# Core Memory\n\n- Important facts the agent should retain"
+              className="styled-scrollbar min-h-[340px] resize-none rounded-2xl border-border/60 bg-background/80 px-4 py-3 font-mono text-sm leading-6"
+            />
+            <p className="mt-3 text-muted-foreground text-xs leading-5">
+              Keep this focused on durable facts, preferences, and project
+              context. Behavior and tone still belong in SOUL.md.
+            </p>
+          </section>
+        ) : hasContent ? (
+          <section className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+            <div className="border-border/60 border-b px-4 py-3">
+              <div className="flex items-center gap-2">
+                <FileText className="h-4 w-4 text-muted-foreground" />
+                <span className="font-medium text-sm">Current memory</span>
+              </div>
+            </div>
+            <div className="px-4 py-4">
+              <MarkdownDocument>{currentContent}</MarkdownDocument>
+            </div>
+          </section>
+        ) : (
+          <section className="rounded-2xl border border-border/80 border-dashed bg-card/80 p-6 shadow-sm">
+            <div className="flex flex-col items-center gap-4 py-8 text-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-muted/60 text-muted-foreground">
+                <Brain className="h-7 w-7" />
+              </div>
+              <div className="space-y-2">
+                <p className="font-medium text-sm">No core memory yet</p>
+                <p className="max-w-[260px] text-muted-foreground text-xs leading-5">
+                  Add the durable context you want the agent to remember across
+                  conversations.
+                </p>
+              </div>
+              <div className="w-full max-w-[280px] rounded-2xl border border-border/60 bg-background/70 p-4 text-left">
+                <p className="mb-3 font-medium text-[11px] text-muted-foreground uppercase tracking-[0.16em]">
+                  Good things to store
+                </p>
+                <ul className="space-y-2 text-foreground text-sm">
+                  {EMPTY_STATE_ITEMS.map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span className="mt-2 h-1.5 w-1.5 rounded-full bg-[var(--accent-orange)]" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <Button onClick={handleEdit}>
+                <PencilLine className="size-4" />
+                Add core memory
+              </Button>
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/apps/agent/entrypoints/sidepanel/memory/useCoreMemory.ts
+++ b/apps/agent/entrypoints/sidepanel/memory/useCoreMemory.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
+import { sentry } from '@/lib/sentry/sentry'
+
+interface CoreMemoryResponse {
+  content: string
+  exists: boolean
+  updatedAt: string | null
+}
+
+const getCoreMemoryQueryKey = (baseUrl: string | null) => [
+  'core-memory',
+  baseUrl,
+]
+
+async function fetchCoreMemory(baseUrl: string): Promise<CoreMemoryResponse> {
+  const response = await fetch(`${baseUrl}/memory/core`)
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  return response.json()
+}
+
+async function saveCoreMemory(
+  baseUrl: string,
+  content: string,
+): Promise<CoreMemoryResponse> {
+  const response = await fetch(`${baseUrl}/memory/core`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ content }),
+  })
+
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  return response.json()
+}
+
+export function useCoreMemory() {
+  const {
+    baseUrl,
+    isLoading: urlLoading,
+    error: urlError,
+  } = useAgentServerUrl()
+  const queryClient = useQueryClient()
+
+  const query = useQuery<CoreMemoryResponse, Error>({
+    queryKey: getCoreMemoryQueryKey(baseUrl),
+    queryFn: () => fetchCoreMemory(baseUrl as string),
+    enabled: !!baseUrl && !urlLoading,
+  })
+
+  const mutation = useMutation({
+    mutationFn: (content: string) => saveCoreMemory(baseUrl as string, content),
+    onSuccess: (memory) => {
+      queryClient.setQueryData(getCoreMemoryQueryKey(baseUrl), memory)
+    },
+    onError: (error) => {
+      sentry.captureException(error, {
+        extra: {
+          message: 'Failed to save core memory from sidepanel',
+        },
+      })
+    },
+  })
+
+  return {
+    memory: query.data ?? null,
+    isLoading: query.isLoading || urlLoading,
+    error: urlError ?? query.error,
+    refetch: query.refetch,
+    saveMemory: mutation.mutateAsync,
+    isSaving: mutation.isPending,
+  }
+}

--- a/apps/server/src/api/routes/memory.ts
+++ b/apps/server/src/api/routes/memory.ts
@@ -1,0 +1,17 @@
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { readCoreMemory, saveCoreMemory } from '../../lib/core-memory'
+
+const SaveCoreMemorySchema = z.object({
+  content: z.string(),
+})
+
+export function createMemoryRoutes() {
+  return new Hono()
+    .get('/core', async (c) => c.json(await readCoreMemory()))
+    .put('/core', zValidator('json', SaveCoreMemorySchema), async (c) => {
+      const { content } = c.req.valid('json')
+      return c.json(await saveCoreMemory(content))
+    })
+}

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -21,6 +21,7 @@ import { createGraphRoutes } from './routes/graph'
 import { createHealthRoute } from './routes/health'
 import { createKlavisRoutes } from './routes/klavis'
 import { createMcpRoutes } from './routes/mcp'
+import { createMemoryRoutes } from './routes/memory'
 import { createProviderRoutes } from './routes/provider'
 import { createSdkRoutes } from './routes/sdk'
 import { createShutdownRoute } from './routes/shutdown'
@@ -109,6 +110,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     )
     .route('/status', createStatusRoute({ controller }))
     .route('/soul', createSoulRoutes())
+    .route('/memory', createMemoryRoutes())
     .route('/skills', createSkillsRoutes())
     .route('/test-provider', createProviderRoutes())
     .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))

--- a/apps/server/src/lib/core-memory.ts
+++ b/apps/server/src/lib/core-memory.ts
@@ -1,0 +1,50 @@
+import { stat } from 'node:fs/promises'
+import { getCoreMemoryPath } from './browseros-dir'
+
+export interface CoreMemoryDocument {
+  content: string
+  exists: boolean
+  updatedAt: string | null
+}
+
+async function getUpdatedAt(filePath: string): Promise<string | null> {
+  try {
+    const fileStat = await stat(filePath)
+    return fileStat.mtime.toISOString()
+  } catch {
+    return null
+  }
+}
+
+export async function readCoreMemory(): Promise<CoreMemoryDocument> {
+  const filePath = getCoreMemoryPath()
+  const file = Bun.file(filePath)
+
+  if (!(await file.exists())) {
+    return {
+      content: '',
+      exists: false,
+      updatedAt: null,
+    }
+  }
+
+  return {
+    content: await file.text(),
+    exists: true,
+    updatedAt: await getUpdatedAt(filePath),
+  }
+}
+
+export async function saveCoreMemory(
+  content: string,
+): Promise<CoreMemoryDocument> {
+  const filePath = getCoreMemoryPath()
+
+  await Bun.write(filePath, content)
+
+  return {
+    content,
+    exists: true,
+    updatedAt: await getUpdatedAt(filePath),
+  }
+}

--- a/apps/server/src/tools/memory/read-core.ts
+++ b/apps/server/src/tools/memory/read-core.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai'
 import { z } from 'zod'
-import { getCoreMemoryPath } from '../../lib/browseros-dir'
+import { readCoreMemory } from '../../lib/core-memory'
 import { executeWithMetrics, toModelOutput } from '../filesystem/utils'
 
 const TOOL_NAME = 'memory_read_core'
@@ -12,15 +12,14 @@ export function createReadCoreTool() {
     inputSchema: z.object({}),
     execute: () =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const file = Bun.file(getCoreMemoryPath())
-        if (!(await file.exists())) {
+        const memory = await readCoreMemory()
+        if (!memory.exists) {
           return { text: 'No core memories yet.' }
         }
-        const content = await file.text()
-        if (!content.trim()) {
+        if (!memory.content.trim()) {
           return { text: 'Core memory file is empty.' }
         }
-        return { text: content }
+        return { text: memory.content }
       }),
     toModelOutput,
   })

--- a/apps/server/src/tools/memory/save-core.ts
+++ b/apps/server/src/tools/memory/save-core.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai'
 import { z } from 'zod'
-import { getCoreMemoryPath } from '../../lib/browseros-dir'
+import { saveCoreMemory } from '../../lib/core-memory'
 import { executeWithMetrics, toModelOutput } from '../filesystem/utils'
 
 const TOOL_NAME = 'memory_save_core'
@@ -14,7 +14,7 @@ export function createSaveCoreTool() {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        await Bun.write(getCoreMemoryPath(), params.content)
+        await saveCoreMemory(params.content)
         return { text: 'Core memories updated.' }
       }),
     toModelOutput,

--- a/apps/server/tests/api/routes/memory.test.ts
+++ b/apps/server/tests/api/routes/memory.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { beforeEach, describe, it, mock } from 'bun:test'
+import assert from 'node:assert'
+
+const readCoreMemory = mock(async () => ({
+  content: '',
+  exists: false,
+  updatedAt: null,
+}))
+
+const saveCoreMemory = mock(async (content: string) => ({
+  content,
+  exists: true,
+  updatedAt: '2026-03-11T00:00:00.000Z',
+}))
+
+describe('createMemoryRoutes', () => {
+  beforeEach(() => {
+    readCoreMemory.mockReset()
+    saveCoreMemory.mockReset()
+
+    mock.module('../../../src/lib/core-memory', () => ({
+      readCoreMemory,
+      saveCoreMemory,
+    }))
+  })
+
+  it('returns the core memory document payload', async () => {
+    readCoreMemory.mockResolvedValue({
+      content: '# Core memory\n\n- prefers concise answers',
+      exists: true,
+      updatedAt: '2026-03-11T16:00:00.000Z',
+    })
+
+    const { createMemoryRoutes } = await import(
+      '../../../src/api/routes/memory'
+    )
+    const route = createMemoryRoutes()
+    const response = await route.request('/core')
+    const body = await response.json()
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(body, {
+      content: '# Core memory\n\n- prefers concise answers',
+      exists: true,
+      updatedAt: '2026-03-11T16:00:00.000Z',
+    })
+    assert.strictEqual(readCoreMemory.mock.calls.length, 1)
+  })
+
+  it('writes the full core memory document', async () => {
+    saveCoreMemory.mockResolvedValue({
+      content: '# Updated core memory',
+      exists: true,
+      updatedAt: '2026-03-11T16:15:00.000Z',
+    })
+
+    const { createMemoryRoutes } = await import(
+      '../../../src/api/routes/memory'
+    )
+    const route = createMemoryRoutes()
+    const response = await route.request('/core', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        content: '# Updated core memory',
+      }),
+    })
+    const body = await response.json()
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(body, {
+      content: '# Updated core memory',
+      exists: true,
+      updatedAt: '2026-03-11T16:15:00.000Z',
+    })
+    assert.deepStrictEqual(saveCoreMemory.mock.calls[0], [
+      '# Updated core memory',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- Add server HTTP APIs to read and save core memory (`CORE.md`).
- Add a sidepanel Core Memory page with rendered markdown, inline edit/save, and clear empty/error states.
- Reuse a shared markdown renderer so SOUL.md and core memory documents render consistently.

## Design

This change adds a small `/memory/core` route on the server and a dedicated memory route in the sidepanel. The UI follows existing sidepanel/server patterns, renders markdown by default, and edits the full core-memory document explicitly so it stays aligned with the existing `memory_save_core` semantics.

## Test plan

- `bun test apps/server/tests/api/routes/memory.test.ts`
- `bun run test`
- `bunx biome check apps/server/src/lib/core-memory.ts apps/server/src/api/routes/memory.ts apps/server/src/api/server.ts apps/server/src/tools/memory/read-core.ts apps/server/src/tools/memory/save-core.ts apps/server/tests/api/routes/memory.test.ts apps/agent/components/elements/markdown-document.tsx apps/agent/entrypoints/sidepanel/memory/useCoreMemory.ts apps/agent/entrypoints/sidepanel/memory/CoreMemoryPage.tsx apps/agent/entrypoints/sidepanel/App.tsx apps/agent/entrypoints/sidepanel/index/ChatHeader.tsx apps/agent/entrypoints/app/soul/SoulViewer.tsx`
- `bun run --filter @browseros/server typecheck`
- `bun --env-file=.env.development run --filter @browseros/agent codegen`
- `bun run --filter @browseros/agent build:dev`
- Attempted `bun run lint` and `bun run typecheck`; both are currently blocked by pre-existing repo issues (unrelated Biome warnings in `apps/server/tests/agent/compaction.test.ts` and agent-wide `tsc` heap exhaustion).
