### PR TITLE
fix: add friendly GET status response for /mcp

### DIFF
--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -5,7 +5,7 @@
  */
 
 import { StreamableHTTPTransport } from '@hono/mcp'
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import type { Browser } from '../../browser/browser'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
@@ -24,36 +24,62 @@ interface McpRouteDeps {
   klavisProxy?: KlavisProxyHandle | null
 }
 
+const MCP_STATUS_MESSAGE =
+  'MCP server is running. Use POST for JSON-RPC requests. GET with Accept: text/event-stream is reserved for SSE streaming.'
+
+function acceptsEventStream(acceptHeader: string | undefined): boolean {
+  return acceptHeader?.includes('text/event-stream') ?? false
+}
+
+function shouldReturnStatusResponse(c: Context<Env>): boolean {
+  return c.req.method === 'GET' && !acceptsEventStream(c.req.header('Accept'))
+}
+
+function createMcpStatusResponse(c: Context<Env>) {
+  return c.json({
+    status: 'ok',
+    message: MCP_STATUS_MESSAGE,
+  })
+}
+
+async function handleMcpTransportRequest(c: Context<Env>, deps: McpRouteDeps) {
+  const mcpServer = createMcpServer(deps)
+  const transport = new StreamableHTTPTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  })
+
+  try {
+    await mcpServer.connect(transport)
+    return transport.handleRequest(c)
+  } catch (error) {
+    Sentry.captureException(error)
+    logger.error('Error handling MCP request', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+
+    return c.json(
+      {
+        jsonrpc: '2.0',
+        error: { code: -32603, message: 'Internal server error' },
+        id: null,
+      },
+      500,
+    )
+  }
+}
+
 export function createMcpRoutes(deps: McpRouteDeps) {
   return new Hono<Env>().all('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
     metrics.log('mcp.request', { scopeId })
 
+    if (shouldReturnStatusResponse(c)) {
+      return createMcpStatusResponse(c)
+    }
+
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
-    const mcpServer = createMcpServer(deps)
-    const transport = new StreamableHTTPTransport({
-      sessionIdGenerator: undefined,
-      enableJsonResponse: true,
-    })
-
-    try {
-      await mcpServer.connect(transport)
-      return transport.handleRequest(c)
-    } catch (error) {
-      Sentry.captureException(error)
-      logger.error('Error handling MCP request', {
-        error: error instanceof Error ? error.message : String(error),
-      })
-
-      return c.json(
-        {
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Internal server error' },
-          id: null,
-        },
-        500,
-      )
-    }
+    return handleMcpTransportRequest(c, deps)
   })
 }

--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -72,11 +72,12 @@ async function handleMcpTransportRequest(c: Context<Env>, deps: McpRouteDeps) {
 export function createMcpRoutes(deps: McpRouteDeps) {
   return new Hono<Env>().all('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
-    metrics.log('mcp.request', { scopeId })
 
     if (shouldReturnStatusResponse(c)) {
       return createMcpStatusResponse(c)
     }
+
+    metrics.log('mcp.request', { scopeId })
 
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).

--- a/apps/server/tests/api/routes/mcp.test.ts
+++ b/apps/server/tests/api/routes/mcp.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, it } from 'bun:test'
+import assert from 'node:assert'
+import { createMcpRoutes } from '../../../src/api/routes/mcp'
+import type { Browser } from '../../../src/browser/browser'
+import type { ToolRegistry } from '../../../src/tools/tool-registry'
+
+function createDeps() {
+  return {
+    version: 'test',
+    registry: {
+      all: () => [],
+      names: () => [],
+    } as unknown as ToolRegistry,
+    browser: {} as unknown as Browser,
+    executionDir: '/tmp',
+    resourcesDir: '/tmp',
+  }
+}
+
+describe('createMcpRoutes', () => {
+  it('returns status info for plain GET requests', async () => {
+    const route = createMcpRoutes(createDeps())
+    const response = await route.request('/')
+
+    assert.strictEqual(response.status, 200)
+    const body = await response.json()
+    assert.deepStrictEqual(body, {
+      status: 'ok',
+      message:
+        'MCP server is running. Use POST for JSON-RPC requests. GET with Accept: text/event-stream is reserved for SSE streaming.',
+    })
+  })
+
+  it('preserves SSE GET handling for MCP clients', async () => {
+    const route = createMcpRoutes(createDeps())
+    const response = await route.request('/', {
+      headers: {
+        Accept: 'text/event-stream',
+      },
+    })
+
+    assert.strictEqual(response.status, 200)
+    assert.ok(
+      response.headers.get('content-type')?.includes('text/event-stream'),
+    )
+    await response.body?.cancel()
+  })
+})


### PR DESCRIPTION
## Summary
- return informative JSON for plain `GET /mcp` sanity checks
- preserve MCP transport handling when the client requests `text/event-stream`
- add route-level coverage for both the status path and the SSE path

## Design
The `/mcp` route now branches early for plain GET requests and returns a small status payload without constructing the MCP transport. Requests that advertise `Accept: text/event-stream`, along with POST and other transport-backed methods, continue through the existing per-request `StreamableHTTPTransport` path so MCP behavior stays intact.

## Test plan
- `bun test apps/server/tests/api/routes/mcp.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run test:integration`
- `bun run test:sdk` *(currently fails in unrelated Agent SDK navigation flows with `NavigationError: No active tab to navigate`)*