### PR TITLE
feat: redesign sidebar navigation layout and settings organization

### DIFF
--- a/apps/agent/components/sidebar/AppSidebar.tsx
+++ b/apps/agent/components/sidebar/AppSidebar.tsx
@@ -2,17 +2,12 @@ import type { FC } from 'react'
 import { cn } from '@/lib/utils'
 import { SidebarBranding } from './SidebarBranding'
 import { SidebarNavigation } from './SidebarNavigation'
-import { SidebarUserFooter } from './SidebarUserFooter'
 
 interface AppSidebarProps {
   expanded?: boolean
-  onOpenShortcuts?: () => void
 }
 
-export const AppSidebar: FC<AppSidebarProps> = ({
-  expanded = false,
-  onOpenShortcuts,
-}) => {
+export const AppSidebar: FC<AppSidebarProps> = ({ expanded = false }) => {
   return (
     <div
       className={cn(
@@ -22,10 +17,6 @@ export const AppSidebar: FC<AppSidebarProps> = ({
     >
       <SidebarBranding expanded={expanded} />
       <SidebarNavigation expanded={expanded} />
-      <SidebarUserFooter
-        expanded={expanded}
-        onOpenShortcuts={onOpenShortcuts}
-      />
     </div>
   )
 }

--- a/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -2,7 +2,7 @@ import {
   ArrowLeft,
   Bot,
   Compass,
-  Info,
+  GitBranch,
   MessageSquare,
   Palette,
   RotateCcw,
@@ -23,36 +23,80 @@ type NavItem = {
   feature?: Feature
 }
 
-const settingsNavItems: NavItem[] = [
-  { name: 'BrowserOS AI', to: '/settings/ai', icon: Bot },
-  { name: 'LLM Chat & Hub', to: '/settings/chat', icon: MessageSquare },
-  { name: 'BrowserOS as MCP', to: '/settings/mcp', icon: Server },
+type NavSection = {
+  label: string
+  items: NavItem[]
+}
+
+const settingsSections: NavSection[] = [
   {
-    name: 'Customization',
-    to: '/settings/customization',
-    icon: Palette,
-    feature: Feature.CUSTOMIZATION_SUPPORT,
+    label: 'Provider Settings',
+    items: [
+      { name: 'BrowserOS AI', to: '/settings/ai', icon: Bot },
+      {
+        name: 'Chat & Hub Provider',
+        to: '/settings/chat',
+        icon: MessageSquare,
+      },
+      { name: 'Search Provider', to: '/settings/search', icon: Search },
+    ],
   },
-  { name: 'Search Provider', to: '/settings/search', icon: Search },
+  {
+    label: 'Other',
+    items: [
+      {
+        name: 'Customization',
+        to: '/settings/customization',
+        icon: Palette,
+        feature: Feature.CUSTOMIZATION_SUPPORT,
+      },
+      { name: 'BrowserOS as MCP', to: '/settings/mcp', icon: Server },
+      {
+        name: 'Workflows',
+        to: '/workflows',
+        icon: GitBranch,
+        feature: Feature.WORKFLOW_SUPPORT,
+      },
+    ],
+  },
+]
+
+const helpItems: NavItem[] = [
   { name: 'Explore Features', to: '/onboarding/features', icon: Compass },
   { name: 'Revisit Onboarding', to: '/onboarding', icon: RotateCcw },
 ]
+
+const navItemClassName =
+  'flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
 
 export const SettingsSidebar: FC = () => {
   const location = useLocation()
   const { supports } = useCapabilities()
 
-  const filteredItems = settingsNavItems.filter(
-    (item) => !item.feature || supports(item.feature),
-  )
+  const renderNavItem = (item: NavItem) => {
+    const Icon = item.icon
+    const isActive = location.pathname === item.to
+
+    return (
+      <NavLink
+        key={item.to}
+        to={item.to}
+        className={cn(
+          navItemClassName,
+          isActive && 'bg-sidebar-accent text-sidebar-accent-foreground',
+        )}
+      >
+        <Icon className="size-4 shrink-0" />
+        <span className="truncate">{item.name}</span>
+      </NavLink>
+    )
+  }
 
   return (
     <div className="flex h-full w-64 flex-col border-r bg-sidebar text-sidebar-foreground">
+      {/* Header with back button and theme toggle */}
       <div className="flex h-14 items-center justify-between border-b px-2">
-        <NavLink
-          to="/home"
-          className="flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-        >
+        <NavLink to="/home" className={navItemClassName}>
           <ArrowLeft className="size-4 shrink-0" />
           <span className="truncate">Back</span>
         </NavLink>
@@ -62,43 +106,31 @@ export const SettingsSidebar: FC = () => {
         />
       </div>
 
+      {/* Sections */}
       <div className="flex-1 overflow-y-auto overflow-x-hidden p-2">
-        <div className="mb-2 px-3 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-          Settings
-        </div>
-        <nav className="space-y-1">
-          {filteredItems.map((item) => {
-            const Icon = item.icon
-            const isActive = location.pathname === item.to
+        {settingsSections.map((section) => {
+          const visibleItems = section.items.filter(
+            (item) => !item.feature || supports(item.feature),
+          )
+          if (visibleItems.length === 0) return null
 
-            return (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                className={cn(
-                  'flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-                  isActive &&
-                    'bg-sidebar-accent text-sidebar-accent-foreground',
-                )}
-              >
-                <Icon className="size-4 shrink-0" />
-                <span className="truncate">{item.name}</span>
-              </NavLink>
-            )
-          })}
-        </nav>
+          return (
+            <div key={section.label} className="mb-4">
+              <div className="mb-2 px-3 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                {section.label}
+              </div>
+              <nav className="space-y-1">{visibleItems.map(renderNavItem)}</nav>
+            </div>
+          )
+        })}
       </div>
 
-      <div className="mt-auto border-t p-2">
-        <a
-          href="https://docs.browseros.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-        >
-          <Info className="size-4 shrink-0" />
-          <span className="truncate">About BrowserOS</span>
-        </a>
+      {/* Help section at bottom */}
+      <div className="border-t p-2">
+        <div className="mb-2 px-3 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+          Help
+        </div>
+        <nav className="space-y-1">{helpItems.map(renderNavItem)}</nav>
       </div>
     </div>
   )

--- a/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -1,12 +1,12 @@
 import {
+  Bot,
   Brain,
   CalendarClock,
-  GitBranch,
   Home,
+  Leaf,
   PlugZap,
   Settings,
   Sparkles,
-  UserPen,
   Wand2,
 } from 'lucide-react'
 import type { FC } from 'react'
@@ -35,30 +35,12 @@ type NavItem = {
 const primaryNavItems: NavItem[] = [
   { name: 'Home', to: '/home', icon: Home },
   {
-    name: 'Workflows',
-    to: '/workflows',
-    icon: GitBranch,
-    feature: Feature.WORKFLOW_SUPPORT,
-  },
-  { name: 'Scheduled Tasks', to: '/scheduled', icon: CalendarClock },
-  {
     name: 'Connect Apps',
     to: '/connect-apps',
     icon: PlugZap,
     feature: Feature.MANAGED_MCP_SUPPORT,
   },
-  {
-    name: 'Personalize',
-    to: '/home/personalize',
-    icon: UserPen,
-    feature: Feature.PERSONALIZATION_SUPPORT,
-  },
-  {
-    name: 'Agent Soul',
-    to: '/home/soul',
-    icon: Sparkles,
-    feature: Feature.SOUL_SUPPORT,
-  },
+  { name: 'Scheduled Tasks', to: '/scheduled', icon: CalendarClock },
   {
     name: 'Skills',
     to: '/home/skills',
@@ -71,6 +53,14 @@ const primaryNavItems: NavItem[] = [
     icon: Brain,
     feature: Feature.MEMORY_SUPPORT,
   },
+  { name: 'Agents', to: '/home/agents', icon: Bot },
+  {
+    name: 'Soul',
+    to: '/home/soul',
+    icon: Sparkles,
+    feature: Feature.SOUL_SUPPORT,
+  },
+  { name: 'Nature', to: '/home/nature', icon: Leaf },
   { name: 'Settings', to: '/settings/ai', icon: Settings },
 ]
 

--- a/apps/agent/entrypoints/app/App.tsx
+++ b/apps/agent/entrypoints/app/App.tsx
@@ -8,6 +8,7 @@ import { OnboardingDemo } from '../onboarding/demo/OnboardingDemo'
 import { FeaturesPage } from '../onboarding/features/Features'
 import { Onboarding } from '../onboarding/index/Onboarding'
 import { StepsLayout } from '../onboarding/steps/StepsLayout'
+import { AgentsPage } from './agents/AgentsPage'
 import { AISettingsPage } from './ai-settings/AISettingsPage'
 import { ConnectMCP } from './connect-mcp/ConnectMCP'
 import { CreateGraphWrapper } from './create-graph/CreateGraphWrapper'
@@ -22,6 +23,7 @@ import { LogoutPage } from './login/LogoutPage'
 import { MagicLinkCallback } from './login/MagicLinkCallback'
 import { MCPSettingsPage } from './mcp-settings/MCPSettingsPage'
 import { MemoryPage } from './memory/MemoryPage'
+import { NaturePage } from './nature/NaturePage'
 import { ProfilePage } from './profile/ProfilePage'
 import { ScheduledTasksPage } from './scheduled-tasks/ScheduledTasksPage'
 import { SearchProviderPage } from './search-provider/SearchProviderPage'
@@ -83,6 +85,8 @@ export const App: FC = () => {
             <Route path="soul" element={<SoulPage />} />
             <Route path="skills" element={<SkillsPage />} />
             <Route path="memory" element={<MemoryPage />} />
+            <Route path="agents" element={<AgentsPage />} />
+            <Route path="nature" element={<NaturePage />} />
           </Route>
 
           {/* Primary nav routes */}

--- a/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -1,0 +1,12 @@
+import type { FC } from 'react'
+
+export const AgentsPage: FC = () => {
+  return (
+    <div className="fade-in slide-in-from-bottom-5 mx-auto w-full max-w-3xl animate-in space-y-6 duration-500">
+      <div>
+        <h2 className="font-semibold text-2xl tracking-tight">Agents</h2>
+        <p className="text-muted-foreground text-sm">Coming soon.</p>
+      </div>
+    </div>
+  )
+}

--- a/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
+++ b/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
@@ -5,7 +5,6 @@ import { Outlet, useLocation } from 'react-router'
 import { AppSidebar } from '@/components/sidebar/AppSidebar'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
-import { ShortcutsDialog } from '@/entrypoints/newtab/index/ShortcutsDialog'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { SETTINGS_PAGE_VIEWED_EVENT } from '@/lib/constants/analyticsEvents'
 import { track } from '@/lib/metrics/track'
@@ -18,12 +17,7 @@ export const SidebarLayout: FC = () => {
   const isMobile = useIsMobile()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [mobileOpen, setMobileOpen] = useState(false)
-  const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false)
   const collapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const openShortcuts = useCallback(() => {
-    setShortcutsDialogOpen(true)
-  }, [])
 
   useEffect(() => {
     track(SETTINGS_PAGE_VIEWED_EVENT, { page: location.pathname })
@@ -77,13 +71,9 @@ export const SidebarLayout: FC = () => {
           </main>
           <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
             <SheetContent side="left" className="w-72 p-0">
-              <AppSidebar expanded onOpenShortcuts={openShortcuts} />
+              <AppSidebar expanded />
             </SheetContent>
           </Sheet>
-          <ShortcutsDialog
-            open={shortcutsDialogOpen}
-            onOpenChange={setShortcutsDialogOpen}
-          />
         </div>
       </RpcClientProvider>
     )
@@ -99,7 +89,7 @@ export const SidebarLayout: FC = () => {
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <AppSidebar expanded={sidebarOpen} onOpenShortcuts={openShortcuts} />
+          <AppSidebar expanded={sidebarOpen} />
         </div>
 
         {/* Main content - full width, centered */}
@@ -109,10 +99,6 @@ export const SidebarLayout: FC = () => {
           </div>
         </main>
       </div>
-      <ShortcutsDialog
-        open={shortcutsDialogOpen}
-        onOpenChange={setShortcutsDialogOpen}
-      />
     </RpcClientProvider>
   )
 }

--- a/apps/agent/entrypoints/app/nature/NaturePage.tsx
+++ b/apps/agent/entrypoints/app/nature/NaturePage.tsx
@@ -1,0 +1,12 @@
+import type { FC } from 'react'
+
+export const NaturePage: FC = () => {
+  return (
+    <div className="fade-in slide-in-from-bottom-5 mx-auto w-full max-w-3xl animate-in space-y-6 duration-500">
+      <div>
+        <h2 className="font-semibold text-2xl tracking-tight">Nature</h2>
+        <p className="text-muted-foreground text-sm">Coming soon.</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Reorder main sidebar to prioritize working features: Home, Connect Apps, Scheduled Tasks, Skills, Memory, Agents, Soul, Nature, Settings
- Reorganize settings sidebar into three grouped sections with headers: Provider Settings, Other, and Help
- Add placeholder pages for upcoming Agents and Nature features
- Remove Personalize and Workflows from main nav; move Workflows to Settings > Other
- Clean up sidebar footer (remove Shortcuts button and About BrowserOS link)

## Design
Data reorganization within the existing architecture. The main sidebar's nav items array is reordered with items added/removed. The settings sidebar changes from a flat list to a section-based structure with lightweight uppercase text headers. Two minimal placeholder pages (AgentsPage, NaturePage) are created as route targets. All existing feature gating, routing patterns, and backward-compatibility redirects remain unchanged.

## Changes
| File | Change |
|------|--------|
| `SidebarNavigation.tsx` | Reorder items, add Agents/Nature, remove Personalize/Workflows, rename "Agent Soul" → "Soul" |
| `SettingsSidebar.tsx` | Section grouping with headers, rename "LLM Chat & Hub" → "Chat & Hub Provider", add Workflows, remove About footer |
| `AppSidebar.tsx` | Remove SidebarUserFooter |
| `SidebarLayout.tsx` | Remove ShortcutsDialog and dead code |
| `App.tsx` | Add routes for `/home/agents` and `/home/nature` |
| `AgentsPage.tsx` | New placeholder page |
| `NaturePage.tsx` | New placeholder page |

## Test plan
- [ ] Verify main sidebar shows items in correct order: Home, Connect Apps, Scheduled Tasks, Skills, Memory, Agents, Soul, Nature, Settings
- [ ] Verify Personalize and Workflows are NOT in main sidebar
- [ ] Navigate to Settings and verify three sections: Provider Settings, Other, Help
- [ ] Verify "Chat & Hub Provider" label (renamed from "LLM Chat & Hub")
- [ ] Verify Workflows appears under Settings > Other section
- [ ] Click Agents → see placeholder page
- [ ] Click Nature → see placeholder page
- [ ] Verify collapsed sidebar tooltips still work
- [ ] Verify mobile hamburger menu works

🤖 Generated with [Claude Code](https://claude.com/claude-code)