### PR TITLE
feat: gate skills page behind server version 0.0.73

### DIFF
--- a/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -59,7 +59,12 @@ const primaryNavItems: NavItem[] = [
     icon: Sparkles,
     feature: Feature.SOUL_SUPPORT,
   },
-  { name: 'Skills', to: '/home/skills', icon: Wand2 },
+  {
+    name: 'Skills',
+    to: '/home/skills',
+    icon: Wand2,
+    feature: Feature.SKILLS_SUPPORT,
+  },
   {
     name: 'Memory',
     to: '/home/memory',

--- a/apps/agent/lib/browseros/capabilities.ts
+++ b/apps/agent/lib/browseros/capabilities.ts
@@ -43,6 +43,8 @@ export enum Feature {
   VERTICAL_TABS_SUPPORT = 'VERTICAL_TABS_SUPPORT',
   // Memory page: core memory viewer and editor
   MEMORY_SUPPORT = 'MEMORY_SUPPORT',
+  // Skills page: agent skills viewer and editor
+  SKILLS_SUPPORT = 'SKILLS_SUPPORT',
 }
 
 /**
@@ -69,6 +71,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.NEWTAB_CHAT_SUPPORT]: { minBrowserOSVersion: '0.40.0.0' },
   [Feature.VERTICAL_TABS_SUPPORT]: { minBrowserOSVersion: '0.42.0.0' },
   [Feature.MEMORY_SUPPORT]: { minServerVersion: '0.0.73' },
+  [Feature.SKILLS_SUPPORT]: { minServerVersion: '0.0.73' },
 }
 
 function parseVersion(version: string): number[] {


### PR DESCRIPTION
## Summary
- Adds `SKILLS_SUPPORT` feature flag gated at server version `0.0.73`
- Hides Skills navigation item when server doesn't support the skills API
- Follows the same gating pattern used by Memory, Soul, and Workflows

## Design
Uses the existing `Feature` enum + `FEATURE_CONFIG` version-check infrastructure. The `useCapabilities()` hook in `SidebarNavigation` already filters nav items by feature support — adding the `feature` property to the Skills nav item is all that's needed.

## Test plan
- [ ] Verify Skills nav item appears on server >= 0.0.73
- [ ] Verify Skills nav item is hidden on server < 0.0.73
- [ ] Verify Skills nav item appears in DEV mode regardless of server version
- [ ] Verify direct URL `/home/skills` still renders (route is not gated, only nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)