### PR TITLE
feat: add GET /mcp health check endpoint

### DIFF
--- a/apps/server/src/api/routes/mcp.ts
+++ b/apps/server/src/api/routes/mcp.ts
@@ -25,7 +25,16 @@ interface McpRouteDeps {
 }
 
 export function createMcpRoutes(deps: McpRouteDeps) {
-  return new Hono<Env>().all('/', async (c) => {
+  const app = new Hono<Env>()
+
+  app.get('/', (c) =>
+    c.json({
+      status: 'ok',
+      message: 'MCP server is running. Use POST to interact.',
+    }),
+  )
+
+  app.post('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
     metrics.log('mcp.request', { scopeId })
 
@@ -56,4 +65,6 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       )
     }
   })
+
+  return app
 }


### PR DESCRIPTION
## Summary
- Add a GET `/mcp` endpoint that returns `{"status":"ok","message":"MCP server is running. Use POST to interact."}` so users get a clear signal when sanity-checking the port with `curl`
- Narrow the catch-all `.all()` handler to `.post()` since the MCP Streamable HTTP transport only uses POST for stateless servers (no session ID = no GET streaming, no DELETE teardown)

## Design
The MCP spec defines GET on the endpoint only for resuming SSE streams in stateful sessions (requires `mcp-session-id` header). Since this server is stateless (`sessionIdGenerator: undefined`), GET was falling into the transport handler and erroring. Now it returns a friendly JSON response instead.

## Test plan
- `curl http://127.0.0.1:9000/mcp` → should return `{"status":"ok","message":"MCP server is running. Use POST to interact."}`
- `curl -X POST http://127.0.0.1:9000/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'` → should still work as before

Resolves TKT-549

🤖 Generated with [Claude Code](https://claude.com/claude-code)