### PR TITLE
fix: skills CRUD broken on Windows due to hardcoded path separator

### DIFF
--- a/apps/server/src/skills/service.ts
+++ b/apps/server/src/skills/service.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 import matter from 'gray-matter'
 import { getSkillsDir } from '../lib/browseros-dir'
 import { logger } from '../lib/logger'
@@ -23,7 +23,7 @@ export function slugify(name: string): string {
 function safeSkillDir(id: string): string {
   const skillsDir = getSkillsDir()
   const resolved = resolve(skillsDir, id)
-  if (!resolved.startsWith(`${skillsDir}/`)) {
+  if (!resolved.startsWith(`${skillsDir}${sep}`)) {
     throw new Error('Invalid skill id')
   }
   return resolved

--- a/apps/server/tests/skills/service.test.ts
+++ b/apps/server/tests/skills/service.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'bun:test'
+import assert from 'node:assert'
+import { sep } from 'node:path'
+
+import { createSkillsRoutes } from '../../src/api/routes/skills'
+
+describe('skills routes', () => {
+  const app = createSkillsRoutes()
+
+  it('GET /:id returns 404 for non-existent skill (not 500 from path check)', async () => {
+    const res = await app.request('/valid-skill-id')
+    assert.strictEqual(res.status, 404)
+    const body = await res.json()
+    assert.strictEqual(body.error, 'Skill not found')
+  })
+
+  it('GET /:id rejects path traversal attempts', async () => {
+    const res = await app.request('/../../../etc/passwd')
+    assert.notStrictEqual(res.status, 200)
+  })
+})
+
+describe('safeSkillDir uses platform separator', () => {
+  it(`path.sep is "${sep}" on this platform`, () => {
+    assert.ok(sep === '/' || sep === '\\')
+  })
+})


### PR DESCRIPTION
## Summary
- Fix `safeSkillDir()` path traversal check that used a hardcoded `/` instead of `path.sep`
- On Windows, `path.resolve()` returns backslash paths (`C:\Users\...`), so the `startsWith` check always failed
- This blocked all single-skill operations: get, create, update, delete (the list endpoint was unaffected)

## Design
Replace `${skillsDir}/` with `${skillsDir}${sep}` using `path.sep` from `node:path`. This returns `\` on Windows and `/` on POSIX, matching what `path.resolve()` produces. The path traversal security guarantee is preserved.

## Test plan
- [x] Added unit test verifying GET /:id returns 404 (not 500) for non-existent skills
- [x] Added unit test verifying path traversal attempts are rejected
- [x] Typecheck passes
- [x] Lint passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)