### PR TITLE
fix: move session dirs to ~/.browseros/sessions and update skill paths

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/apps/server/src/agent/ai-sdk-agent.ts
+++ b/apps/server/src/agent/ai-sdk-agent.ts
@@ -72,7 +72,7 @@ export class AiSdkAgent {
     const allBrowserTools = buildBrowserToolSet(
       config.registry,
       config.browser,
-      config.resolvedConfig.sessionExecutionDir,
+      config.resolvedConfig.workingDir,
     )
     const browserTools = config.resolvedConfig.chatMode
       ? Object.fromEntries(
@@ -98,7 +98,7 @@ export class AiSdkAgent {
     // Add filesystem tools (Pi coding agent) — skip in chat mode (read-only)
     const filesystemTools = config.resolvedConfig.chatMode
       ? {}
-      : buildFilesystemToolSet(config.resolvedConfig.sessionExecutionDir)
+      : buildFilesystemToolSet(config.resolvedConfig.workingDir)
     const memoryTools = config.resolvedConfig.chatMode
       ? {}
       : buildMemoryToolSet()
@@ -143,7 +143,7 @@ export class AiSdkAgent {
       exclude: excludeSections,
       isScheduledTask: config.resolvedConfig.isScheduledTask,
       scheduledTaskWindowId: config.browserContext?.windowId,
-      workspaceDir: config.resolvedConfig.sessionExecutionDir,
+      workspaceDir: config.resolvedConfig.workingDir,
       soulContent,
       isSoulBootstrap: isBootstrap,
       chatMode: config.resolvedConfig.chatMode,

--- a/apps/server/src/agent/tool-adapter.ts
+++ b/apps/server/src/agent/tool-adapter.ts
@@ -38,12 +38,12 @@ function contentToModelOutput(
 export function buildBrowserToolSet(
   registry: ToolRegistry,
   browser: Browser,
-  executionDir: string,
+  workingDir: string,
 ): ToolSet {
   const toolSet: ToolSet = {}
   const ctx: ToolContext = {
     browser,
-    directories: { executionDir },
+    directories: { workingDir },
   }
 
   for (const def of registry.all()) {

--- a/apps/server/src/agent/types.ts
+++ b/apps/server/src/agent/types.ts
@@ -32,7 +32,7 @@ export interface ResolvedAgentConfig {
   sessionToken?: string
   contextWindowSize?: number
   userSystemPrompt?: string
-  sessionExecutionDir: string
+  workingDir: string
   /** Whether the model supports image inputs (vision). Defaults to true. */
   supportsImages?: boolean
   /** Eval mode - enables window management tools. Defaults to false. */

--- a/apps/server/src/api/routes/chat.ts
+++ b/apps/server/src/api/routes/chat.ts
@@ -1,4 +1,3 @@
-import { PATHS } from '@browseros/shared/constants/paths'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { SessionStore } from '../../agent/session-store'
@@ -17,21 +16,18 @@ import { ConversationIdParamSchema } from '../utils/validation'
 interface ChatRouteDeps {
   browser: Browser
   registry: ToolRegistry
-  executionDir?: string
   browserosId?: string
   rateLimiter?: RateLimiter
 }
 
 export function createChatRoutes(deps: ChatRouteDeps) {
   const { browserosId, rateLimiter } = deps
-  const executionDir = deps.executionDir || PATHS.DEFAULT_EXECUTION_DIR
 
   const sessionStore = new SessionStore()
   const klavisClient = new KlavisClient()
   const service = new ChatService({
     sessionStore,
     klavisClient,
-    executionDir,
     browser: deps.browser,
     registry: deps.registry,
     browserosId,

--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -130,7 +130,6 @@ export async function createHttpServer(config: HttpServerConfig) {
       createChatRoutes({
         browser,
         registry,
-        executionDir,
         browserosId,
         rateLimiter,
       }),

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -12,6 +12,7 @@ import { formatUserMessage } from '../../agent/format-message'
 import type { SessionStore } from '../../agent/session-store'
 import type { ResolvedAgentConfig } from '../../agent/types'
 import type { Browser } from '../../browser/browser'
+import { getSessionsDir } from '../../lib/browseros-dir'
 import type { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { resolveLLMConfig } from '../../lib/clients/llm/config'
 import { logger } from '../../lib/logger'
@@ -261,7 +262,7 @@ export class ChatService {
   private async resolveSessionDir(request: ChatRequest): Promise<string> {
     const dir = request.userWorkingDir
       ? request.userWorkingDir
-      : path.join(this.deps.executionDir, 'sessions', request.conversationId)
+      : path.join(getSessionsDir(), request.conversationId)
     await mkdir(dir, { recursive: true })
     return dir
   }

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -39,7 +39,7 @@ export class ChatService {
 
     const llmConfig = await resolveLLMConfig(request, this.deps.browserosId)
 
-    const sessionExecutionDir = await this.resolveSessionDir(request)
+    const workingDir = await this.resolveSessionDir(request)
 
     const agentConfig: ResolvedAgentConfig = {
       conversationId: request.conversationId,
@@ -55,7 +55,7 @@ export class ChatService {
       sessionToken: llmConfig.sessionToken,
       contextWindowSize: request.contextWindowSize,
       userSystemPrompt: request.userSystemPrompt,
-      sessionExecutionDir,
+      workingDir,
       supportsImages: request.supportsImages,
       chatMode: request.mode === 'chat',
       isScheduledTask: request.isScheduledTask,

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -22,7 +22,6 @@ import type { BrowserContext, ChatRequest } from '../types'
 export interface ChatServiceDeps {
   sessionStore: SessionStore
   klavisClient: KlavisClient
-  executionDir: string
   browser: Browser
   registry: ToolRegistry
   browserosId?: string

--- a/apps/server/src/api/services/chat-service.ts
+++ b/apps/server/src/api/services/chat-service.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { mkdir } from 'node:fs/promises'
+import { mkdir, utimes } from 'node:fs/promises'
 import path from 'node:path'
 import { createAgentUIStreamResponse, type UIMessage } from 'ai'
 import { AiSdkAgent } from '../../agent/ai-sdk-agent'
@@ -264,6 +264,10 @@ export class ChatService {
       ? request.userWorkingDir
       : path.join(getSessionsDir(), request.conversationId)
     await mkdir(dir, { recursive: true })
+    if (!request.userWorkingDir) {
+      const now = new Date()
+      await utimes(dir, now, now).catch(() => {})
+    }
     return dir
   }
 }

--- a/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/apps/server/src/api/services/mcp/mcp-server.ts
@@ -42,7 +42,7 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
   registerTools(server, deps.registry, {
     browser: deps.browser,
     directories: {
-      executionDir: deps.executionDir,
+      workingDir: deps.executionDir,
       resourcesDir: deps.resourcesDir,
     },
   })

--- a/apps/server/src/lib/browseros-dir.ts
+++ b/apps/server/src/lib/browseros-dir.ts
@@ -1,7 +1,8 @@
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readdir, rm, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { PATHS } from '@browseros/shared/constants/paths'
+import { logger } from './logger'
 
 export function getBrowserosDir(): string {
   return join(homedir(), PATHS.BROWSEROS_DIR_NAME)
@@ -9,6 +10,10 @@ export function getBrowserosDir(): string {
 
 export function getMemoryDir(): string {
   return join(getBrowserosDir(), PATHS.MEMORY_DIR_NAME)
+}
+
+export function getSessionsDir(): string {
+  return join(getBrowserosDir(), PATHS.SESSIONS_DIR_NAME)
 }
 
 export function getSoulPath(): string {
@@ -26,4 +31,35 @@ export function getSkillsDir(): string {
 export async function ensureBrowserosDir(): Promise<void> {
   await mkdir(getMemoryDir(), { recursive: true })
   await mkdir(getSkillsDir(), { recursive: true })
+  await mkdir(getSessionsDir(), { recursive: true })
+}
+
+export async function cleanOldSessions(): Promise<void> {
+  const sessionsDir = getSessionsDir()
+  let entries: string[]
+  try {
+    entries = await readdir(sessionsDir)
+  } catch {
+    return
+  }
+
+  const cutoff = Date.now() - PATHS.SESSION_RETENTION_DAYS * 24 * 60 * 60 * 1000
+  let removed = 0
+
+  for (const entry of entries) {
+    const entryPath = join(sessionsDir, entry)
+    try {
+      const info = await stat(entryPath)
+      if (info.isDirectory() && info.mtimeMs < cutoff) {
+        await rm(entryPath, { recursive: true })
+        removed++
+      }
+    } catch {
+      // skip entries that were already removed or inaccessible
+    }
+  }
+
+  if (removed > 0) {
+    logger.info(`Cleaned ${removed} stale session directories`)
+  }
 }

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -18,7 +18,7 @@ import { ControllerBackend } from './browser/backends/controller'
 import { Browser } from './browser/browser'
 import type { ServerConfig } from './config'
 import { INLINED_ENV } from './env'
-import { ensureBrowserosDir } from './lib/browseros-dir'
+import { cleanOldSessions, ensureBrowserosDir } from './lib/browseros-dir'
 import { initializeDb } from './lib/db'
 import { identity } from './lib/identity'
 import { logger } from './lib/logger'
@@ -132,6 +132,7 @@ export class Application {
   private async initCoreServices(): Promise<void> {
     this.configureLogDirectory()
     await ensureBrowserosDir()
+    await cleanOldSessions()
     await seedSoulTemplate()
     await seedDefaultSkills()
 

--- a/apps/server/src/skills/defaults/compare-prices/SKILL.md
+++ b/apps/server/src/skills/defaults/compare-prices/SKILL.md
@@ -29,7 +29,7 @@ Confirm with the user before searching:
 
 | Step | Tool | Detail |
 |------|------|--------|
-| Create output directory | `evaluate_script` | Create `~/Downloads/compare-<product-slug>/` with a `raw/` subfolder |
+| Create output directory | `evaluate_script` | Create `compare-<product-slug>/` in your working directory with a `raw/` subfolder |
 | Open hidden window | `create_hidden_window` | Dedicated workspace — keeps the user's browsing undisturbed |
 | Open parallel tabs | `new_hidden_page` | Open up to **10 tabs** concurrently, one per retailer/search |
 

--- a/apps/server/src/skills/defaults/deep-research/SKILL.md
+++ b/apps/server/src/skills/defaults/deep-research/SKILL.md
@@ -19,7 +19,7 @@ Activate when the user asks to research a topic, compare information across sour
 
 ### Phase 1 — Clarify & Plan
 
-1. **Clarify the research question.** If the query is vague, ask the user for specifics: scope, depth, preferred sources, and where to save output (default: `~/Downloads/research-<topic-slug>/`).
+1. **Clarify the research question.** If the query is vague, ask the user for specifics: scope, depth, preferred sources, and where to save output (default: `research-<topic-slug>/` in your working directory).
 2. **Plan search queries.** Break the topic into 3–5 search angles. Example for "best standing desks":
    - `best standing desks 2025 reviews`
    - `standing desk comparison reddit`

--- a/apps/server/src/skills/defaults/extract-data/SKILL.md
+++ b/apps/server/src/skills/defaults/extract-data/SKILL.md
@@ -22,7 +22,7 @@ Activate when the user asks to extract, scrape, pull, or collect structured data
 1. **Clarify the request.** Before extracting, confirm with the user:
    - **Source(s):** Single page, list of URLs, or search-then-extract?
    - **Output format:** CSV, JSON, or Markdown table? Default to CSV if not specified.
-   - **Output location:** Where to save files. Default: `~/Downloads/extract-<topic-slug>/`.
+   - **Output location:** Where to save files. Default: `extract-<topic-slug>/` in your working directory.
    - **What data to extract:** Column names, specific fields, or "everything in the table."
 2. **Create the output directory.** Use `evaluate_script` to create the target folder:
    ```

--- a/apps/server/src/skills/defaults/find-alternatives/SKILL.md
+++ b/apps/server/src/skills/defaults/find-alternatives/SKILL.md
@@ -29,9 +29,9 @@ Activate when the user:
    - **Price range** — same range, cheaper, or open budget? If unclear, default to ±30% of the reference product's price.
    - **Key criteria** — what matters most? (e.g., price, quality, brand, specific features)
    - **Any exclusions** — brands or stores to skip
-3. **Create output directory.** Use `evaluate_script` to create:
+3. **Create output directory.** Use `evaluate_script` to create in your working directory:
    ```
-   ~/Downloads/alternatives-<product-slug>/
+   alternatives-<product-slug>/
    ├── raw/              ← per-source research data
    ├── findings.md       ← running notes and rankings
    └── report.html       ← final HTML report

--- a/apps/server/src/skills/defaults/read-later/SKILL.md
+++ b/apps/server/src/skills/defaults/read-later/SKILL.md
@@ -29,7 +29,7 @@ Activate when the user asks to save a page for later, read it later, bookmark so
 ## Notification Format
 
 ```
-Saved to Read Later
+Saved to 📚 Read Later
 Title: <page title>
 URL: <page url>
 PDF: <download path>

--- a/apps/server/src/skills/defaults/read-later/SKILL.md
+++ b/apps/server/src/skills/defaults/read-later/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: read-later
-description: Bookmark the current page to a "Read Later" folder and save a PDF copy for offline reading. Use when the user wants to save a page for later, bookmark it for reading, or keep an offline copy.
+description: Bookmark the current page to a "📚 Read Later" folder and save a PDF copy for offline reading. Use when the user wants to save a page for later, bookmark it for reading, or keep an offline copy.
 metadata:
   display-name: Read Later
   enabled: "true"
@@ -9,7 +9,7 @@ metadata:
 
 # Read Later
 
-Quick-save the current page: bookmark it into a dedicated "Read Later" folder and download a PDF copy for offline reading.
+Quick-save the current page: bookmark it into a dedicated "📚 Read Later" folder and download a PDF copy for offline reading.
 
 ## When to Apply
 
@@ -20,9 +20,9 @@ Activate when the user asks to save a page for later, read it later, bookmark so
 | Step | Tool | Detail |
 |------|------|--------|
 | Get current page | `get_active_page` | Identify the page URL and title |
-| Check for folder | `get_bookmarks` | Look for an existing folder named "Read Later" in the bookmark bar |
-| Create folder (if needed) | `create_bookmark` | If the folder doesn't exist, create "Read Later" in the bookmark bar |
-| Add bookmark | `create_bookmark` | Save the current page URL and title into the "Read Later" folder |
+| Check for folder | `get_bookmarks` | Look for an existing folder named "📚 Read Later" in the bookmark bar |
+| Create folder (if needed) | `create_bookmark` | If the folder doesn't exist, create "📚 Read Later" in the bookmark bar |
+| Add bookmark | `create_bookmark` | Save the current page URL and title into the "📚 Read Later" folder |
 | Save PDF | `save_pdf` | Download the full page as a PDF to the working directory |
 | Notify user | — | Tell the user the page has been saved with the bookmark location and PDF file path |
 
@@ -45,6 +45,6 @@ PDF: <download path>
 
 ## Tips
 
-- Always check if "Read Later" already exists before creating it — avoid duplicate folders.
+- Always check if "📚 Read Later" already exists before creating it — avoid duplicate folders.
 - If the page title is empty or generic, use the domain + path as the bookmark title.
 - The PDF captures the page as-is, including the current scroll position and expanded sections.

--- a/apps/server/src/skills/defaults/read-later/SKILL.md
+++ b/apps/server/src/skills/defaults/read-later/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 # Read Later
 
-Quick-save the current page: bookmark it into a dedicated "📚 Read Later" folder and download a PDF copy for offline reading.
+Quick-save the current page: bookmark it into a dedicated "Read Later" folder and download a PDF copy for offline reading.
 
 ## When to Apply
 
@@ -20,16 +20,16 @@ Activate when the user asks to save a page for later, read it later, bookmark so
 | Step | Tool | Detail |
 |------|------|--------|
 | Get current page | `get_active_page` | Identify the page URL and title |
-| Check for folder | `get_bookmarks` | Look for an existing folder named "📚 Read Later" in the bookmark bar |
-| Create folder (if needed) | `create_bookmark` | If the folder doesn't exist, create "📚 Read Later" in the bookmark bar |
-| Add bookmark | `create_bookmark` | Save the current page URL and title into the "📚 Read Later" folder |
-| Save PDF | `save_pdf` | Download the full page as a PDF to the user's default downloads directory |
+| Check for folder | `get_bookmarks` | Look for an existing folder named "Read Later" in the bookmark bar |
+| Create folder (if needed) | `create_bookmark` | If the folder doesn't exist, create "Read Later" in the bookmark bar |
+| Add bookmark | `create_bookmark` | Save the current page URL and title into the "Read Later" folder |
+| Save PDF | `save_pdf` | Download the full page as a PDF to the working directory |
 | Notify user | — | Tell the user the page has been saved with the bookmark location and PDF file path |
 
 ## Notification Format
 
 ```
-Saved to 📚 Read Later
+Saved to Read Later
 Title: <page title>
 URL: <page url>
 PDF: <download path>
@@ -45,6 +45,6 @@ PDF: <download path>
 
 ## Tips
 
-- Always check if "📚 Read Later" already exists before creating it — avoid duplicate folders.
+- Always check if "Read Later" already exists before creating it — avoid duplicate folders.
 - If the page title is empty or generic, use the domain + path as the bookmark title.
 - The PDF captures the page as-is, including the current scroll position and expanded sections.

--- a/apps/server/src/skills/defaults/save-page/SKILL.md
+++ b/apps/server/src/skills/defaults/save-page/SKILL.md
@@ -21,7 +21,7 @@ Activate when the user asks to save a page as PDF, download a page for offline r
    - Dismiss any popups or overlays that would appear in the PDF
    - Scroll to load any lazy-loaded content if the page uses infinite scroll
 
-3. **Save as PDF** using `save_pdf` with a descriptive filename:
+3. **Save as PDF** using `save_pdf` with a descriptive filename in the working directory:
    - Pattern: `{domain}-{title-slug}-{date}.pdf`
    - Example: `nytimes-climate-report-2025-03-11.pdf`
    - Let the user specify a custom path if they prefer

--- a/apps/server/src/tools/framework.ts
+++ b/apps/server/src/tools/framework.ts
@@ -18,7 +18,7 @@ export type ToolHandler = (
 ) => Promise<void>
 
 export interface ToolDirectories {
-  executionDir: string
+  workingDir: string
   resourcesDir?: string
 }
 
@@ -27,12 +27,12 @@ export type ToolContext = {
   directories: ToolDirectories
 }
 
-export function resolveExecutionPath(
+export function resolveWorkingPath(
   ctx: ToolContext,
   targetPath: string,
   cwd?: string,
 ): string {
-  return resolve(cwd ?? ctx.directories.executionDir, targetPath)
+  return resolve(cwd ?? ctx.directories.workingDir, targetPath)
 }
 
 export function defineTool<

--- a/apps/server/src/tools/page-actions.ts
+++ b/apps/server/src/tools/page-actions.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rename, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { z } from 'zod'
-import { defineTool, resolveExecutionPath } from './framework'
+import { defineTool, resolveWorkingPath } from './framework'
 
 const pageParam = z.number().describe('Page ID (from list_pages)')
 const elementParam = z
@@ -27,7 +27,7 @@ export const save_pdf = defineTool({
     path: z.string(),
   }),
   handler: async (args, ctx, response) => {
-    const resolvedPath = resolveExecutionPath(ctx, args.path, args.cwd)
+    const resolvedPath = resolveWorkingPath(ctx, args.path, args.cwd)
     const { data } = await ctx.browser.printToPDF(args.page)
     await Bun.write(resolvedPath, Buffer.from(data, 'base64'))
     response.text(`Saved PDF to ${resolvedPath}`)
@@ -77,7 +77,7 @@ export const save_screenshot = defineTool({
     fullPage: z.boolean(),
   }),
   handler: async (args, ctx, response) => {
-    const resolvedPath = resolveExecutionPath(ctx, args.path, args.cwd)
+    const resolvedPath = resolveWorkingPath(ctx, args.path, args.cwd)
     const { data } = await ctx.browser.screenshot(args.page, {
       format: args.format,
       quality: args.quality,
@@ -120,10 +120,10 @@ export const download_file = defineTool({
     destinationPath: z.string(),
   }),
   handler: async (args, ctx, response) => {
-    const resolvedDir = resolveExecutionPath(ctx, args.path, args.cwd)
-    await mkdir(ctx.directories.executionDir, { recursive: true })
+    const resolvedDir = resolveWorkingPath(ctx, args.path, args.cwd)
+    await mkdir(ctx.directories.workingDir, { recursive: true })
     const tempDir = await mkdtemp(
-      join(ctx.directories.executionDir, 'browseros-dl-'),
+      join(ctx.directories.workingDir, 'browseros-dl-'),
     )
 
     try {

--- a/apps/server/tests/__helpers__/with-browser.ts
+++ b/apps/server/tests/__helpers__/with-browser.ts
@@ -86,7 +86,7 @@ export async function withBrowser(
         args,
         {
           browser,
-          directories: { executionDir: process.cwd() },
+          directories: { workingDir: process.cwd() },
         },
         signal,
       )

--- a/apps/server/tests/agent/compaction.test.ts
+++ b/apps/server/tests/agent/compaction.test.ts
@@ -311,7 +311,7 @@ function agentConfig(
     conversationId: 'test-conversation',
     provider: LLM_PROVIDERS.OPENROUTER,
     model: 'moonshotai/kimi-k2.5',
-    sessionExecutionDir: '/tmp/browseros-tests',
+    workingDir: '/tmp/browseros-tests',
     ...overrides,
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -144,7 +144,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.73",
+      "version": "0.0.74",
       "bin": {
         "browseros-server": "./src/index.ts",
       },

--- a/packages/shared/src/constants/paths.ts
+++ b/packages/shared/src/constants/paths.ts
@@ -10,10 +10,12 @@ export const PATHS = {
   DEFAULT_EXECUTION_DIR: process.cwd(),
   BROWSEROS_DIR_NAME: '.browseros',
   MEMORY_DIR_NAME: 'memory',
+  SESSIONS_DIR_NAME: 'sessions',
   TOOL_OUTPUT_DIR_NAME: 'tool-output',
   SOUL_FILE_NAME: 'SOUL.md',
   CORE_MEMORY_FILE_NAME: 'CORE.md',
   SKILLS_DIR_NAME: 'skills',
   SOUL_MAX_LINES: 150,
   MEMORY_RETENTION_DAYS: 30,
+  SESSION_RETENTION_DAYS: 30,
 } as const


### PR DESCRIPTION
## Summary
- Move default session directories from `executionDir/sessions/` to `~/.browseros/sessions/` — co-locates session data with other user data (soul, memory, skills)
- Add 30-day cleanup for stale session directories at server startup (matching memory retention)
- Update 6 default skills to reference the agent's working directory instead of hardcoding `~/Downloads/`

## Design
Session directories conceptually belong with user data, not server infrastructure. In production, `executionDir` is `~/Library/Application Support/BrowserOS/.browseros` (app-managed), while `~/.browseros/` is the user-level BrowserOS home. When no workspace is selected, sessions now default to `~/.browseros/sessions/{conversationId}/`. User-selected workspaces still override this. `executionDir` and `resourcesDir` are unchanged.

## Test plan
- [ ] Verify server starts and creates `~/.browseros/sessions/` directory
- [ ] Start a conversation without workspace selected — verify session dir is created under `~/.browseros/sessions/`
- [ ] Start a conversation with workspace selected — verify user workspace is used
- [ ] Verify stale session cleanup works (directories older than 30 days removed at startup)
- [ ] Verify `bun run typecheck` passes
- [ ] Verify `bun run lint` passes
- [ ] Test skills (deep-research, compare-prices, etc.) output to working directory instead of ~/Downloads/

🤖 Generated with [Claude Code](https://claude.com/claude-code)