### PR TITLE
fix: use 127.0.0.1 as default hostname for HTTP server

### DIFF
--- a/apps/server/src/api/server.ts
+++ b/apps/server/src/api/server.ts
@@ -35,7 +35,7 @@ import {
 import type { Env, HttpServerConfig } from './types'
 import { defaultCorsConfig } from './utils/cors'
 
-async function assertPortAvailable(port: number): Promise<void> {
+async function assertPortAvailable(port: number, host: string): Promise<void> {
   const net = await import('node:net')
   return new Promise((resolve, reject) => {
     const probe = net.createServer()
@@ -52,7 +52,7 @@ async function assertPortAvailable(port: number): Promise<void> {
       }
     })
 
-    probe.listen({ port, host: '127.0.0.1', exclusive: true }, () => {
+    probe.listen({ port, host, exclusive: true }, () => {
       probe.close(() => resolve())
     })
   })
@@ -61,7 +61,7 @@ async function assertPortAvailable(port: number): Promise<void> {
 export async function createHttpServer(config: HttpServerConfig) {
   const {
     port,
-    host = '0.0.0.0',
+    host = '127.0.0.1',
     browserosId,
     executionDir,
     resourcesDir,
@@ -183,7 +183,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     )
   })
 
-  await assertPortAvailable(port)
+  await assertPortAvailable(port, host)
 
   const server = Bun.serve({
     fetch: (request, server) => app.fetch(request, { server }),

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -86,7 +86,7 @@ export class Application {
     try {
       await createHttpServer({
         port: this.config.serverPort,
-        host: '0.0.0.0',
+        host: this.config.mcpAllowRemote ? '0.0.0.0' : '127.0.0.1',
         version: VERSION,
         browser,
         controller,


### PR DESCRIPTION
## Summary

- Fix `Bun.serve()` failing on Windows compiled binaries when binding to `0.0.0.0`
- Default HTTP server hostname changed from `0.0.0.0` to `127.0.0.1`
- Preserve `0.0.0.0` binding when `--allow-remote-in-mcp` is explicitly enabled
- Align `assertPortAvailable` probe hostname with actual `Bun.serve()` hostname

## Problem

On Windows, `browseros_server.exe` (Bun compiled binary) crash-loops with:

```
Failed to start HTTP server (port: 9200, error: "Failed to start server. Is port 1455 in use?")
```

The error repeats indefinitely (5,300+ crash-restart cycles observed in logs). The "port 1455" is actually a Windows socket error code leaking into Bun's error message — the port itself is not in use.

**Root cause:** `Bun.serve({ hostname: '0.0.0.0' })` fails in compiled binaries on Windows. The `assertPortAvailable` probe succeeds because it binds to `127.0.0.1`, but then `Bun.serve()` attempts `0.0.0.0` which triggers the failure.

Related: [oven-sh/bun#12127](https://github.com/oven-sh/bun/issues/12127)

## Fix

1. **`server.ts`**: Default `host` changed from `'0.0.0.0'` to `'127.0.0.1'`
2. **`server.ts`**: `assertPortAvailable()` now accepts and uses the same `host` parameter as `Bun.serve()` (was hardcoded to `'127.0.0.1'`)
3. **`main.ts`**: Host selection respects `--allow-remote-in-mcp` flag: `this.config.mcpAllowRemote ? '0.0.0.0' : '127.0.0.1'`

This is also a security improvement — the MCP server only needs localhost connections by default, so binding to `0.0.0.0` was unnecessarily broad.

## Testing

- Verified on Windows 11 with BrowserOS v0.44.0.1 (Chromium 146.0.7821.31)
- The server previously crashed immediately on every startup; with `127.0.0.1` it should bind successfully

Fixes #498