### PR TITLE
fix: persist default kimi hub provider to BrowserOS prefs on first load

### DIFF
--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -30,10 +30,19 @@ export async function loadProviders(): Promise<LlmHubProvider[]> {
     const providers = (providersPref?.value as LlmHubProvider[]) || []
 
     if (providers.length === 0) {
-      return isKimiLaunchEnabled() ? [KIMI_PROVIDER] : []
+      if (isKimiLaunchEnabled()) {
+        const defaults = [KIMI_PROVIDER]
+        await saveProviders(defaults)
+        return defaults
+      }
+      return []
     }
 
-    return ensureKimiFirst(providers)
+    const normalized = ensureKimiFirst(providers)
+    if (normalized.length !== providers.length) {
+      await saveProviders(normalized)
+    }
+    return normalized
   } catch {
     return isKimiLaunchEnabled() ? [KIMI_PROVIDER] : []
   }

--- a/apps/agent/lib/llm-hub/storage.ts
+++ b/apps/agent/lib/llm-hub/storage.ts
@@ -39,7 +39,7 @@ export async function loadProviders(): Promise<LlmHubProvider[]> {
     }
 
     const normalized = ensureKimiFirst(providers)
-    if (normalized.length !== providers.length) {
+    if (normalized !== providers) {
       await saveProviders(normalized)
     }
     return normalized


### PR DESCRIPTION
## Summary
- When `VITE_PUBLIC_KIMI_LAUNCH` is enabled, `loadProviders()` in `llm-hub/storage.ts` returned the default Kimi provider in-memory but never persisted it to the BrowserOS pref
- The browser's C++ code reads the pref directly and found it empty, so Kimi didn't appear in the toolbar/hub until user manually edited and saved
- Now `loadProviders()` persists defaults and `ensureKimiFirst()` additions to the pref immediately

Fixes #428

## Test plan
- [ ] Fresh install with `VITE_PUBLIC_KIMI_LAUNCH=true` → Kimi should appear in hub without manual edit/save
- [ ] Update from previous version → Kimi should be auto-added and persisted
- [ ] With `VITE_PUBLIC_KIMI_LAUNCH=false` → No change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)