### PR TITLE
fix: gate skills page to BrowserOS 0.43.0.0+

### DIFF
--- a/apps/agent/lib/browseros/capabilities.ts
+++ b/apps/agent/lib/browseros/capabilities.ts
@@ -71,7 +71,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.NEWTAB_CHAT_SUPPORT]: { minBrowserOSVersion: '0.40.0.0' },
   [Feature.VERTICAL_TABS_SUPPORT]: { minBrowserOSVersion: '0.42.0.0' },
   [Feature.MEMORY_SUPPORT]: { minServerVersion: '0.0.73' },
-  [Feature.SKILLS_SUPPORT]: { minServerVersion: '0.0.73' },
+  [Feature.SKILLS_SUPPORT]: { minBrowserOSVersion: '0.43.0.0' },
 }
 
 function parseVersion(version: string): number[] {


### PR DESCRIPTION
## Summary
- Change SKILLS_SUPPORT feature gate from `minServerVersion: '0.0.73'` to `minBrowserOSVersion: '0.43.0.0'`

## Changes
- Updated `capabilities.ts` to gate the skills page behind BrowserOS version 0.43.0.0 instead of server version 0.0.73

🤖 Generated with [Claude Code](https://claude.com/claude-code)