### PR TITLE
fix: incorrect tab got the active tab glow

### DIFF
--- a/apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx
+++ b/apps/agent/entrypoints/sidepanel/index/useNotifyActiveTab.tsx
@@ -70,7 +70,7 @@ export const useNotifyActiveTab = ({
     let cancelled = false
 
     const activate = async () => {
-      let targetTabId = toolTabId
+      let targetTabId = toolTabId ?? previousTabId ?? undefined
 
       if (!targetTabId) {
         const tabs = await chrome.tabs.query({


### PR DESCRIPTION
This pull request makes a small but important improvement to the logic for determining which browser tab to notify as active in the `useNotifyActiveTab` hook. Now, if `toolTabId` is not available, it will fall back to `previousTabId`, ensuring better reliability when activating a tab.

* Improved tab activation logic in `useNotifyActiveTab` to use `previousTabId` as a fallback when `toolTabId` is unavailable, increasing robustness.