### PR TITLE
fix: quote argument-hint values in SKILL.md frontmatter

### DIFF
--- a/.claude/skills/dev-debug/SKILL.md
+++ b/.claude/skills/dev-debug/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-debug
 description: Debug an issue by identifying root causes, fixing the most probable one, testing, and committing. Use with "/dev-debug <description of the issue>".
 disable-model-invocation: true
-argument-hint: [issue description]
+argument-hint: "[issue description]"
 ---
 
 # Debug Workflow

--- a/.claude/skills/dev/SKILL.md
+++ b/.claude/skills/dev/SKILL.md
@@ -2,7 +2,7 @@
 name: dev
 description: Full feature development workflow. Explores codebase, designs, writes PRD, implements, reviews, fixes, and creates PR. Use with "/dev <feature description>".
 disable-model-invocation: true
-argument-hint: [feature description]
+argument-hint: "[feature description]"
 ---
 
 # Dev Workflow — Orchestrator

--- a/.claude/skills/dev1-start/SKILL.md
+++ b/.claude/skills/dev1-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev1-start
 description: Start a new feature development. Does a high-level exploration of the codebase to understand the stack and project layout, then kicks off the design phase. Sub-skill of the /dev workflow.
-argument-hint: [feature description]
+argument-hint: "[feature description]"
 ---
 
 # Dev Workflow — Step 1: Start & Explore

--- a/.claude/skills/dev2-design/SKILL.md
+++ b/.claude/skills/dev2-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev2-design
 description: Generate high-level design options for a feature. Presents 2-4 design alternatives with pros and cons. Sub-skill of the /dev workflow.
-argument-hint: [feature_name]
+argument-hint: "[feature_name]"
 ---
 
 # Dev Workflow — Step 2: Design Options

--- a/.claude/skills/dev3-prd/SKILL.md
+++ b/.claude/skills/dev3-prd/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev3-prd
 description: Generate questions, clarify unknowns, then write a PRD using pyramid principles. Sub-skill of the /dev workflow.
-argument-hint: [feature_name]
+argument-hint: "[feature_name]"
 ---
 
 # Dev Workflow — Step 3: Questions & PRD

--- a/.claude/skills/dev4-implement/SKILL.md
+++ b/.claude/skills/dev4-implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev4-implement
 description: Implement a feature from its PRD. Creates a work tree if needed, writes clean code following Google-level standards, and tests iteratively. Sub-skill of the /dev workflow.
-argument-hint: [feature_name]
+argument-hint: "[feature_name]"
 ---
 
 # Dev Workflow — Step 4: Implement

--- a/.claude/skills/dev5-review/SKILL.md
+++ b/.claude/skills/dev5-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev5-review
 description: Review implemented code for quality, correctness, and style. Produces review comments and creates a commit. Sub-skill of the /dev workflow.
-argument-hint: [feature_name]
+argument-hint: "[feature_name]"
 ---
 
 # Dev Workflow — Step 5: Code Review

--- a/.claude/skills/dev6-review-fix/SKILL.md
+++ b/.claude/skills/dev6-review-fix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev6-review-fix
 description: Apply fixes for review comments from dev5-review and commit. Sub-skill of the /dev workflow.
-argument-hint: [feature_name]
+argument-hint: "[feature_name]"
 ---
 
 # Dev Workflow — Step 6: Fix Review Comments

--- a/.claude/skills/dev7-pr/SKILL.md
+++ b/.claude/skills/dev7-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev7-pr
 description: Create a PR, push to GitHub, wait for Greptile review, address comments, and push final. Sub-skill of the /dev workflow.
-argument-hint: [feature_name]
+argument-hint: "[feature_name]"
 ---
 
 # Dev Workflow — Step 7: PR & External Review


### PR DESCRIPTION
## Summary

The nine `SKILL.md` files under `.claude/skills/` currently declare their
`argument-hint` frontmatter field as an unquoted bracketed value, e.g.:

```yaml
argument-hint: [feature_name]
```

In YAML, that is a flow-sequence containing a single scalar, not a
string. GitHub Copilot CLI 1.0.65 tightened its skill loader to require
`argument-hint` to be a string and now rejects these skills at load time.
Claude Code has historically been lenient about the same field but is
also moving toward stricter validation (see anthropics/claude-code#22161).

## Fix

Wrap the bracketed values in double quotes so they parse as plain
strings, preserving the original hint text while satisfying the stricter
schema:

```yaml
argument-hint: "[feature_name]"
```

Nine files touched — the full `dev*` workflow plus `dev-debug`:

- `.claude/skills/dev/SKILL.md`
- `.claude/skills/dev-debug/SKILL.md`
- `.claude/skills/dev1-start/SKILL.md`
- `.claude/skills/dev2-design/SKILL.md`
- `.claude/skills/dev3-prd/SKILL.md`
- `.claude/skills/dev4-implement/SKILL.md`
- `.claude/skills/dev5-review/SKILL.md`
- `.claude/skills/dev6-review-fix/SKILL.md`
- `.claude/skills/dev7-pr/SKILL.md`

No behavioural change — the rendered hint text is identical, the type is
just now `string` instead of `list[string]`.

## Prior art

- anthropics/claude-code#22161 (upstream tracking issue)

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.claude/skills/dev5-review/SKILL.md').read().split('---',2)[1])"` returns `argument-hint` as `str` (verified locally for all 9 files).
- [x] Load one of the affected skills under Copilot CLI >= 1.0.65 and confirm it no longer errors.
- [x] Load under Claude Code and confirm the argument hint still renders.

## CLA

I will sign the CLA in a follow-up comment on this PR per `CLA.md`.
