### PR TITLE
fix: remove duplicate hidden window and improve scheduled task prompt

### DIFF
--- a/apps/agent/entrypoints/background/scheduledJobRuns.ts
+++ b/apps/agent/entrypoints/background/scheduledJobRuns.ts
@@ -109,25 +109,6 @@ export const scheduledJobRuns = async () => {
       throw new Error(`Job not found: ${jobId}`)
     }
 
-    const backgroundWindow = await chrome.windows.create({
-      url: 'chrome://newtab',
-      focused: false,
-      state: 'minimized',
-      type: 'normal',
-    })
-
-    // FIXME: Race condition - the controller-ext extension sends a window_created
-    // WebSocket message to register window ownership, but our HTTP request may arrive
-    // at the server before that registration completes. This delay is a temporary fix.
-    // Proper solution: ControllerBridge should wait/poll for window ownership registration.
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-
-    const backgroundTab = backgroundWindow?.tabs?.[0]
-
-    if (!backgroundWindow || !backgroundTab) {
-      throw new Error('Failed to create background window')
-    }
-
     const jobRun = await createJobRun(jobId, 'running')
     const abortController = new AbortController()
     runAbortControllers.set(jobRun.id, abortController)
@@ -135,8 +116,6 @@ export const scheduledJobRuns = async () => {
     try {
       const response = await getChatServerResponse({
         message: job.query,
-        activeTab: backgroundTab,
-        windowId: backgroundWindow.id,
         signal: abortController.signal,
       })
 
@@ -163,13 +142,6 @@ export const scheduledJobRuns = async () => {
       })
     } finally {
       runAbortControllers.delete(jobRun.id)
-      if (backgroundWindow.id) {
-        try {
-          await chrome.windows.remove(backgroundWindow.id)
-        } catch {
-          // Window may already be closed
-        }
-      }
       await updateJobLastRunAt(jobId)
     }
   }

--- a/apps/server/src/agent/prompt.ts
+++ b/apps/server/src/agent/prompt.ts
@@ -352,11 +352,15 @@ function getPageContext(
     '\n\n**CRITICAL RULES:**\n1. **Do NOT call `get_active_page` or `list_pages` to find your starting page.** Use the **page ID from the Browser Context** directly.'
 
   if (options?.isScheduledTask) {
-    const windowLine = options.scheduledTaskWindowId
-      ? `When creating new pages with \`new_page\`, always pass \`windowId: ${options.scheduledTaskWindowId}\`.`
-      : 'When creating new pages with `new_page`, pass the `windowId` from the Browser Context.'
-    prompt += `\n2. ${windowLine}`
-    prompt += '\n3. Complete the task end-to-end and report results.'
+    const windowRef = options.scheduledTaskWindowId
+      ? `\`windowId: ${options.scheduledTaskWindowId}\``
+      : 'the `windowId` from the Browser Context'
+    prompt += `\n2. **Always pass ${windowRef}** when calling \`new_page\` or \`new_hidden_page\`. Never omit the \`windowId\` parameter.`
+    prompt +=
+      '\n3. **Do NOT close your dedicated hidden window** (via `close_window`). It is managed by the system and will be cleaned up automatically.'
+    prompt +=
+      '\n4. **Do NOT create new windows** (via `create_window` or `create_hidden_window`). Use your existing hidden window for all pages.'
+    prompt += '\n5. Complete the task end-to-end and report results.'
   }
 
   prompt += '\n</page_context>'


### PR DESCRIPTION
## Summary
- **Removed duplicate hidden window creation** — the frontend (`scheduledJobRuns.ts`) was creating a minimized Chrome window that the server (`ChatService`) immediately overwrote with its own hidden window. Two windows per scheduled task, only one used.
- **Improved scheduled task prompt** — expanded windowId rules to cover both `new_page` and `new_hidden_page`, added rules forbidding window closure/creation

## Changes

### `scheduledJobRuns.ts` (-28 lines)
- Removed `chrome.windows.create()` — server handles window lifecycle
- Removed 1-second race condition delay hack (FIXME)
- Removed `chrome.windows.remove()` cleanup in finally block
- Removed `windowId`/`activeTab` params to `getChatServerResponse()`

### `prompt.ts` (+9 lines, -5 lines)
- Rule 2: Cover both `new_page` and `new_hidden_page` for windowId requirement
- Rule 3: Forbid closing the dedicated hidden window
- Rule 4: Forbid creating new windows
- (Rebased on #493 which removed the old CDP tool reference)

## Test plan
- [ ] Run a scheduled task and verify only 1 hidden window is created (by the server)
- [ ] Verify the agent passes `windowId` to page creation calls
- [ ] Verify the agent doesn't close its hidden window mid-task
- [ ] Check `list_windows` during scheduled task shows exactly 1 hidden window

🤖 Generated with [Claude Code](https://claude.com/claude-code)