### PR TITLE
feat: add core memory viewer and editor to newtab

### DIFF
--- a/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -1,4 +1,5 @@
 import {
+  Brain,
   CalendarClock,
   GitBranch,
   Home,
@@ -56,6 +57,12 @@ const primaryNavItems: NavItem[] = [
     to: '/home/soul',
     icon: Sparkles,
     feature: Feature.SOUL_SUPPORT,
+  },
+  {
+    name: 'Memory',
+    to: '/home/memory',
+    icon: Brain,
+    feature: Feature.MEMORY_SUPPORT,
   },
   { name: 'Settings', to: '/settings/ai', icon: Settings },
 ]

--- a/apps/agent/entrypoints/app/App.tsx
+++ b/apps/agent/entrypoints/app/App.tsx
@@ -21,6 +21,7 @@ import { LoginPage } from './login/LoginPage'
 import { LogoutPage } from './login/LogoutPage'
 import { MagicLinkCallback } from './login/MagicLinkCallback'
 import { MCPSettingsPage } from './mcp-settings/MCPSettingsPage'
+import { MemoryPage } from './memory/MemoryPage'
 import { ProfilePage } from './profile/ProfilePage'
 import { ScheduledTasksPage } from './scheduled-tasks/ScheduledTasksPage'
 import { SearchProviderPage } from './search-provider/SearchProviderPage'
