### PR TITLE
feat: redesign sidebar navigation

### DIFF
--- a/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -2,6 +2,7 @@ import {
   ArrowLeft,
   Bot,
   Compass,
+  GitBranch,
   Info,
   MessageSquare,
   Palette,
@@ -28,11 +29,11 @@ type NavSection = {
   items: NavItem[]
 }
 
-const settingsNavSections: NavSection[] = [
+const primarySettingsSections: NavSection[] = [
   {
     label: 'Provider Settings',
     items: [
-      { name: 'LLM Providers', to: '/settings/ai', icon: Bot },
+      { name: 'BrowserOS AI', to: '/settings/ai', icon: Bot },
       {
         name: 'Chat & Hub Provider',
         to: '/settings/chat',
@@ -42,31 +43,35 @@ const settingsNavSections: NavSection[] = [
     ],
   },
   {
-    label: 'BrowserOS Features',
+    label: 'Other',
     items: [
-      { name: 'BrowserOS as MCP', to: '/settings/mcp', icon: Server },
       {
         name: 'Customization',
         to: '/settings/customization',
         icon: Palette,
         feature: Feature.CUSTOMIZATION_SUPPORT,
       },
+      { name: 'BrowserOS as MCP', to: '/settings/mcp', icon: Server },
+      {
+        name: 'Workflows',
+        to: '/workflows',
+        icon: GitBranch,
+        feature: Feature.WORKFLOW_SUPPORT,
+      },
     ],
   },
-  {
-    label: 'Misc',
-    items: [
-      { name: 'Explore Features', to: '/onboarding/features', icon: Compass },
-      { name: 'Revisit Onboarding', to: '/onboarding', icon: RotateCcw },
-    ],
-  },
+]
+
+const helpItems: NavItem[] = [
+  { name: 'Explore Features', to: '/onboarding/features', icon: Compass },
+  { name: 'Revisit Onboarding', to: '/onboarding', icon: RotateCcw },
 ]
 
 export const SettingsSidebar: FC = () => {
   const location = useLocation()
   const { supports } = useCapabilities()
 
-  const filteredSections = settingsNavSections
+  const filteredSections = primarySettingsSections
     .map((section) => ({
       ...section,
       items: section.items.filter(
@@ -74,6 +79,10 @@ export const SettingsSidebar: FC = () => {
       ),
     }))
     .filter((section) => section.items.length > 0)
+
+  const filteredHelpItems = helpItems.filter(
+    (item) => !item.feature || supports(item.feature),
+  )
 
   const getNavLinkClassName = (isActive: boolean) =>
     cn(
@@ -128,11 +137,17 @@ export const SettingsSidebar: FC = () => {
         />
       </div>
 
-      <div className="flex-1 overflow-y-auto overflow-x-hidden p-2">
+      <div className="flex flex-1 flex-col overflow-y-auto overflow-x-hidden p-2">
         <div className="mb-2 px-3 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
           Settings
         </div>
         <div>{filteredSections.map(renderSection)}</div>
+        <div className="mt-auto pt-4">
+          <div className={sectionLabelClassName}>Help</div>
+          <nav className="space-y-1">
+            {filteredHelpItems.map(renderNavItem)}
+          </nav>
+        </div>
       </div>
 
       <div className="mt-auto border-t p-2">

--- a/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -23,27 +23,93 @@ type NavItem = {
   feature?: Feature
 }
 
-const settingsNavItems: NavItem[] = [
-  { name: 'BrowserOS AI', to: '/settings/ai', icon: Bot },
-  { name: 'LLM Chat & Hub', to: '/settings/chat', icon: MessageSquare },
-  { name: 'BrowserOS as MCP', to: '/settings/mcp', icon: Server },
+type NavSection = {
+  label: string
+  items: NavItem[]
+}
+
+const settingsNavSections: NavSection[] = [
   {
-    name: 'Customization',
-    to: '/settings/customization',
-    icon: Palette,
-    feature: Feature.CUSTOMIZATION_SUPPORT,
+    label: 'Provider Settings',
+    items: [
+      { name: 'LLM Providers', to: '/settings/ai', icon: Bot },
+      {
+        name: 'Chat & Hub Provider',
+        to: '/settings/chat',
+        icon: MessageSquare,
+      },
+      { name: 'Search Provider', to: '/settings/search', icon: Search },
+    ],
   },
-  { name: 'Search Provider', to: '/settings/search', icon: Search },
-  { name: 'Explore Features', to: '/onboarding/features', icon: Compass },
-  { name: 'Revisit Onboarding', to: '/onboarding', icon: RotateCcw },
+  {
+    label: 'BrowserOS Features',
+    items: [
+      { name: 'BrowserOS as MCP', to: '/settings/mcp', icon: Server },
+      {
+        name: 'Customization',
+        to: '/settings/customization',
+        icon: Palette,
+        feature: Feature.CUSTOMIZATION_SUPPORT,
+      },
+    ],
+  },
+  {
+    label: 'Misc',
+    items: [
+      { name: 'Explore Features', to: '/onboarding/features', icon: Compass },
+      { name: 'Revisit Onboarding', to: '/onboarding', icon: RotateCcw },
+    ],
+  },
 ]
 
 export const SettingsSidebar: FC = () => {
   const location = useLocation()
   const { supports } = useCapabilities()
 
-  const filteredItems = settingsNavItems.filter(
-    (item) => !item.feature || supports(item.feature),
+  const filteredSections = settingsNavSections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter(
+        (item) => !item.feature || supports(item.feature),
+      ),
+    }))
+    .filter((section) => section.items.length > 0)
+
+  const getNavLinkClassName = (isActive: boolean) =>
+    cn(
+      'flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+      isActive && 'bg-sidebar-accent text-sidebar-accent-foreground',
+    )
+
+  const getSectionClassName = (index: number) =>
+    cn(index > 0 && 'mt-3 border-t pt-3')
+
+  const sectionLabelClassName =
+    'mb-2 px-3 font-semibold text-[10px] text-muted-foreground uppercase tracking-[0.18em]'
+
+  const isActivePath = (path: string) => location.pathname === path
+
+  const renderNavItem = (item: NavItem) => {
+    const Icon = item.icon
+    const isActive = isActivePath(item.to)
+
+    return (
+      <NavLink
+        key={item.to}
+        to={item.to}
+        className={getNavLinkClassName(isActive)}
+      >
+        <Icon className="size-4 shrink-0" />
+        <span className="truncate">{item.name}</span>
+      </NavLink>
+    )
+  }
+
+  const renderSection = (section: NavSection, index: number) => (
+    <div key={section.label} className={getSectionClassName(index)}>
+      <div className={sectionLabelClassName}>{section.label}</div>
+      <nav className="space-y-1">{section.items.map(renderNavItem)}</nav>
+    </div>
   )
 
   return (
@@ -66,27 +132,7 @@ export const SettingsSidebar: FC = () => {
         <div className="mb-2 px-3 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
           Settings
         </div>
-        <nav className="space-y-1">
-          {filteredItems.map((item) => {
-            const Icon = item.icon
-            const isActive = location.pathname === item.to
-
-            return (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                className={cn(
-                  'flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-                  isActive &&
-                    'bg-sidebar-accent text-sidebar-accent-foreground',
-                )}
-              >
-                <Icon className="size-4 shrink-0" />
-                <span className="truncate">{item.name}</span>
-              </NavLink>
-            )
-          })}
-        </nav>
+        <div>{filteredSections.map(renderSection)}</div>
       </div>
 
       <div className="mt-auto border-t p-2">

--- a/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -11,7 +11,7 @@ import {
   Server,
 } from 'lucide-react'
 import type { FC } from 'react'
-import { NavLink, useLocation } from 'react-router'
+import { NavLink } from 'react-router'
 import { ThemeToggle } from '@/components/elements/theme-toggle'
 import { Feature } from '@/lib/browseros/capabilities'
 import { useCapabilities } from '@/lib/browseros/useCapabilities'
@@ -28,6 +28,18 @@ type NavSection = {
   label: string
   items: NavItem[]
 }
+
+const getNavLinkClassName = (isActive: boolean) =>
+  cn(
+    'flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+    isActive && 'bg-sidebar-accent text-sidebar-accent-foreground',
+  )
+
+const getSectionClassName = (index: number) =>
+  cn(index > 0 && 'mt-3 border-t pt-3')
+
+const sectionLabelClassName =
+  'mb-2 px-3 font-semibold text-[10px] text-muted-foreground uppercase tracking-[0.18em]'
 
 const primarySettingsSections: NavSection[] = [
   {
@@ -46,7 +58,7 @@ const primarySettingsSections: NavSection[] = [
     label: 'Other',
     items: [
       {
-        name: 'Customization',
+        name: 'Customize BrowserOS',
         to: '/settings/customization',
         icon: Palette,
         feature: Feature.CUSTOMIZATION_SUPPORT,
@@ -68,7 +80,6 @@ const helpItems: NavItem[] = [
 ]
 
 export const SettingsSidebar: FC = () => {
-  const location = useLocation()
   const { supports } = useCapabilities()
 
   const filteredSections = primarySettingsSections
@@ -84,29 +95,15 @@ export const SettingsSidebar: FC = () => {
     (item) => !item.feature || supports(item.feature),
   )
 
-  const getNavLinkClassName = (isActive: boolean) =>
-    cn(
-      'flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-      isActive && 'bg-sidebar-accent text-sidebar-accent-foreground',
-    )
-
-  const getSectionClassName = (index: number) =>
-    cn(index > 0 && 'mt-3 border-t pt-3')
-
-  const sectionLabelClassName =
-    'mb-2 px-3 font-semibold text-[10px] text-muted-foreground uppercase tracking-[0.18em]'
-
-  const isActivePath = (path: string) => location.pathname === path
-
   const renderNavItem = (item: NavItem) => {
     const Icon = item.icon
-    const isActive = isActivePath(item.to)
 
     return (
       <NavLink
         key={item.to}
         to={item.to}
-        className={getNavLinkClassName(isActive)}
+        end
+        className={({ isActive }) => getNavLinkClassName(isActive)}
       >
         <Icon className="size-4 shrink-0" />
         <span className="truncate">{item.name}</span>

--- a/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -17,16 +17,31 @@ import { Feature } from '@/lib/browseros/capabilities'
 import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import { cn } from '@/lib/utils'
 
-type NavItem = {
+type BaseNavItem = {
   name: string
-  to: string
   icon: typeof Bot
   feature?: Feature
 }
 
+type InternalNavItem = BaseNavItem & {
+  href?: never
+  to: string
+}
+
+type ExternalNavItem = BaseNavItem & {
+  href: string
+  to?: never
+}
+
+type NavItem = InternalNavItem | ExternalNavItem
+
 type NavSection = {
   label: string
   items: NavItem[]
+}
+
+function isExternalNavItem(item: NavItem): item is ExternalNavItem {
+  return 'href' in item
 }
 
 const getNavLinkClassName = (isActive: boolean) =>
@@ -75,7 +90,8 @@ const primarySettingsSections: NavSection[] = [
 ]
 
 const helpItems: NavItem[] = [
-  { name: 'Explore Features', to: '/onboarding/features', icon: Compass },
+  { name: 'Docs', href: 'https://docs.browseros.com/', icon: Info },
+  { name: 'Features', to: '/onboarding/features', icon: Compass },
   { name: 'Revisit Onboarding', to: '/onboarding', icon: RotateCcw },
 ]
 
@@ -97,6 +113,21 @@ export const SettingsSidebar: FC = () => {
 
   const renderNavItem = (item: NavItem) => {
     const Icon = item.icon
+
+    if (isExternalNavItem(item)) {
+      return (
+        <a
+          key={item.href}
+          href={item.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={getNavLinkClassName(false)}
+        >
+          <Icon className="size-4 shrink-0" />
+          <span className="truncate">{item.name}</span>
+        </a>
+      )
+    }
 
     return (
       <NavLink
@@ -145,18 +176,6 @@ export const SettingsSidebar: FC = () => {
             {filteredHelpItems.map(renderNavItem)}
           </nav>
         </div>
-      </div>
-
-      <div className="mt-auto border-t p-2">
-        <a
-          href="https://docs.browseros.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-        >
-          <Info className="size-4 shrink-0" />
-          <span className="truncate">About BrowserOS</span>
-        </a>
       </div>
     </div>
   )

--- a/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -6,7 +6,6 @@ import {
   PlugZap,
   Settings,
   Sparkles,
-  UserPen,
   Wand2,
 } from 'lucide-react'
 import type { FC } from 'react'
@@ -35,30 +34,12 @@ type NavItem = {
 const primaryNavItems: NavItem[] = [
   { name: 'Home', to: '/home', icon: Home },
   {
-    name: 'Workflows',
-    to: '/workflows',
-    icon: GitBranch,
-    feature: Feature.WORKFLOW_SUPPORT,
-  },
-  { name: 'Scheduled Tasks', to: '/scheduled', icon: CalendarClock },
-  {
     name: 'Connect Apps',
     to: '/connect-apps',
     icon: PlugZap,
     feature: Feature.MANAGED_MCP_SUPPORT,
   },
-  {
-    name: 'Personalize',
-    to: '/home/personalize',
-    icon: UserPen,
-    feature: Feature.PERSONALIZATION_SUPPORT,
-  },
-  {
-    name: 'Agent Soul',
-    to: '/home/soul',
-    icon: Sparkles,
-    feature: Feature.SOUL_SUPPORT,
-  },
+  { name: 'Scheduled Tasks', to: '/scheduled', icon: CalendarClock },
   {
     name: 'Skills',
     to: '/home/skills',
@@ -70,6 +51,18 @@ const primaryNavItems: NavItem[] = [
     to: '/home/memory',
     icon: Brain,
     feature: Feature.MEMORY_SUPPORT,
+  },
+  {
+    name: 'Soul',
+    to: '/home/soul',
+    icon: Sparkles,
+    feature: Feature.SOUL_SUPPORT,
+  },
+  {
+    name: 'Workflows',
+    to: '/workflows',
+    icon: GitBranch,
+    feature: Feature.WORKFLOW_SUPPORT,
   },
   { name: 'Settings', to: '/settings/ai', icon: Settings },
 ]

--- a/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -1,7 +1,6 @@
 import {
   Brain,
   CalendarClock,
-  GitBranch,
   Home,
   PlugZap,
   Settings,
@@ -57,12 +56,6 @@ const primaryNavItems: NavItem[] = [
     to: '/home/soul',
     icon: Sparkles,
     feature: Feature.SOUL_SUPPORT,
-  },
-  {
-    name: 'Workflows',
-    to: '/workflows',
-    icon: GitBranch,
-    feature: Feature.WORKFLOW_SUPPORT,
   },
   { name: 'Settings', to: '/settings/ai', icon: Settings },
 ]


### PR DESCRIPTION
## Summary
- reorder the main app sidebar around higher-value destinations and hide `Personalize` from the primary nav
- rename `Agent Soul` to `Soul` and keep existing route and feature-gating behavior intact
- redesign the settings sidebar into grouped sections for provider settings, BrowserOS features, and miscellaneous links while keeping help at the bottom

## Design
This keeps the change scoped to navigation IA and presentation in the existing `apps/agent` sidebar components. The implementation uses the current route surface instead of introducing new destinations, so the main sidebar is reprioritized and the settings sidebar moves from one flat list to a section-based model with lightweight dividers.

## Test plan
- [x] `bun run lint`
- [ ] `bun run typecheck` (repo/agent typecheck currently exhausts the Node heap in this environment)
- [ ] Manual UI verification in the extension shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)