### PR TITLE
fix: skills editor content not scrollable on desktop

### DIFF
--- a/apps/agent/entrypoints/app/skills/SkillsPage.tsx
+++ b/apps/agent/entrypoints/app/skills/SkillsPage.tsx
@@ -363,8 +363,8 @@ const SkillDialog: FC<{
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid min-h-0 flex-1 overflow-y-auto lg:grid-cols-[280px_minmax(0,1fr)] lg:overflow-hidden">
-          <div className="space-y-5 border-b bg-muted/20 px-6 py-5 lg:border-r lg:border-b-0">
+        <div className="grid min-h-0 flex-1 overflow-y-auto lg:grid-cols-[280px_minmax(0,1fr)] lg:grid-rows-[minmax(0,1fr)] lg:overflow-hidden">
+          <div className="space-y-5 border-b bg-muted/20 px-6 py-5 lg:overflow-y-auto lg:border-r lg:border-b-0">
             <div className="space-y-2">
               <Label htmlFor="skill-name">Name</Label>
               <Input
@@ -417,7 +417,7 @@ const SkillDialog: FC<{
               onChange={setContent}
               onKeyDown={handleContentKeyDown}
               placeholder="Write instructions for the agent. Use markdown for structure."
-              className="mt-4 min-h-[320px] flex-1 overflow-y-auto text-sm"
+              className="mt-4 min-h-[320px] flex-1 text-sm"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Fix broken scroll in the Skills editor dialog on desktop (lg+) screens
- The grid row had no explicit height constraint, so content expanded beyond the dialog and was clipped without a scrollbar
- Added `grid-rows-[minmax(0,1fr)]` on lg to constrain the row, enabling the existing inner scroll container to activate

## Test plan
- [ ] Open Skills page, edit a skill with long markdown instructions
- [ ] Verify editor content is scrollable on desktop
- [ ] Verify toolbar stays sticky at top of editor
- [ ] Verify left sidebar scrolls independently if its content overflows
- [ ] Verify mobile layout (stacked, full-page scroll) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)