### PR TITLE
feat(agent): add Gmail workflow affordance

### DIFF
--- a/apps/agent/codegen.ts
+++ b/apps/agent/codegen.ts
@@ -7,7 +7,8 @@ import type { CodegenConfig } from '@graphql-codegen/cli'
 const env = process.env
 
 const schemaPath =
-  env.GRAPHQL_SCHEMA_PATH ?? path.resolve(__dirname, 'schema/schema.graphql')
+  env.GRAPHQL_SCHEMA_PATH?.trim() ||
+  path.resolve(__dirname, 'schema/schema.graphql')
 if (!existsSync(schemaPath)) {
   throw new Error(
     'No schema found. Either set GRAPHQL_SCHEMA_PATH in .env.development ' +

--- a/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -27,6 +27,7 @@ import {
 import { McpServerIcon } from '@/entrypoints/app/connect-mcp/McpServerIcon'
 import { useGetUserMCPIntegrations } from '@/entrypoints/app/connect-mcp/useGetUserMCPIntegrations'
 import { useChatSessionContext } from '@/entrypoints/sidepanel/layout/ChatSessionContext'
+import { isBrowserWorkflowQuery } from '@/lib/browser-workflows/isBrowserWorkflowQuery'
 import { Feature } from '@/lib/browseros/capabilities'
 import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import {
@@ -260,6 +261,13 @@ export const NewTab = () => {
       closeMention()
       return
     }
+
+    const query = inputValueRef.current.trim()
+    if (isBrowserWorkflowQuery(query)) {
+      runBrowserOSAction(query, 'agent')
+      return
+    }
+
     if (highlightedIndex > -1) {
       const selectedItem = flatItems[highlightedIndex]
       runSelectedAction(selectedItem)
@@ -288,6 +296,28 @@ export const NewTab = () => {
     setSelectedTabs([])
   }
 
+  const runBrowserOSAction = (message: string, mode: 'chat' | 'agent') => {
+    track(NEWTAB_AI_TRIGGERED_EVENT, {
+      mode,
+      tabs_count: selectedTabs.length,
+    })
+    const action = createBrowserOSAction({
+      mode,
+      message,
+      tabs: selectedTabs,
+    })
+    if (supports(Feature.NEWTAB_CHAT_SUPPORT)) {
+      startInlineChat(message, mode, action)
+    } else {
+      openSidePanelWithSearch('open', {
+        query: message,
+        mode,
+        action,
+      })
+      reset()
+      setSelectedTabs([])
+    }
+  }
   const runSelectedAction = (item: SuggestionItem | undefined) => {
     if (!item) return
 

--- a/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
+++ b/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
@@ -6,6 +6,7 @@ import { ChatFooter } from '@/entrypoints/sidepanel/index/ChatFooter'
 import { ChatMessages } from '@/entrypoints/sidepanel/index/ChatMessages'
 import type { ChatMode } from '@/entrypoints/sidepanel/index/chatTypes'
 import { useChatSessionContext } from '@/entrypoints/sidepanel/layout/ChatSessionContext'
+import { isBrowserWorkflowQuery } from '@/lib/browser-workflows/isBrowserWorkflowQuery'
 import { createBrowserOSAction } from '@/lib/chat-actions/types'
 import {
   NEWTAB_CHAT_MODE_CHANGED_EVENT,
@@ -92,7 +93,13 @@ export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
       })
       sendMessage({ text: messageText, action })
     } else {
-      sendMessage({ text: messageText })
+      const action = isBrowserWorkflowQuery(messageText)
+        ? createBrowserOSAction({
+            mode,
+            message: messageText,
+          })
+        : undefined
+      sendMessage({ text: messageText, action })
     }
     setInput('')
     setAttachedTabs([])
@@ -153,7 +160,9 @@ export const NewTabChat: FC<NewTabChatProps> = ({ onBackToSearch }) => {
           />
         )}
         {agentUrlError && <ChatError error={agentUrlError} />}
-        {chatError && <ChatError error={chatError} />}
+        {chatError && messages[messages.length - 1]?.role !== 'assistant' && (
+          <ChatError error={chatError} />
+        )}
       </main>
 
       <div className="mx-auto w-full max-w-3xl px-4">

--- a/apps/agent/lib/browser-workflows/isBrowserWorkflowQuery.ts
+++ b/apps/agent/lib/browser-workflows/isBrowserWorkflowQuery.ts
@@ -1,0 +1,8 @@
+const BROWSER_WORKFLOW_PATTERNS = [
+  /\b(compose|draft|write|send)\b.*\b(email|mail)\b/i,
+  /\b(email|mail)\b.*\b(compose|draft|write|send)\b/i,
+]
+
+export function isBrowserWorkflowQuery(text: string) {
+  return BROWSER_WORKFLOW_PATTERNS.some((pattern) => pattern.test(text))
+}

--- a/apps/server/src/affordances/recipes.ts
+++ b/apps/server/src/affordances/recipes.ts
@@ -1,0 +1,94 @@
+import { RecipeRegistry } from './registry'
+import type { Recipe } from './types'
+
+/**
+ * Built-in starter recipes - universal sites with broad relevance.
+ * See `docs/affordances.md` for the recipe-authoring guide.
+ */
+export const builtInRecipes: Recipe[] = [
+  {
+    id: 'gmail',
+    siteMcp: 'browseros',
+    method: 'script',
+    urlMatch: ['mail.google.com'],
+    openUrl: 'https://mail.google.com/mail/u/0/#inbox',
+    intents: [
+      {
+        tool: 'gmail_compose_draft',
+        args: '(to, subject, body, cc?, bcc?)',
+        summary:
+          'Open Gmail compose with recipient, subject, and body prefilled; never sends',
+      },
+    ],
+    contextHints: {
+      '/mail/': [
+        'gmail_compose_draft - open a prefilled compose draft without clicking through Gmail',
+      ],
+    },
+    flowHints: [
+      'For "draft an email" tasks, write the message body first, then call gmail_compose_draft so the user can review before sending',
+    ],
+    notes:
+      'Uses Gmail compose URL parameters and requires the user to be signed into Gmail in BrowserOS.',
+  },
+  {
+    id: 'wikipedia',
+    siteMcp: 'browseros',
+    method: 'script',
+    urlMatch: ['wikipedia.org'],
+    openUrl: 'https://en.wikipedia.org/',
+    intents: [
+      {
+        tool: 'get_page_content',
+        args: '(page, selector="#mw-content-text")',
+        summary: 'Extract the article body as clean markdown',
+      },
+      {
+        tool: 'navigate_page',
+        args: '(page, url="https://en.wikipedia.org/wiki/Special:Search?search=<q>")',
+        summary: 'Run a search via URL',
+      },
+    ],
+    contextHints: {
+      '/wiki/': [
+        'get_page_content - pull the article markdown without DOM scraping',
+      ],
+      'Special:Search': ['get_page_content - read the result list'],
+    },
+    flowHints: [
+      'For long articles, get_page_content with selector="#mw-content-text" is much smaller than take_snapshot',
+    ],
+    notes: '',
+  },
+  {
+    id: 'pubmed',
+    siteMcp: 'browseros',
+    method: 'script',
+    urlMatch: ['pubmed.ncbi.nlm.nih.gov'],
+    openUrl: 'https://pubmed.ncbi.nlm.nih.gov/',
+    intents: [
+      {
+        tool: 'navigate_page',
+        args: '(page, url="https://pubmed.ncbi.nlm.nih.gov/?term=<q>")',
+        summary: 'Search PubMed (MeSH, [tw], date filters supported)',
+      },
+      {
+        tool: 'get_page_content',
+        args: '(page, selector="article")',
+        summary: 'Extract title + abstract on a PMID page',
+      },
+    ],
+    contextHints: {
+      '/?term=': ['get_page_content - read the result list'],
+    },
+    flowHints: [
+      'search -> click a result -> get_page_content for the abstract',
+    ],
+    notes:
+      'NCBI also exposes the E-utilities API if you prefer method:"api" - see https://www.ncbi.nlm.nih.gov/books/NBK25500/',
+  },
+]
+
+export function createDefaultRegistry(): RecipeRegistry {
+  return new RecipeRegistry().registerMany(builtInRecipes)
+}

--- a/apps/server/src/affordances/registry.ts
+++ b/apps/server/src/affordances/registry.ts
@@ -1,0 +1,42 @@
+import { matches, type Recipe } from './types'
+
+/**
+ * In-process registry of site-affordance recipes.
+ */
+export class RecipeRegistry {
+  private recipes: Recipe[] = []
+
+  register(recipe: Recipe): this {
+    if (this.recipes.some((r) => r.id === recipe.id)) {
+      throw new Error(`Duplicate recipe id: "${recipe.id}"`)
+    }
+    this.recipes.push(recipe)
+    return this
+  }
+
+  registerMany(recipes: Recipe[]): this {
+    for (const r of recipes) this.register(r)
+    return this
+  }
+
+  findByUrl(url: string): Recipe | undefined {
+    return this.recipes.find((r) => matches(r, url))
+  }
+
+  findById(id: string): Recipe | undefined {
+    return this.recipes.find((r) => r.id === id || r.siteMcp === id)
+  }
+
+  all(): readonly Recipe[] {
+    return this.recipes
+  }
+}
+
+/** Return tool hints that apply to the current URL fragment. */
+export function contextIntentsFor(recipe: Recipe, url: string): string[] {
+  const out: string[] = []
+  for (const [sub, tools] of Object.entries(recipe.contextHints)) {
+    if (url.includes(sub)) out.push(...tools)
+  }
+  return out
+}

--- a/apps/server/src/affordances/types.ts
+++ b/apps/server/src/affordances/types.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod'
+
+/**
+ * How a site-aware affordance gets its work done.
+ *
+ * - `mcp`    - built on top of an existing first/third-party MCP server.
+ * - `api`    - calls the site's official HTTP API (REST/GraphQL).
+ * - `script` - drives a live authenticated browser tab via BrowserOS primitives.
+ */
+export const methodSchema = z.enum(['mcp', 'api', 'script'])
+export type Method = z.infer<typeof methodSchema>
+
+/** One high-level action available via a site-MCP tool. */
+export const intentSchema = z.object({
+  tool: z.string(),
+  args: z.string(),
+  summary: z.string(),
+})
+export type Intent = z.infer<typeof intentSchema>
+
+/**
+ * A site's cached affordances - metadata only, no execution engine.
+ */
+export const recipeSchema = z.object({
+  id: z.string(),
+  siteMcp: z.string(),
+  method: methodSchema,
+  urlMatch: z.array(z.string()),
+  openUrl: z.string().url(),
+  intents: z.array(intentSchema),
+  contextHints: z.record(z.string(), z.array(z.string())).default({}),
+  flowHints: z.array(z.string()).default([]),
+  notes: z.string().default(''),
+})
+export type Recipe = z.infer<typeof recipeSchema>
+
+/** True if `url` matches any of `recipe.urlMatch`. */
+export function matches(recipe: Recipe, url: string): boolean {
+  let host = ''
+  let pathname = ''
+  try {
+    const u = new URL(url)
+    host = u.hostname
+    pathname = u.pathname
+  } catch {
+    return false
+  }
+  const hostPath = host + pathname
+  for (const sub of recipe.urlMatch) {
+    const target = sub.startsWith('/') ? hostPath : host
+    if (target.includes(sub)) {
+      return true
+    }
+  }
+  return false
+}

--- a/apps/server/src/agent/chat-mode.ts
+++ b/apps/server/src/agent/chat-mode.ts
@@ -11,4 +11,6 @@ export const CHAT_MODE_ALLOWED_TOOLS = new Set([
   'take_snapshot',
   'take_enhanced_snapshot',
   'evaluate_script',
+  'site_describe',
+  'site_intents',
 ])

--- a/apps/server/src/tools/affordances.ts
+++ b/apps/server/src/tools/affordances.ts
@@ -1,0 +1,281 @@
+import { z } from 'zod'
+import { createDefaultRegistry } from '../affordances/recipes'
+import { contextIntentsFor, type RecipeRegistry } from '../affordances/registry'
+import { defineTool } from './framework'
+
+/**
+ * Site-affordance tools.
+ *
+ * These sit one level above the BrowserOS primitives (snapshot/click/navigate)
+ * and give the agent a discovery surface for site-specific cached recipes.
+ * Instead of "snapshot -> find compose button -> click -> wait -> snapshot -> find
+ * To field -> fill -> ...", the agent calls `site_describe(page)`, sees that
+ * Gmail's compose URL parameters skip the click chain entirely, and uses
+ * `navigate_page` with the right URL.
+ *
+ * Recipes themselves are pure metadata - see `affordances/types.ts` and
+ * `affordances/recipes.ts`. To add your own, register on the shared registry.
+ */
+
+// Module-level singleton so all three tools share the same registry. Users
+// can call `registry.register(...)` at startup to add their own recipes.
+export const registry: RecipeRegistry = createDefaultRegistry()
+
+const recipeJson = (r: ReturnType<RecipeRegistry['findById']>) => {
+  if (!r) return null
+  return {
+    id: r.id,
+    site_mcp: r.siteMcp,
+    method: r.method, // mcp | api | script
+    url_match: r.urlMatch,
+    open_url: r.openUrl,
+    intents: r.intents,
+    flow_hints: r.flowHints,
+    notes: r.notes,
+  }
+}
+
+export const site_describe = defineTool({
+  name: 'site_describe',
+  description:
+    'Given a page, return cached affordance metadata for the matching site - ' +
+    'recommended high-level tools, URL-aware contextual hints, and how the ' +
+    "site's MCP is implemented (mcp/api/script). Use BEFORE take_snapshot " +
+    'to discover whether a cached recipe path exists. Always succeeds; for ' +
+    'unknown sites returns `{recognized: false}` and a fallback hint.',
+  input: z.object({
+    page: z.number().describe('Page ID (from list_pages)'),
+  }),
+  output: z.object({
+    recognized: z.boolean(),
+    url: z.string(),
+    title: z.string().optional(),
+    site: z.string().optional(),
+    site_mcp: z.string().optional(),
+    method: z.enum(['mcp', 'api', 'script']).optional(),
+    intents: z
+      .array(
+        z.object({ tool: z.string(), args: z.string(), summary: z.string() }),
+      )
+      .optional(),
+    contextual_intents: z.array(z.string()).optional(),
+    flow_hints: z.array(z.string()).optional(),
+    notes: z.string().optional(),
+    next_actions: z.array(z.string()),
+  }),
+  handler: async (args, ctx, response) => {
+    const pages = await ctx.browser.listPages()
+    const page = pages.find((p) => p.pageId === args.page)
+    if (!page) {
+      response.error(`No page with id ${args.page}. Call list_pages first.`)
+      return
+    }
+
+    const recipe = registry.findByUrl(page.url)
+    if (!recipe) {
+      const out = {
+        recognized: false as const,
+        url: page.url,
+        title: page.title,
+        next_actions: [
+          'take_snapshot(page) - no cached recipe; use raw DOM',
+          'site_intents() - see what sites have cached recipes',
+        ],
+      }
+      response.text(JSON.stringify(out, null, 2))
+      response.data(out)
+      return
+    }
+
+    const contextual = contextIntentsFor(recipe, page.url)
+    const out = {
+      recognized: true as const,
+      url: page.url,
+      title: page.title,
+      site: recipe.id,
+      site_mcp: recipe.siteMcp,
+      method: recipe.method,
+      intents: recipe.intents,
+      contextual_intents: contextual,
+      flow_hints: recipe.flowHints,
+      notes: recipe.notes,
+      next_actions: [
+        `Prefer ${recipe.siteMcp}_* tools over take_snapshot+click here.`,
+        ...contextual.map((t: string) => `On this URL, try: ${t}`),
+        ...recipe.flowHints.map((h: string) => `Common flow: ${h}`),
+        'take_snapshot(page) - fallback if no intent fits',
+      ],
+    }
+    response.text(JSON.stringify(out, null, 2))
+    response.data(out)
+  },
+})
+
+export const site_intents = defineTool({
+  name: 'site_intents',
+  description:
+    'Return the full registry of recognised sites and their cached intents. ' +
+    'Use when planning a multi-site task or when you do not know what sites ' +
+    'have cached recipes available.',
+  input: z.object({}),
+  output: z.object({
+    sites: z.array(z.unknown()),
+    count: z.number(),
+    next_actions: z.array(z.string()),
+  }),
+  handler: async (_args, _ctx, response) => {
+    const sites = registry.all().map(recipeJson)
+    const out = {
+      sites,
+      count: sites.length,
+      next_actions: [
+        "site_open(site_id='wikipedia') - navigate to a known site",
+        'site_describe(page) - once on a site, get contextual hints',
+      ],
+    }
+    response.text(JSON.stringify(out, null, 2))
+    response.data(out)
+  },
+})
+
+function buildGmailComposeUrl(input: {
+  to: string
+  subject?: string
+  body: string
+  cc?: string
+  bcc?: string
+}): string {
+  const url = new URL('https://mail.google.com/mail/')
+  url.searchParams.set('view', 'cm')
+  url.searchParams.set('fs', '1')
+  url.searchParams.set('to', input.to)
+  if (input.cc) url.searchParams.set('cc', input.cc)
+  if (input.bcc) url.searchParams.set('bcc', input.bcc)
+  if (input.subject) url.searchParams.set('su', input.subject)
+  url.searchParams.set('body', input.body)
+  return url.toString()
+}
+
+export const gmail_compose_draft = defineTool({
+  name: 'gmail_compose_draft',
+  description:
+    'Open Gmail compose with a drafted email prefilled. Use when the user asks ' +
+    'to draft an email in Gmail. This only opens a draft and never sends it; ' +
+    'the user must review and press Send themselves.',
+  input: z.object({
+    to: z.string().describe('Recipient email address or comma-separated list'),
+    subject: z.string().optional().describe('Email subject line'),
+    body: z.string().describe('Draft email body to prefill'),
+    cc: z.string().optional().describe('Optional CC recipients'),
+    bcc: z.string().optional().describe('Optional BCC recipients'),
+    page: z
+      .number()
+      .optional()
+      .describe('If provided, navigate this tab instead of opening a new tab'),
+  }),
+  output: z.object({
+    ok: z.boolean(),
+    page_id: z.number(),
+    url: z.string(),
+    sent: z.literal(false),
+    next_actions: z.array(z.string()),
+  }),
+  handler: async (args, ctx, response) => {
+    const url = buildGmailComposeUrl(args)
+    let pageId: number
+    if (args.page !== undefined) {
+      await ctx.browser.goto(args.page, url)
+      pageId = args.page
+    } else {
+      pageId = await ctx.browser.newPage(url, { background: false })
+    }
+
+    const out = {
+      ok: true,
+      page_id: pageId,
+      url,
+      sent: false as const,
+      next_actions: [
+        'Wait for Gmail to load, then let the user review the draft.',
+        'Do not press Send unless the user explicitly asks after reviewing.',
+      ],
+    }
+
+    response.text(JSON.stringify(out, null, 2))
+    response.data(out)
+    response.includePages()
+  },
+})
+
+export const site_open = defineTool({
+  name: 'site_open',
+  description:
+    "Open a known site by id (e.g. 'wikipedia', 'pubmed'). If `page` is " +
+    'given, navigates that tab; otherwise opens a new tab. Returns the page ' +
+    "id and the recipe's intents so the agent can immediately call a " +
+    'high-level tool.',
+  input: z.object({
+    site_id: z.string().describe('Recipe id, e.g. "wikipedia"'),
+    page: z
+      .number()
+      .optional()
+      .describe('If given, reuse this tab instead of opening a new one'),
+  }),
+  output: z.object({
+    ok: z.boolean(),
+    site: z.string().optional(),
+    site_mcp: z.string().optional(),
+    method: z.enum(['mcp', 'api', 'script']).optional(),
+    page_id: z.number().optional(),
+    url: z.string().optional(),
+    intents: z
+      .array(
+        z.object({ tool: z.string(), args: z.string(), summary: z.string() }),
+      )
+      .optional(),
+    next_actions: z.array(z.string()),
+    error: z.string().optional(),
+  }),
+  handler: async (args, ctx, response) => {
+    const recipe = registry.findById(args.site_id)
+    if (!recipe) {
+      const out = {
+        ok: false as const,
+        error: `unknown site_id '${args.site_id}'`,
+        next_actions: ['site_intents() - list available site ids'],
+      }
+      response.text(JSON.stringify(out, null, 2))
+      response.data(out)
+      return
+    }
+
+    let pageId: number
+    if (args.page !== undefined) {
+      await ctx.browser.goto(args.page, recipe.openUrl)
+      pageId = args.page
+    } else {
+      pageId = await ctx.browser.newPage(recipe.openUrl, {})
+    }
+
+    const out = {
+      ok: true as const,
+      site: recipe.id,
+      site_mcp: recipe.siteMcp,
+      method: recipe.method,
+      page_id: pageId,
+      url: recipe.openUrl,
+      intents: recipe.intents,
+      next_actions: [
+        `site_describe(page=${pageId}) - verify and get contextual intents`,
+        ...recipe.intents
+          .slice(0, 3)
+          .map(
+            (i: { tool: string; args: string; summary: string }) =>
+              `${i.tool}${i.args} - ${i.summary}`,
+          ),
+      ],
+    }
+    response.text(JSON.stringify(out, null, 2))
+    response.data(out)
+  },
+})

--- a/apps/server/src/tools/registry.ts
+++ b/apps/server/src/tools/registry.ts
@@ -1,4 +1,10 @@
 import {
+  gmail_compose_draft,
+  site_describe,
+  site_intents,
+  site_open,
+} from './affordances'
+import {
   create_bookmark,
   get_bookmarks,
   move_bookmark,
@@ -138,6 +144,12 @@ export const registry = createRegistry([
   update_tab_group,
   ungroup_tabs,
   close_tab_group,
+
+  // Site Affordances (4)
+  gmail_compose_draft,
+  site_describe,
+  site_intents,
+  site_open,
 
   // Info (1)
   browseros_info,

--- a/docs/affordances.md
+++ b/docs/affordances.md
@@ -1,0 +1,125 @@
+# Site affordances
+
+> A discovery surface for site-aware cached recipes on top of BrowserOS's
+> primitives. Tell the agent "you're on Gmail - call `gmail_compose`, not
+> `take_snapshot`+`click`+`fill`" so it lands on the cached path instead of
+> re-deriving the click sequence every time.
+
+## Why this exists
+
+The base BrowserOS tool surface (`take_snapshot`, `click`, `fill`,
+`navigate_page`, `evaluate_script`, ...) is low-level. An agent using only
+those has to (1) discover what's possible on each site, and (2) re-derive
+the click sequence every time. Both are slow and flaky.
+
+A *recipe* is metadata that tells the agent, in one tool call:
+
+- "this URL is Gmail";
+- "the high-level intents you can call here are `gmail_compose`,
+  `gmail_list_recent`, ...";
+- "based on the URL fragment you're currently on (e.g. `#search/`), the
+  most relevant ones are X and Y";
+- "this site-MCP is implemented via `script` (DOM/JS), so expect it to be
+  brittle if Gmail's DOM rotates".
+
+Recipes are **pure metadata** - they don't execute anything. The actual
+deterministic work happens in whatever BrowserOS tool, site-MCP, API, or
+script each recipe points at via its `intents`.
+
+## The three tools
+
+| Tool             | What it does                                                                                                                          |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `site_describe`  | Given a page id, returns the matching recipe (intents, method, URL-aware contextual hints, flow hints). Falls back gracefully if no recipe matches. |
+| `site_intents`   | Returns the full registry of recognised sites - useful for planning multi-site tasks.                                                  |
+| `site_open`      | Open a known site by id (e.g. `wikipedia`). Returns the new page id and intents so the agent can act immediately.                     |
+
+## Built-in workflow tools
+
+Some recipes point at BrowserOS-owned workflow tools when a task has a safe,
+deterministic shortcut.
+
+| Tool                  | What it does                                                                                                      |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------|
+| `gmail_compose_draft` | Opens Gmail compose with `to`, `subject`, and `body` prefilled. It never sends; the user reviews and presses Send. |
+
+## The `method` classification
+
+Each recipe declares **how it's implemented**:
+
+- `mcp` - built on top of an existing first/third-party MCP server. Cheapest,
+  most reliable. Almost always preferred when available.
+- `api` - calls the site's official HTTP API. Reliable, but needs an API key
+  or OAuth.
+- `script` - drives a live authenticated browser tab via BrowserOS
+  primitives. No API needed; works on any site you can log into; brittle
+  if the DOM changes.
+
+The classification surfaces in `site_describe` / `site_intents` / `site_open`
+output so the agent (and human reviewer) sees the cost / auth / reliability
+profile at a glance.
+
+## Adding your own recipe
+
+```ts
+import { registry } from './apps/server/src/tools/affordances'
+import type { Recipe } from './apps/server/src/affordances/types'
+
+const myRecipe: Recipe = {
+  id: 'github',
+  siteMcp: 'github',
+  method: 'api', // gh CLI / REST API > DOM scraping
+  urlMatch: ['github.com'],
+  openUrl: 'https://github.com/',
+  intents: [
+    { tool: 'gh_search_issues', args: '(query, count=20)', summary: 'Search issues' },
+    { tool: 'gh_open_pr', args: '(repo, number)', summary: 'Open a PR by number' },
+  ],
+  contextHints: {
+    '/issues': ['gh_search_issues'],
+    '/pull/': ['gh_open_pr'],
+  },
+  flowHints: ['list issues -> open by number -> comment'],
+  notes: '',
+}
+
+registry.register(myRecipe)
+```
+
+## Built-in starter recipes
+
+The default registry ships with:
+
+- `gmail`     - draft-only Gmail compose shortcut via `gmail_compose_draft`
+
+- `wikipedia` - search + article extraction via `get_page_content`
+- `pubmed`    - search + abstract extraction; NCBI's E-utilities API
+                exists if you prefer `method: 'api'`
+
+These point at existing BrowserOS primitives so they work out of the box.
+For a larger reference implementation covering 15 sites (Gmail, Outlook,
+Canvas, Claude.ai, Notion, LinkedIn, YouTube, ...), see
+[r-sayar/cloud-browser-mcp](https://github.com/r-sayar/cloud-browser-mcp) -
+each site has its own Python stdio MCP server backed by a logged-in
+BrowserOS tab.
+
+## Design
+
+Recipes are deliberately **just data**, not a DSL. The matcher
+(`affordances/types.ts -> matches()`) parses the URL once, then does cheap
+substring tests against `urlMatch`. Path-style entries (`/in/`) match
+host+path; everything else matches host only - avoids false positives on
+auth/redirect flows whose query strings mention a third-party site.
+
+The registry is in-process and shared by all three tools (see the
+`registry` singleton in `apps/server/src/tools/affordances.ts`). Mutating
+it at startup is the intended extension point.
+
+## Non-goals
+
+- **Not an execution engine.** Recipes don't run JavaScript or open tabs
+  themselves - that's `navigate_page` / `evaluate_script` / your site-MCP.
+- **Not a router.** The agent still picks which tool to call; recipes just
+  tell it which tools are *available* for the current site.
+- **Not auth-aware.** Recipes don't know if you're signed in - they assume
+  the calling agent has handled login.


### PR DESCRIPTION
## Summary

Adds a lightweight site affordance layer for BrowserOS workflows, with Gmail compose as the first cached workflow.

This lets agent-facing flows discover higher-level site actions instead of always relying on low-level browser primitives like `take_snapshot`, `click`, and `fill`. The new-tab BrowserOS query path can now recognize email drafting requests and route them into the BrowserOS agent flow instead of treating them as Google searches.

## What Changed

- Added site affordance registry and recipe types
- Added affordance tools:
  - `site_describe`
  - `site_intents`
  - `site_open`
  - `gmail_compose_draft`
- Registered the affordance tools with the server tool registry
- Updated chat mode tool allowlist for affordance discovery
- Added Gmail compose recipe support
- Added new-tab workflow detection for email drafting prompts
- Routed matching new-tab prompts into BrowserOS agent mode
- Added affordance docs

## Why

The current browser automation surface is powerful but low-level. For common workflows, the agent has to rediscover the same site capabilities and click paths repeatedly.

This PR adds a first step toward cached browser workflows: the agent can ask what affordances exist for a site/task and call a direct workflow tool when available.

Example:

https://github.com/user-attachments/assets/fa6352ba-ba6c-4858-9e85-b96204317195


```text
draft me an email to [someone@gmail.com](mailto:someone@gmail.com) asking to review my pull request