@@ -79,6 +80,7 @@ export const App: FC = () => {
             <Route index element={<NewTab />} />
             <Route path="personalize" element={<Personalize />} />
             <Route path="soul" element={<SoulPage />} />
+            <Route path="memory" element={<MemoryPage />} />
           </Route>
 
           {/* Primary nav routes */}

--- a/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
@@ -40,11 +40,6 @@ const MEMORY_EXAMPLES: Example[] = [
       "Look at my open tabs right now and figure out what I'm working on. Save the relevant context to core memory.",
   },
   {
-    label: 'Set how I like to chat',
-    query:
-      "I like short, direct answers. Don't over-explain or add filler. Remember how I prefer to communicate.",
-  },
-  {
     label: 'Review memories',
     query:
       'Read your core memories and tell me what you know about me. Is anything outdated?',

--- a/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
@@ -78,18 +78,18 @@ export const MemoryExamples: FC = () => {
         {MEMORY_EXAMPLES.map((example) => (
           <div
             key={example.label}
-            className="flex items-center justify-between rounded-lg border border-border bg-card p-3 transition-colors hover:bg-muted/50"
+            className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-muted/50 sm:flex-row sm:items-center sm:justify-between"
           >
-            <div className="mr-3 min-w-0 flex-1">
+            <div className="min-w-0 flex-1">
               <p className="font-medium text-sm">{example.label}</p>
-              <p className="mt-0.5 truncate text-muted-foreground text-xs">
+              <p className="mt-0.5 line-clamp-2 text-muted-foreground text-xs leading-relaxed">
                 {example.query}
               </p>
             </div>
             <Button
               variant="outline"
               size="sm"
-              className="shrink-0 gap-1.5"
+              className="shrink-0 gap-1.5 self-start sm:self-center"
               onClick={() => handleTryIt(example.query)}
             >
               <MessageSquare className="h-3.5 w-3.5" />

--- a/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
@@ -1,0 +1,128 @@
+import { MessageSquare, Send } from 'lucide-react'
+import type { FC } from 'react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Textarea } from '@/components/ui/textarea'
+import { openSidePanelWithSearch } from '@/lib/messaging/sidepanel/openSidepanelWithSearch'
+
+interface Example {
+  label: string
+  query: string
+}
+
+const MEMORY_EXAMPLES: Example[] = [
+  {
+    label: 'Introduce yourself',
+    query:
+      'My name is [name] and I work as a [role] at [company]. Save this to your core memory.',
+  },
+  {
+    label: 'Share preferences',
+    query:
+      'I prefer dark mode, concise answers, and TypeScript. Remember these preferences.',
+  },
+  {
+    label: 'Add your stack',
+    query:
+      'My main tech stack is React, Node.js, and PostgreSQL. Save this to core memory.',
+  },
+  {
+    label: 'Review memories',
+    query:
+      'Read your core memories and tell me what you know about me. Is anything outdated?',
+  },
+]
+
+export const MemoryExamples: FC = () => {
+  const [editingQuery, setEditingQuery] = useState('')
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const handleTryIt = (query: string) => {
+    setEditingQuery(query)
+    setDialogOpen(true)
+  }
+
+  const handleSend = () => {
+    if (!editingQuery.trim()) return
+    openSidePanelWithSearch('open', {
+      query: editingQuery.trim(),
+      mode: 'agent',
+    })
+    setDialogOpen(false)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="font-medium text-sm">Teach your agent about you</h3>
+        <p className="mt-1 text-muted-foreground text-xs">
+          Use these prompts to help your agent learn. Edit the message before
+          sending.
+        </p>
+      </div>
+
+      <div className="grid gap-2">
+        {MEMORY_EXAMPLES.map((example) => (
+          <div
+            key={example.label}
+            className="flex items-center justify-between rounded-lg border border-border bg-card p-3 transition-colors hover:bg-muted/50"
+          >
+            <div className="mr-3 min-w-0 flex-1">
+              <p className="font-medium text-sm">{example.label}</p>
+              <p className="mt-0.5 truncate text-muted-foreground text-xs">
+                {example.query}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="shrink-0 gap-1.5"
+              onClick={() => handleTryIt(example.query)}
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+              Try it
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit message</DialogTitle>
+            <DialogDescription>
+              Customize the prompt before sending it to your agent.
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            value={editingQuery}
+            onChange={(e) => setEditingQuery(e.target.value)}
+            rows={4}
+            className="resize-none"
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSend}
+              disabled={!editingQuery.trim()}
+              className="gap-1.5"
+            >
+              <Send className="h-3.5 w-3.5" />
+              Send
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
@@ -25,14 +25,24 @@ const MEMORY_EXAMPLES: Example[] = [
       'My name is [name] and I work as a [role] at [company]. Save this to your core memory.',
   },
   {
-    label: 'Share preferences',
+    label: 'Learn from my bookmarks',
     query:
-      'I prefer dark mode, concise answers, and TypeScript. Remember these preferences.',
+      'Look through my bookmarks and figure out what topics and interests matter to me. Save the key themes to your core memory.',
   },
   {
-    label: 'Add your stack',
+    label: 'Summarize my week',
     query:
-      'My main tech stack is React, Node.js, and PostgreSQL. Save this to core memory.',
+      "Check my browsing history from the past 7 days and summarize what I've been focused on. Save the highlights to your core memory.",
+  },
+  {
+    label: 'Know my open tabs',
+    query:
+      "Look at my open tabs right now and figure out what I'm working on. Save the relevant context to core memory.",
+  },
+  {
+    label: 'Set how I like to chat',
+    query:
+      "I like short, direct answers. Don't over-explain or add filler. Remember how I prefer to communicate.",
   },
   {
     label: 'Review memories',

--- a/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryExamples.tsx
@@ -30,9 +30,9 @@ const MEMORY_EXAMPLES: Example[] = [
       'Look through my bookmarks and figure out what topics and interests matter to me. Save the key themes to your core memory.',
   },
   {
-    label: 'Summarize my week',
+    label: 'Learn my habits',
     query:
-      "Check my browsing history from the past 7 days and summarize what I've been focused on. Save the highlights to your core memory.",
+      'Go through my recent browsing history and figure out what tools and sites I rely on, what topics I keep coming back to, and what my day-to-day looks like. Save what you learn about me to core memory.',
   },
   {
     label: 'Know my open tabs',

--- a/apps/agent/entrypoints/app/memory/MemoryHeader.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryHeader.tsx
@@ -1,0 +1,21 @@
+import { Brain } from 'lucide-react'
+import type { FC } from 'react'
+
+export const MemoryHeader: FC = () => {
+  return (
+    <div className="rounded-xl border border-border bg-card p-6 shadow-sm transition-all hover:shadow-md">
+      <div className="flex items-start gap-4">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-violet-500/10">
+          <Brain className="h-6 w-6 text-violet-500" />
+        </div>
+        <div className="flex-1">
+          <h2 className="mb-1 font-semibold text-xl">Agent Memory</h2>
+          <p className="text-muted-foreground text-sm">
+            Facts your agent remembers about you — your name, preferences,
+            projects, and tools. Edit directly or teach through conversation.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/app/memory/MemoryPage.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryPage.tsx
@@ -1,0 +1,14 @@
+import type { FC } from 'react'
+import { MemoryExamples } from './MemoryExamples'
+import { MemoryHeader } from './MemoryHeader'
+import { MemoryViewer } from './MemoryViewer'
+
+export const MemoryPage: FC = () => {
+  return (
+    <div className="fade-in slide-in-from-bottom-5 animate-in space-y-6 duration-500">
+      <MemoryHeader />
+      <MemoryViewer />
+      <MemoryExamples />
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/app/memory/MemoryPage.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryPage.tsx
@@ -5,7 +5,7 @@ import { MemoryViewer } from './MemoryViewer'
 
 export const MemoryPage: FC = () => {
   return (
-    <div className="fade-in slide-in-from-bottom-5 animate-in space-y-6 duration-500">
+    <div className="fade-in slide-in-from-bottom-5 mx-auto w-full max-w-3xl animate-in space-y-6 duration-500">
       <MemoryHeader />
       <MemoryViewer />
       <MemoryExamples />

--- a/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
@@ -154,7 +154,7 @@ export const MemoryViewer: FC = () => {
           <Textarea
             value={editContent}
             onChange={(e) => setEditContent(e.target.value)}
-            className="max-h-[480px] min-h-[200px] resize-y font-mono text-sm leading-relaxed"
+            className="styled-scrollbar max-h-[480px] min-h-[200px] resize-y font-mono text-sm leading-relaxed"
             placeholder="# Core Memories&#10;&#10;Write facts about yourself — name, preferences, projects, tools..."
             autoFocus
           />
@@ -165,9 +165,12 @@ export const MemoryViewer: FC = () => {
           )}
         </div>
       ) : (
-        <pre className="max-h-[480px] overflow-x-auto overflow-y-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
-          {content}
-        </pre>
+        <div className="relative">
+          <pre className="styled-scrollbar max-h-[60vh] overflow-x-auto overflow-y-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
+            {content}
+          </pre>
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 rounded-b-xl bg-gradient-to-t from-card to-transparent" />
+        </div>
       )}
     </div>
   )

--- a/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
@@ -98,17 +98,19 @@ export const MemoryViewer: FC = () => {
         if (!isEditing) refetch()
       }}
     >
-      <div className="flex items-center justify-between border-border border-b px-4 py-3">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-col gap-3 border-border border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-2">
           <Brain className="h-4 w-4 text-muted-foreground" />
           <span className="font-medium text-sm">CORE.md</span>
           {isEditing ? (
-            <span className="text-violet-500 text-xs">editing</span>
+            <span className="shrink-0 text-violet-500 text-xs">editing</span>
           ) : (
-            <span className="text-muted-foreground text-xs">editable</span>
+            <span className="shrink-0 text-muted-foreground text-xs">
+              editable
+            </span>
           )}
         </div>
-        <div className="flex items-center gap-1.5">
+        <div className="flex flex-wrap items-center gap-1.5">
           {isEditing ? (
             <>
               <Button
@@ -165,7 +167,7 @@ export const MemoryViewer: FC = () => {
           )}
         </div>
       ) : (
-        <pre className="overflow-x-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
+        <pre className="styled-scrollbar max-h-[65vh] overflow-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
           {content}
         </pre>
       )}

--- a/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
@@ -165,12 +165,9 @@ export const MemoryViewer: FC = () => {
           )}
         </div>
       ) : (
-        <div className="relative">
-          <pre className="styled-scrollbar max-h-[60vh] overflow-x-auto overflow-y-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
-            {content}
-          </pre>
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 rounded-b-xl bg-gradient-to-t from-card to-transparent" />
-        </div>
+        <pre className="overflow-x-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
+          {content}
+        </pre>
       )}
     </div>
   )

--- a/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
@@ -6,22 +6,33 @@ import { Textarea } from '@/components/ui/textarea'
 import { useMemoryContent } from './useMemoryContent'
 
 export const MemoryViewer: FC = () => {
-  const { content, isLoading, error, refetch, save, isSaving, saveError } =
-    useMemoryContent()
+  const {
+    content,
+    isLoading,
+    error,
+    refetch,
+    save,
+    isSaving,
+    saveError,
+    resetSaveError,
+  } = useMemoryContent()
   const [isEditing, setIsEditing] = useState(false)
   const [editContent, setEditContent] = useState('')
 
   const handleEdit = () => {
+    resetSaveError()
     setEditContent(content || '')
     setIsEditing(true)
   }
 
   const handleCreate = () => {
+    resetSaveError()
     setEditContent('')
     setIsEditing(true)
   }
 
   const handleCancel = () => {
+    resetSaveError()
     setIsEditing(false)
     setEditContent('')
   }
@@ -149,7 +160,7 @@ export const MemoryViewer: FC = () => {
           />
           {saveError && (
             <p className="mt-2 text-destructive text-xs">
-              Failed to save. Please try again.
+              {saveError.message || 'Failed to save. Please try again.'}
             </p>
           )}
         </div>

--- a/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
@@ -1,0 +1,163 @@
+import { Brain, Check, Loader2, Pencil, Plus, X } from 'lucide-react'
+import type { FC } from 'react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { useMemoryContent } from './useMemoryContent'
+
+export const MemoryViewer: FC = () => {
+  const { content, isLoading, error, refetch, save, isSaving, saveError } =
+    useMemoryContent()
+  const [isEditing, setIsEditing] = useState(false)
+  const [editContent, setEditContent] = useState('')
+
+  const handleEdit = () => {
+    setEditContent(content || '')
+    setIsEditing(true)
+  }
+
+  const handleCreate = () => {
+    setEditContent('')
+    setIsEditing(true)
+  }
+
+  const handleCancel = () => {
+    setIsEditing(false)
+    setEditContent('')
+  }
+
+  const handleSave = async () => {
+    try {
+      await save(editContent)
+      setIsEditing(false)
+    } catch {
+      // saveError is rendered inline below the textarea
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-border bg-card p-12">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-destructive/50 bg-destructive/5 p-6">
+        <p className="text-destructive text-sm">
+          Could not load memory. Make sure BrowserOS server is running.
+        </p>
+      </div>
+    )
+  }
+
+  if (!content && !isEditing) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="flex flex-col items-center gap-3 py-8 text-center">
+          <Brain className="h-8 w-8 text-muted-foreground/50" />
+          <div>
+            <p className="font-medium text-sm">No memories yet</p>
+            <p className="mt-1 text-muted-foreground text-xs">
+              Start a conversation and your agent will learn about you, or add
+              memories directly.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2 gap-1.5"
+            onClick={handleCreate}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add memory
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: mouseEnter for background refetch
+    <div
+      className="rounded-xl border border-border bg-card shadow-sm"
+      onMouseEnter={() => {
+        if (!isEditing) refetch()
+      }}
+    >
+      <div className="flex items-center justify-between border-border border-b px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Brain className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium text-sm">CORE.md</span>
+          {isEditing ? (
+            <span className="text-violet-500 text-xs">editing</span>
+          ) : (
+            <span className="text-muted-foreground text-xs">editable</span>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          {isEditing ? (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1 px-2 text-xs"
+                onClick={handleCancel}
+                disabled={isSaving}
+              >
+                <X className="h-3 w-3" />
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                className="h-7 gap-1 px-2 text-xs"
+                onClick={handleSave}
+                disabled={isSaving}
+              >
+                {isSaving ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Check className="h-3 w-3" />
+                )}
+                Save
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              onClick={handleEdit}
+            >
+              <Pencil className="h-3 w-3" />
+              Edit
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {isEditing ? (
+        <div className="p-3">
+          <Textarea
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            className="min-h-[200px] resize-y font-mono text-sm leading-relaxed"
+            placeholder="# Core Memories&#10;&#10;Write facts about yourself — name, preferences, projects, tools..."
+            autoFocus
+          />
+          {saveError && (
+            <p className="mt-2 text-destructive text-xs">
+              Failed to save. Please try again.
+            </p>
+          )}
+        </div>
+      ) : (
+        <pre className="overflow-x-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
+          {content}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
+++ b/apps/agent/entrypoints/app/memory/MemoryViewer.tsx
@@ -154,7 +154,7 @@ export const MemoryViewer: FC = () => {
           <Textarea
             value={editContent}
             onChange={(e) => setEditContent(e.target.value)}
-            className="min-h-[200px] resize-y font-mono text-sm leading-relaxed"
+            className="max-h-[480px] min-h-[200px] resize-y font-mono text-sm leading-relaxed"
             placeholder="# Core Memories&#10;&#10;Write facts about yourself — name, preferences, projects, tools..."
             autoFocus
           />
@@ -165,7 +165,7 @@ export const MemoryViewer: FC = () => {
           )}
         </div>
       ) : (
-        <pre className="overflow-x-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
+        <pre className="max-h-[480px] overflow-x-auto overflow-y-auto whitespace-pre-wrap p-4 font-mono text-sm leading-relaxed">
           {content}
         </pre>
       )}

--- a/apps/agent/entrypoints/app/memory/useMemoryContent.ts
+++ b/apps/agent/entrypoints/app/memory/useMemoryContent.ts
@@ -14,7 +14,15 @@ async function saveMemory(baseUrl: string, content: string): Promise<void> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content }),
   })
-  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`
+    try {
+      const body = await response.json()
+      if (body?.error?.message) message = body.error.message
+      else if (body?.success === false && body?.message) message = body.message
+    } catch {}
+    throw new Error(message)
+  }
 }
 
 export function useMemoryContent() {
@@ -42,5 +50,6 @@ export function useMemoryContent() {
     save: saveMutation.mutateAsync,
     isSaving: saveMutation.isPending,
     saveError: saveMutation.error,
+    resetSaveError: saveMutation.reset,
   }
 }

--- a/apps/agent/entrypoints/app/memory/useMemoryContent.ts
+++ b/apps/agent/entrypoints/app/memory/useMemoryContent.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
+
+async function fetchMemory(baseUrl: string): Promise<string> {
+  const response = await fetch(`${baseUrl}/memory`)
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  const data = await response.json()
+  return data.content || ''
+}
+
+async function saveMemory(baseUrl: string, content: string): Promise<void> {
+  const response = await fetch(`${baseUrl}/memory`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+}
+
+export function useMemoryContent() {
+  const { baseUrl, isLoading: urlLoading } = useAgentServerUrl()
+  const queryClient = useQueryClient()
+
+  const { data, isLoading, error, refetch } = useQuery<string, Error>({
+    queryKey: ['memory', baseUrl],
+    queryFn: () => fetchMemory(baseUrl as string),
+    enabled: !!baseUrl && !urlLoading,
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: (content: string) => saveMemory(baseUrl as string, content),
+    onSuccess: (_data, content) => {
+      queryClient.setQueryData(['memory', baseUrl], content)
+    },
+  })
+
+  return {
+    content: data ?? null,
+    isLoading: isLoading || urlLoading,
+    error,
+    refetch,
+    save: saveMutation.mutateAsync,
+    isSaving: saveMutation.isPending,
+    saveError: saveMutation.error,
+  }
+}

--- a/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
+++ b/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
@@ -8,7 +8,8 @@ export const NewTabLayout: FC = () => {
 
   return (
     <ChatSessionProvider origin="newtab">
-      {location.pathname !== '/home/soul' && <NewTabFocusGrid />}
+      {location.pathname !== '/home/soul' &&
+        location.pathname !== '/home/memory' && <NewTabFocusGrid />}
       <Outlet />
     </ChatSessionProvider>
   )

--- a/apps/agent/lib/browseros/capabilities.ts
+++ b/apps/agent/lib/browseros/capabilities.ts
@@ -41,6 +41,8 @@ export enum Feature {
   NEWTAB_CHAT_SUPPORT = 'NEWTAB_CHAT_SUPPORT',
   // Vertical tabs preference and customization
   VERTICAL_TABS_SUPPORT = 'VERTICAL_TABS_SUPPORT',
+  // Memory page: core memory viewer and editor
+  MEMORY_SUPPORT = 'MEMORY_SUPPORT',
 }
 
 /**
@@ -66,6 +68,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.SOUL_SUPPORT]: { minServerVersion: '0.0.67' },
   [Feature.NEWTAB_CHAT_SUPPORT]: { minBrowserOSVersion: '0.40.0.0' },
   [Feature.VERTICAL_TABS_SUPPORT]: { minBrowserOSVersion: '0.42.0.0' },
+  [Feature.MEMORY_SUPPORT]: { minServerVersion: '0.0.73' },
 }
 
 function parseVersion(version: string): number[] {

--- a/apps/server/src/api/routes/memory.ts
+++ b/apps/server/src/api/routes/memory.ts
@@ -1,0 +1,29 @@
+import { mkdir } from 'node:fs/promises'
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { getCoreMemoryPath, getMemoryDir } from '../../lib/browseros-dir'
+
+const MAX_CONTENT_LENGTH = 50_000
+
+const SaveMemorySchema = z.object({
+  content: z.string().max(MAX_CONTENT_LENGTH),
+})
+
+export function createMemoryRoutes() {
+  return new Hono()
+    .get('/', async (c) => {
+      const file = Bun.file(getCoreMemoryPath())
+      if (!(await file.exists())) {
+        return c.json({ content: '' })
+      }
+      const content = await file.text()
+      return c.json({ content })
+    })
+    .put('/', zValidator('json', SaveMemorySchema), async (c) => {
+      const { content } = c.req.valid('json')
+      await mkdir(getMemoryDir(), { recursive: true })
+      await Bun.write(getCoreMemoryPath(), content)
+      return c.json({ success: true })
+    })
+}

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -21,6 +21,7 @@ import { createGraphRoutes } from './routes/graph'
 import { createHealthRoute } from './routes/health'
 import { createKlavisRoutes } from './routes/klavis'
 import { createMcpRoutes } from './routes/mcp'
+import { createMemoryRoutes } from './routes/memory'
 import { createProviderRoutes } from './routes/provider'
 import { createSdkRoutes } from './routes/sdk'
 import { createShutdownRoute } from './routes/shutdown'
@@ -109,6 +110,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     )
     .route('/status', createStatusRoute({ controller }))
     .route('/soul', createSoulRoutes())
+    .route('/memory', createMemoryRoutes())
     .route('/skills', createSkillsRoutes())
     .route('/test-provider', createProviderRoutes())
     .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))


### PR DESCRIPTION
## Summary
- Adds a new **Memory** page (`/home/memory`) in the newtab app for viewing and inline-editing the agent's core memories (`CORE.md`)
- New server API: `GET /memory` (read) and `PUT /memory` (save with Zod validation, 50k char limit)
- React Query hook with optimistic cache update for instant feedback after save
- Example prompts ("Teach your agent about you") to help users populate memory through conversation
- Feature-gated behind `MEMORY_SUPPORT` (server >= 0.0.73)

## Design
Follows the established Agent Soul pattern:
- `MemoryHeader` — violet Brain icon with title/description
- `MemoryViewer` — read-only `<pre>` with Edit toggle to inline `<textarea>`, Save/Cancel buttons, save error display
- `MemoryExamples` — prompt cards with edit-before-send dialog (same pattern as `SoulExamples`)
- `useMemoryContent` — React Query hook for read + useMutation for write

## Test plan
- [ ] Navigate to Memory page from sidebar navigation
- [ ] Verify empty state renders when no CORE.md exists
- [ ] Click "Add memory" and create content, save successfully
- [ ] Edit existing memory content, verify inline editing works
- [ ] Cancel editing and verify content reverts
- [ ] Verify save error is displayed on network failure
- [ ] Verify example prompts open sidepanel chat with correct message
- [ ] Verify feature is hidden when server version < 0.0.73

🤖 Generated with [Claude Code](https://claude.com/claude-code)